### PR TITLE
Avoid crash from GetNPCsCloseToSpot

### DIFF
--- a/GameServer/world/WorldMgr.cs
+++ b/GameServer/world/WorldMgr.cs
@@ -1584,7 +1584,7 @@ namespace DOL.GS
 
 		public static HashSet<GameNPC> GetNPCsCloseToSpot(ushort regionid, int x, int y, int z, ushort radiusToCheck)
 		{
-			return GetNPCsCloseToSpot(regionid, x, y, z, radiusToCheck);
+			return GetNPCsCloseToSpot(regionid, new Point3D( x, y, z), radiusToCheck);
 		}
 
 		public static HashSet<GameNPC> GetNPCsCloseToSpot(ushort regionid, Point3D point, ushort radiusToCheck)


### PR DESCRIPTION
* When testing DecimationTrap found that server would crash with stack overflow errors with recursive calls to/from GetNPCsCloseToSpot
* Updated to invoke the function which takes in a Point instead of the direct coordinates