### PR TITLE
Rework `EntityManager`

### DIFF
--- a/GameServer/ECS-Components/AttackComponent.cs
+++ b/GameServer/ECS-Components/AttackComponent.cs
@@ -19,12 +19,12 @@ using static DOL.GS.GameObject;
 
 namespace DOL.GS
 {
-    public class AttackComponent
+    public class AttackComponent : IManagedEntity
     {
         public GameLiving owner;
         public WeaponAction weaponAction;
         public AttackAction attackAction;
-        public int EntityManagerId { get; set; } = EntityManager.UNSET_ID;
+        public EntityManagerId EntityManagerId { get; set; } = new();
 
         /// <summary>
         /// The objects currently attacking this living
@@ -108,7 +108,7 @@ namespace DOL.GS
                 weaponAction = null;
 
             if (weaponAction is null && attackAction is null && !owner.InCombat)
-                EntityManagerId = EntityManager.Remove(EntityManager.EntityType.AttackComponent, EntityManagerId);
+                EntityManager.Remove(EntityManager.EntityType.AttackComponent, this);
         }
 
         /// <summary>
@@ -576,9 +576,7 @@ namespace DOL.GS
             {
                 m_startAttackTarget = attackTarget;
                 StartAttackRequested = true;
-
-                if (EntityManagerId == EntityManager.UNSET_ID)
-                    EntityManagerId = EntityManager.Add(EntityManager.EntityType.AttackComponent, this);
+                EntityManager.Add(EntityManager.EntityType.AttackComponent, this);
             }
         }
 

--- a/GameServer/ECS-Components/CraftComponent.cs
+++ b/GameServer/ECS-Components/CraftComponent.cs
@@ -2,11 +2,11 @@
 
 namespace DOL.GS
 {
-    public class CraftComponent
+    public class CraftComponent : IManagedEntity
     {
         public CraftAction CraftAction { get; set; }
         public bool CraftState { get; set; }
-        public int EntityManagerId { get; private set; } = EntityManager.UNSET_ID;
+        public EntityManagerId EntityManagerId { get; set; } = new();
         public List<Recipe> Recipes { get; private set; } = new();
         private GamePlayer _owner;
         private object _recipesLock = new();
@@ -44,7 +44,7 @@ namespace DOL.GS
             CraftAction?.Tick(time);
 
             if (CraftAction == null)
-                EntityManagerId = EntityManager.Remove(EntityManager.EntityType.CraftComponent, EntityManagerId);
+                EntityManager.Remove(EntityManager.EntityType.CraftComponent, this);
         }
 
         public void StartCraft(Recipe recipe, AbstractCraftingSkill skill, int craftingTime)
@@ -52,9 +52,7 @@ namespace DOL.GS
             if (CraftAction == null)
             {
                 CraftAction = new CraftAction(_owner, craftingTime, recipe, skill);
-
-                if (EntityManagerId == EntityManager.UNSET_ID)
-                    EntityManagerId = EntityManager.Add(EntityManager.EntityType.CraftComponent, this);
+                EntityManager.Add(EntityManager.EntityType.CraftComponent, this);
             }
         }
 

--- a/GameServer/ECS-Components/EffectList/ECSGameEffect.cs
+++ b/GameServer/ECS-Components/EffectList/ECSGameEffect.cs
@@ -22,7 +22,7 @@ namespace DOL.GS
     /// <summary>
     /// Base class for all Effects
     /// </summary>
-    public class ECSGameEffect
+    public class ECSGameEffect : IManagedEntity
     {
         //public ISpellHandler SpellHandler;
         //Based on GameLoop expire tick
@@ -42,7 +42,7 @@ namespace DOL.GS
         public int TickInterval;
         public long NextTick;
         public int PreviousPosition = -1;
-        public int EntityManagerId { get; set; }= EntityManager.UNSET_ID;
+        public EntityManagerId EntityManagerId { get; set; } = new();
         public ISpellHandler SpellHandler { get; protected set; }
 
         /// <summary>

--- a/GameServer/ECS-Components/EffectList/EffectListComponent.cs
+++ b/GameServer/ECS-Components/EffectList/EffectListComponent.cs
@@ -7,12 +7,12 @@ using DOL.GS.Spells;
 namespace DOL.GS
 {
     // Component for holding persistent effects on the player.
-    public class EffectListComponent
+    public class EffectListComponent : IManagedEntity
     {
         private int _lastUpdateEffectsCount;
 
         public GameLiving Owner { get; private set; }
-        public int EntityManagerId { get; set; } = EntityManager.UNSET_ID;
+        public EntityManagerId EntityManagerId { get; set; } = new();
         public Dictionary<eEffect, List<ECSGameEffect>> Effects { get; private set; } = new Dictionary<eEffect, List<ECSGameEffect>>();
         public object EffectsLock { get; private set; } = new();
         public List<ECSGameSpellEffect> ConcentrationEffects { get; private set; } = new List<ECSGameSpellEffect>(20);
@@ -34,8 +34,7 @@ namespace DOL.GS
                     if (!Owner.IsAlive || Owner.ObjectState != GameObject.eObjectState.Active)
                         return false;
 
-                    if (EntityManagerId == EntityManager.UNSET_ID)
-                        EntityManagerId = EntityManager.Add(EntityManager.EntityType.EffectListComponent, this);
+                    EntityManager.Add(EntityManager.EntityType.EffectListComponent, this);
 
                     // Check to prevent crash from holding sprint button down.
                     if (effect is ECSGameAbilityEffect)

--- a/GameServer/ECS-Debug/ECSDebug.cs
+++ b/GameServer/ECS-Debug/ECSDebug.cs
@@ -306,7 +306,7 @@ namespace DOL.GS.Commands
                 TimerService.DebugTickCount = tickcount;
                 DisplayMessage(client, "Debugging next " + tickcount + " TimerService tick(s)");
             }
-            
+
             if (args[1].ToLower().Equals("think"))
             {
                 int tickcount = int.Parse(args[2]);

--- a/GameServer/ECS-Services/AttackService.cs
+++ b/GameServer/ECS-Services/AttackService.cs
@@ -17,9 +17,9 @@ namespace DOL.GS
             GameLoop.CurrentServiceTick = SERVICE_NAME;
             Diagnostics.StartPerfCounter(SERVICE_NAME);
 
-            List<AttackComponent> list = EntityManager.GetAll<AttackComponent>(EntityManager.EntityType.AttackComponent);
+            List<AttackComponent> list = EntityManager.UpdateAndGetAll<AttackComponent>(EntityManager.EntityType.AttackComponent, out int lastNonNullIndex);
 
-            Parallel.For(0, EntityManager.GetLastNonNullIndex(EntityManager.EntityType.AttackComponent) + 1, i =>
+            Parallel.For(0, lastNonNullIndex + 1, i =>
             {
                 try
                 {

--- a/GameServer/ECS-Services/CastingService.cs
+++ b/GameServer/ECS-Services/CastingService.cs
@@ -17,9 +17,9 @@ namespace DOL.GS
             GameLoop.CurrentServiceTick = SERVICE_NAME;
             Diagnostics.StartPerfCounter(SERVICE_NAME);
 
-            List<CastingComponent> list = EntityManager.GetAll<CastingComponent>(EntityManager.EntityType.CastingComponent);
+            List<CastingComponent> list = EntityManager.UpdateAndGetAll<CastingComponent>(EntityManager.EntityType.CastingComponent, out int lastNonNullIndex);
 
-            Parallel.For(0, EntityManager.GetLastNonNullIndex(EntityManager.EntityType.CastingComponent) + 1, i =>
+            Parallel.For(0, lastNonNullIndex + 1, i =>
             {
                 try
                 {

--- a/GameServer/ECS-Services/CraftingService.cs
+++ b/GameServer/ECS-Services/CraftingService.cs
@@ -13,9 +13,9 @@ namespace DOL.GS
             GameLoop.CurrentServiceTick = SERVICE_NAME;
             Diagnostics.StartPerfCounter(SERVICE_NAME);
 
-            List<CraftComponent> list = EntityManager.GetAll<CraftComponent>(EntityManager.EntityType.CraftComponent);
+            List<CraftComponent> list = EntityManager.UpdateAndGetAll<CraftComponent>(EntityManager.EntityType.CraftComponent, out int lastNonNullIndex);
 
-            Parallel.For(0, EntityManager.GetLastNonNullIndex(EntityManager.EntityType.CraftComponent) + 1, i =>
+            Parallel.For(0, lastNonNullIndex + 1, i =>
             {
                 list[i]?.Tick(tick);
             });

--- a/GameServer/ECS-Services/DailyQuestService.cs
+++ b/GameServer/ECS-Services/DailyQuestService.cs
@@ -48,9 +48,9 @@ namespace DOL.GS
                     GameServer.Database.AddObject(newTime);
                 }
 
-                List<GamePlayer> players = EntityManager.GetAll<GamePlayer>(EntityManager.EntityType.Player);
+                List<GamePlayer> players = EntityManager.UpdateAndGetAll<GamePlayer>(EntityManager.EntityType.Player, out int lastNonNullIndex);
 
-                for (int i = 0; i < EntityManager.GetLastNonNullIndex(EntityManager.EntityType.Player) + 1; i++)
+                for (int i = 0; i < lastNonNullIndex + 1; i++)
                 {
                     GamePlayer player = players[i];
 

--- a/GameServer/ECS-Services/EffectListService.cs
+++ b/GameServer/ECS-Services/EffectListService.cs
@@ -19,9 +19,9 @@ namespace DOL.GS
             GameLoop.CurrentServiceTick = SERVICE_NAME;
             Diagnostics.StartPerfCounter(SERVICE_NAME);
 
-            List<EffectListComponent> list = EntityManager.GetAll<EffectListComponent>(EntityManager.EntityType.EffectListComponent);
+            List<EffectListComponent> list = EntityManager.UpdateAndGetAll<EffectListComponent>(EntityManager.EntityType.EffectListComponent, out int lastNonNullIndex);
 
-            Parallel.For(0, EntityManager.GetLastNonNullIndex(EntityManager.EntityType.EffectListComponent) + 1, i =>
+            Parallel.For(0, lastNonNullIndex + 1, i =>
             {
                 EffectListComponent e = list[i];
 
@@ -43,7 +43,7 @@ namespace DOL.GS
         {
             if (!effectListComponent.Effects.Any())
             {
-                effectListComponent.EntityManagerId = EntityManager.Remove(EntityManager.EntityType.EffectListComponent, effectListComponent.EntityManagerId);
+                EntityManager.Remove(EntityManager.EntityType.EffectListComponent, effectListComponent);
                 return;
             }
 

--- a/GameServer/ECS-Services/EffectService.cs
+++ b/GameServer/ECS-Services/EffectService.cs
@@ -24,9 +24,9 @@ namespace DOL.GS
             GameLoop.CurrentServiceTick = SERVICE_NAME;
             Diagnostics.StartPerfCounter(SERVICE_NAME);
 
-            List<ECSGameEffect> list = EntityManager.GetAll<ECSGameEffect>(EntityManager.EntityType.Effect);
+            List<ECSGameEffect> list = EntityManager.UpdateAndGetAll<ECSGameEffect>(EntityManager.EntityType.Effect, out int lastNonNullIndex);
 
-            Parallel.For(0, EntityManager.GetLastNonNullIndex(EntityManager.EntityType.Effect) + 1, i =>
+            Parallel.For(0, lastNonNullIndex + 1, i =>
             {
                 ECSGameEffect effect = list[i];
 
@@ -40,7 +40,7 @@ namespace DOL.GS
                 else
                     HandlePropertyModification(effect);
 
-                effect.EntityManagerId = EntityManager.Remove(EntityManager.EntityType.Effect, effect.EntityManagerId);
+                EntityManager.Remove(EntityManager.EntityType.Effect, effect);
 
                 long stopTick = GameTimer.GetTickCount();
 
@@ -279,9 +279,7 @@ namespace DOL.GS
 
             effect.CancelEffect = true;
             effect.ExpireTick = GameLoop.GameLoopTime - 1;
-
-            if (effect.EntityManagerId == EntityManager.UNSET_ID)
-                effect.EntityManagerId = EntityManager.Add(EntityManager.EntityType.Effect, effect);
+            EntityManager.Add(EntityManager.EntityType.Effect, effect);
         }
 
         /// <summary>

--- a/GameServer/ECS-Services/MonthlyQuestService.cs
+++ b/GameServer/ECS-Services/MonthlyQuestService.cs
@@ -48,9 +48,9 @@ namespace DOL.GS
                     GameServer.Database.AddObject(newTime);
                 }
 
-                List<GamePlayer> players = EntityManager.GetAll<GamePlayer>(EntityManager.EntityType.Player);
+                List<GamePlayer> players = EntityManager.UpdateAndGetAll<GamePlayer>(EntityManager.EntityType.Player, out int lastNonNullIndex);
 
-                for (int i = 0; i < EntityManager.GetLastNonNullIndex(EntityManager.EntityType.Player) + 1; i++)
+                for (int i = 0; i < lastNonNullIndex + 1; i++)
                 {
                     GamePlayer player = players[i];
 

--- a/GameServer/ECS-Services/NPCThinkService.cs
+++ b/GameServer/ECS-Services/NPCThinkService.cs
@@ -13,7 +13,6 @@ namespace DOL.GS
     public static class NPCThinkService
     {
         private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-
         private const string SERVICE_NAME = "NPCThinkService";
 
         private static int _nonNullBrainCount;
@@ -33,9 +32,9 @@ namespace DOL.GS
                 _nullBrainCount = 0;
             }
 
-            List<ABrain> list = EntityManager.GetAll<ABrain>(EntityManager.EntityType.Brain);
+            List<ABrain> list = EntityManager.UpdateAndGetAll<ABrain>(EntityManager.EntityType.Brain, out int lastNonNullIndex);
 
-            Parallel.For(0, EntityManager.GetLastNonNullIndex(EntityManager.EntityType.Brain) + 1, i =>
+            Parallel.For(0, lastNonNullIndex + 1, i =>
             {
                 ABrain brain = list[i];
 
@@ -89,8 +88,7 @@ namespace DOL.GS
             // Output debug info.
             if (Debug)
             {
-                log.Debug($"==== Non-Null NPCs in EntityManager Array: {_nonNullBrainCount} | Null NPCs: {_nullBrainCount} | Total Size: {list.Count}====");
-                log.Debug("---------------------------------------------------------------------------");
+                log.Debug($"==== Non-null NCs in EntityManager array: {_nonNullBrainCount} | Null NPCs: {_nullBrainCount} | Total size: {list.Count} ====");
                 DebugTickCount--;
             }
 

--- a/GameServer/ECS-Services/WeeklyQuestService.cs
+++ b/GameServer/ECS-Services/WeeklyQuestService.cs
@@ -49,9 +49,9 @@ namespace DOL.GS
                     GameServer.Database.AddObject(newTime);
                 }
 
-                List<GamePlayer> players = EntityManager.GetAll<GamePlayer>(EntityManager.EntityType.Player);
+                List<GamePlayer> players = EntityManager.UpdateAndGetAll<GamePlayer>(EntityManager.EntityType.Player, out int lastNonNullIndex);
 
-                for (int i = 0; i < EntityManager.GetLastNonNullIndex(EntityManager.EntityType.Player) + 1; i++)
+                for (int i = 0; i < lastNonNullIndex + 1; i++)
                 {
                     GamePlayer player = players[i];
 

--- a/GameServer/ECS-Services/ZoneService.cs
+++ b/GameServer/ECS-Services/ZoneService.cs
@@ -20,10 +20,10 @@ namespace DOL.GS
             GameLoop.CurrentServiceTick = SERVICE_NAME;
             Diagnostics.StartPerfCounter(SERVICE_NAME);
 
-            List<ObjectChangingSubZone> list = EntityManager.GetAll<ObjectChangingSubZone>(EntityManager.EntityType.ObjectChangingSubZone);
+            List<ObjectChangingSubZone> list = EntityManager.UpdateAndGetAll<ObjectChangingSubZone>(EntityManager.EntityType.ObjectChangingSubZone, out int lastNonNullIndex);
 
             // Remove objects from one sub zone, and add them to another.
-            Parallel.For(0, EntityManager.GetLastNonNullIndex(EntityManager.EntityType.ObjectChangingSubZone) + 1, i =>
+            Parallel.For(0, lastNonNullIndex + 1, i =>
             {
                 ObjectChangingSubZone objectChangingSubZone = list[i];
 
@@ -72,7 +72,7 @@ namespace DOL.GS
                         destinationZone.OnObjectAddedToZone();
                 }
 
-                EntityManager.Remove(EntityManager.EntityType.ObjectChangingSubZone, i);
+                EntityManager.Remove(EntityManager.EntityType.ObjectChangingSubZone, objectChangingSubZone);
             });
 
             if (_failedRemove > 0)

--- a/GameServer/EntityManager/EntityManager.cs
+++ b/GameServer/EntityManager/EntityManager.cs
@@ -8,7 +8,6 @@ namespace DOL.GS
 {
     public static class EntityManager
     {
-        public const int UNSET_ID = -1;
         private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
         public enum EntityType
@@ -20,128 +19,232 @@ namespace DOL.GS
             CastingComponent,
             EffectListComponent,
             CraftComponent,
-            ObjectChangingSubZone
+            ObjectChangingSubZone,
+            Timer,
+            AuxTimer
         }
 
         private static Dictionary<EntityType, dynamic> _entityArrays = new()
         {
-            { EntityType.Player, new EntityArrayWrapper<GamePlayer>(ServerProperties.Properties.MAX_PLAYERS) },
-            { EntityType.Brain, new EntityArrayWrapper<ABrain>(ServerProperties.Properties.MAX_ENTITIES) },
-            { EntityType.Effect, new EntityArrayWrapper<ECSGameEffect>(250) },
-            { EntityType.AttackComponent, new EntityArrayWrapper<AttackComponent>(1250) },
-            { EntityType.CastingComponent, new EntityArrayWrapper<CastingComponent>(1250) },
-            { EntityType.EffectListComponent, new EntityArrayWrapper<EffectListComponent>(3000) },
-            { EntityType.CraftComponent, new EntityArrayWrapper<CraftComponent>(250) },
-            { EntityType.ObjectChangingSubZone, new EntityArrayWrapper<ObjectChangingSubZone>(ServerProperties.Properties.MAX_ENTITIES) }
+            { EntityType.Player, new EntityArray<GamePlayer>(ServerProperties.Properties.MAX_PLAYERS) },
+            { EntityType.Brain, new EntityArray<ABrain>(ServerProperties.Properties.MAX_ENTITIES) },
+            { EntityType.Effect, new EntityArray<ECSGameEffect>(250) },
+            { EntityType.AttackComponent, new EntityArray<AttackComponent>(1250) },
+            { EntityType.CastingComponent, new EntityArray<CastingComponent>(1250) },
+            { EntityType.EffectListComponent, new EntityArray<EffectListComponent>(3000) },
+            { EntityType.CraftComponent, new EntityArray<CraftComponent>(100) },
+            { EntityType.ObjectChangingSubZone, new EntityArray<ObjectChangingSubZone>(ServerProperties.Properties.MAX_ENTITIES) },
+            { EntityType.Timer, new EntityArray<ECSGameTimer>(500) },
+            { EntityType.AuxTimer, new EntityArray<AuxECSGameTimer>(250) }
         };
 
-        public static int Add<T>(EntityType type, T entity)
+        public static bool Add<T>(EntityType type, T entity) where T : IManagedEntity
         {
-            return _entityArrays[type].Add(entity);
+            EntityManagerId id = entity.EntityManagerId;
+
+            // Return false if the entity is already present and not being removed.
+            if (id.IsSet && !id.IsPendingRemoval)
+                return false;
+
+            _entityArrays[type].Add(entity);
+            return true;
         }
 
-        public static int Remove(EntityType type, int id)
+        public static bool Remove<T>(EntityType type, T entity) where T : IManagedEntity
         {
-            _entityArrays[type].Remove(id);
-            return UNSET_ID;
+            EntityManagerId id = entity.EntityManagerId;
+
+            // Return false if the entity is absent and not being added.
+            if (!id.IsSet && !id.IsPendingAddition)
+                return false;
+
+            _entityArrays[type].Remove(entity);
+            return true;
         }
 
-        public static List<T> GetAll<T>(EntityType type)
+        // Applies pending additions and removals then returns the list alongside the last non-null index.
+        // Thread unsafe. The returned list should not be modified.
+        public static List<T> UpdateAndGetAll<T>(EntityType type, out int lastNonNullIndex) where T : IManagedEntity
         {
-            return _entityArrays[type].Entities;
+            dynamic array = _entityArrays[type];
+            lastNonNullIndex = array.Update();
+            return array.Entities;
         }
 
-        public static int GetLastNonNullIndex(EntityType type)
-        {
-            return _entityArrays[type].GetLastNonNullIndex();
-        }
-
-        private class EntityArrayWrapper<T> where T : class
+        private class EntityArray<T> where T : class, IManagedEntity
         {
             private static Comparer<int> _descendingOrder = Comparer<int>.Create((x, y) => x < y ? 1 : x > y ? -1 : 0);
-            public List<T> Entities { get; private set; }
-            private int _lastNonNullIndex = -1;
-            private SortedSet<int> _deletedIndexes = new(_descendingOrder);
-            private object _lock = new();
 
-            public EntityArrayWrapper(int capacity)
+            private SortedSet<int> _deletedIndexes = new(_descendingOrder);
+            private Stack<T> _entitiesToAdd  = new();
+            private Stack<T> _entitiesToRemove = new();
+            private object _entitiesToAddLock = new();
+            private object _entitiesToRemoveLock = new();
+            private int _lastNonNullIndex = -1;
+
+            public List<T> Entities { get; private set; }
+
+            public EntityArray(int capacity)
             {
                 Entities = new List<T>(capacity);
             }
 
-            public int Add(T entity)
+            public void Add(T entity)
             {
-                lock (_lock)
+                lock (_entitiesToAddLock)
                 {
-                    if (_deletedIndexes.Any())
-                    {
-                        int index = _deletedIndexes.Max;
-                        _deletedIndexes.Remove(index);
-                        Entities[index] = entity;
-
-                        if (index > _lastNonNullIndex)
-                            _lastNonNullIndex = index;
-
-                        return index;
-                    }
-                    else
-                    {
-                        // Increase the capacity of the list in the event that it's too small. This is a costly operation.
-                        // 'Add' already does it, but we want to know when it happens and control by how much it grows (instead of doubling it).
-                        if (++_lastNonNullIndex >= Entities.Capacity)
-                        {
-                            int newCapacity = Entities.Capacity + 100;
-                            log.Warn($"{typeof(T)} {nameof(Entities)} is too short. Resizing it to {newCapacity}.");
-                            ListExtras.Resize(Entities, newCapacity);
-                        }
-
-                        Entities.Add(entity);
-                        return _lastNonNullIndex;
-                    }
+                    _entitiesToAdd.Push(entity);
+                    entity.EntityManagerId.OnPreAdd();
                 }
             }
 
-            public void Remove(int id)
+            public void Remove(T entity)
             {
-                if (id == -1)
-                    return;
-
-                lock (_lock)
+                lock (_entitiesToRemoveLock)
                 {
-                    Entities[id] = null;
-                    _deletedIndexes.Add(id);
-
-                    if (id == _lastNonNullIndex)
-                    {
-                        if (_deletedIndexes.Any())
-                        {
-                            int lastIndex = _deletedIndexes.Min;
-
-                            // Find the first non-contiguous number. For example if the collection contains 7 6 3 1, we should return 5.
-                            foreach (int index in _deletedIndexes)
-                            {
-                                if (lastIndex - index > 0)
-                                    break;
-
-                                lastIndex--;
-                            }
-
-                            _lastNonNullIndex = lastIndex;
-                        }
-                        else
-                            _lastNonNullIndex--;
-                    }
+                    _entitiesToRemove.Push(entity);
+                    entity.EntityManagerId.OnPreRemove();
                 }
             }
 
-            public int GetLastNonNullIndex()
+            public int Update()
             {
-                lock (_lock)
+                lock (_entitiesToRemoveLock)
                 {
+                    while (_entitiesToRemove.Count > 0)
+                    {
+                        T entity = _entitiesToRemove.Pop();
+                        EntityManagerId id = entity.EntityManagerId;
+
+                        if (id.IsPendingRemoval)
+                        {
+                            if (id.IsSet)
+                                RemoveInternal(id.Value);
+
+                            id.Unset();
+                        }
+                    }
+                }
+
+                lock (_entitiesToAddLock)
+                {
+                    while (_entitiesToAdd.Count > 0)
+                    {
+                        T entity = _entitiesToAdd.Pop();
+                        EntityManagerId id = entity.EntityManagerId;
+
+                        if (id.IsPendingAddition && !id.IsSet)
+                            id.Value = AddInternal(entity);
+                    }
+                }
+
+                return _lastNonNullIndex;
+            }
+
+            private int AddInternal(T entity)
+            {
+                if (_deletedIndexes.Any())
+                {
+                    int index = _deletedIndexes.Max;
+                    _deletedIndexes.Remove(index);
+                    Entities[index] = entity;
+
+                    if (index > _lastNonNullIndex)
+                        _lastNonNullIndex = index;
+
+                    return index;
+                }
+                else
+                {
+                    // Increase the capacity of the list in the event that it's too small. This is a costly operation.
+                    // 'Add' already does it, but we want to know when it happens and control by how much it grows (instead of doubling it).
+                    if (++_lastNonNullIndex >= Entities.Capacity)
+                    {
+                        int newCapacity = Entities.Capacity + 100;
+                        log.Warn($"{typeof(T)} {nameof(Entities)} is too short. Resizing it to {newCapacity}.");
+                        ListExtras.Resize(Entities, newCapacity);
+                    }
+
+                    Entities.Add(entity);
                     return _lastNonNullIndex;
                 }
             }
+
+            private void RemoveInternal(int id)
+            {
+                Entities[id] = null;
+                _deletedIndexes.Add(id);
+
+                if (id == _lastNonNullIndex)
+                {
+                    if (_deletedIndexes.Any())
+                    {
+                        int lastIndex = _deletedIndexes.Min;
+
+                        // Find the first non-contiguous number. For example if the collection contains 7 6 3 1, we should return 5.
+                        foreach (int index in _deletedIndexes)
+                        {
+                            if (lastIndex - index > 0)
+                                break;
+
+                            lastIndex--;
+                        }
+
+                        _lastNonNullIndex = lastIndex;
+                    }
+                    else
+                        _lastNonNullIndex--;
+                }
+            }
         }
+    }
+
+    public class EntityManagerId
+    {
+        private const int UNSET_ID = -1;
+        private int _value = UNSET_ID;
+        private PendingState _pendingState = PendingState.NONE;
+
+        public int Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                _pendingState = PendingState.NONE;
+            }
+        }
+        public bool IsSet => _value > UNSET_ID;
+        public bool IsPendingAddition => _pendingState == PendingState.ADDITION;
+        public bool IsPendingRemoval => _pendingState == PendingState.REMOVAL;
+
+        public void OnPreAdd()
+        {
+            _pendingState = PendingState.ADDITION;
+        }
+
+        public void OnPreRemove()
+        {
+            _pendingState = PendingState.REMOVAL;
+        }
+
+        public void Unset()
+        {
+            Value = UNSET_ID;
+        }
+
+        private enum PendingState
+        {
+            NONE,
+            ADDITION,
+            REMOVAL
+        }
+    }
+
+    // Interface to be implemented by classes that are to be managed by the entity manager.
+    public interface IManagedEntity
+    {
+        public EntityManagerId EntityManagerId { get; set; }
     }
 
     // Extension methods for 'List<T>' that could be moved elsewhere.

--- a/GameServer/ai/ABrain.cs
+++ b/GameServer/ai/ABrain.cs
@@ -27,10 +27,10 @@ namespace DOL.AI
 	/// <summary>
 	/// This class is the base of all arteficial intelligence in game objects
 	/// </summary>
-	public abstract class ABrain
+	public abstract class ABrain : IManagedEntity
 	{
 		public FSM FSM { get; set; }
-		public int EntityManagerId { get; set; } = EntityManager.UNSET_ID;
+		public EntityManagerId EntityManagerId { get; set; } = new();
 		public virtual GameNPC Body { get; set; }
 		public virtual bool IsActive => Body != null && Body.IsAlive && Body.ObjectState == GameObject.eObjectState.Active && Body.IsVisibleToPlayers;
 		public virtual int ThinkInterval { get; set; } = 2500;
@@ -56,10 +56,7 @@ namespace DOL.AI
 		/// <returns>true if started</returns>
 		public virtual bool Start()
 		{
-			if (EntityManagerId == EntityManager.UNSET_ID)
-				EntityManagerId = EntityManager.Add(EntityManager.EntityType.Brain, this);
-
-			return true;
+			return EntityManager.Add(EntityManager.EntityType.Brain, this);
 		}
 
 		/// <summary>
@@ -68,10 +65,7 @@ namespace DOL.AI
 		/// <returns>true if stopped</returns>
 		public virtual bool Stop()
 		{
-			if (EntityManagerId != EntityManager.UNSET_ID)
-				EntityManagerId = EntityManager.Remove(EntityManager.EntityType.Brain, EntityManagerId);
-
-			return true;
+			return EntityManager.Remove(EntityManager.EntityType.Brain, this);
 		}
 
 		/// <summary>

--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -3034,8 +3034,7 @@ namespace DOL.GS
 
 			lock (BrainSync)
 			{
-				if (Brain?.EntityManagerId == EntityManager.UNSET_ID)
-					Brain.Start();
+				Brain?.Start();
 			}
 		}
 

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -51,7 +51,7 @@ namespace DOL.GS
     /// <summary>
     /// This class represents a player inside the game
     /// </summary>
-    public class GamePlayer : GameLiving
+    public class GamePlayer : GameLiving, IManagedEntity
     {
         private const int SECONDS_TO_QUIT_ON_LINKDEATH = 60;
 
@@ -68,8 +68,8 @@ namespace DOL.GS
         public double NonCombatNonSprintRegen { get; set; }
         public double CombatRegen { get; set; }
         public double SpecLock { get; set; }
-        public int EntityManagerId { get; set; } = EntityManager.UNSET_ID;
-        
+        public EntityManagerId EntityManagerId { get; set; } = new();
+
         public ECSGameTimer EnduRegenTimer { get { return m_enduRegenerationTimer; } }
         public ECSGameTimer PredatorTimeoutTimer
         {
@@ -819,7 +819,7 @@ namespace DOL.GS
         #endregion
 
         #endregion
-		
+
         #region Player Quitting
         /// <summary>
         /// quit timer
@@ -1044,7 +1044,7 @@ namespace DOL.GS
                 IsOnHorse = false;
 
             GameEventMgr.RemoveAllHandlersForObject(m_inventory);
-            EntityManagerId = EntityManager.Remove(EntityManager.EntityType.Player, EntityManagerId);
+            EntityManager.Remove(EntityManager.EntityType.Player, this);
 
             if (CraftTimer != null)
             {
@@ -14417,7 +14417,7 @@ namespace DOL.GS
         }
 
         #endregion
-        
+
         #region Achievements
 
         public void Achieve(string achievementName, int count = 1)
@@ -15543,7 +15543,7 @@ namespace DOL.GS
 
             LoadFromDatabase(dbChar);
             CreateStatistics();
-            EntityManagerId = EntityManager.Add(EntityManager.EntityType.Player, this);
+            EntityManager.Add(EntityManager.EntityType.Player, this);
 
             m_combatTimer = new ECSGameTimer(this, new ECSGameTimer.ECSTimerCallback(_ =>
             {

--- a/GameServer/managers/GameLoopManager/AuxGameLoop.cs
+++ b/GameServer/managers/GameLoopManager/AuxGameLoop.cs
@@ -23,7 +23,7 @@ namespace DOL.GS
                 IsBackground = true
             };
             _gameLoopThread.Start();
-            
+
             return true;
         }
 

--- a/GameServer/world/SubZone.cs
+++ b/GameServer/world/SubZone.cs
@@ -57,12 +57,13 @@ namespace DOL.GS
     }
 
     // Temporary objects to be added to the 'EntityManager' and consummed by the 'ZoneService', representing an object to be moved from one 'SubZone' to another.
-    public class ObjectChangingSubZone
+    public class ObjectChangingSubZone : IManagedEntity
     {
         public LightConcurrentLinkedList<SubZoneObject>.Node SubZoneObject { get; private set; }
         public eGameObjectType ObjectType { get; private set; }
         public Zone DestinationZone { get; private set; }
         public SubZone DestinationSubZone { get; private set; }
+        public EntityManagerId EntityManagerId { get; set; } = new();
 
         public ObjectChangingSubZone(LightConcurrentLinkedList<SubZoneObject>.Node subZoneObject, eGameObjectType objectType, Zone destinationZone, SubZone destinationSubZone)
         {


### PR DESCRIPTION
Forgot to mention in the commit message, `Add` and `Remove` return false if they couldn't perform the action, either because the entity is already added or pending addition, or absent or pending removal. The returned value is used in two places only:
- To tell whether or not a timer is alive (so if it's pending addition for example, it's considered alive).
- In `ABrain.Start` since `ControlledNPCState_AGGRO.Think` calls it constantly (indirectly via `SendObjectUpdate`). Returning false when it's already added or pending addition prevents `ControlledNpcBrain.Start` from calling `FollowOwner` over and over again.