### PR TITLE
Fix Melee Crit Damage

### DIFF
--- a/GameServer/ECS-Components/AttackComponent.cs
+++ b/GameServer/ECS-Components/AttackComponent.cs
@@ -1364,8 +1364,8 @@ namespace DOL.GS
 
                     ApplyTargetConversionRegen(ad.Target, (int) (preConversionDamage - damage));
                     ad.Modifier = (int) (damage - preResistDamage);
+                    ad.Damage = (int)damage;
                     ad.CriticalDamage = CalculateMeleeCriticalDamage(ad, action, weapon);
-                    ad.Damage = (int) damage;
                     break;
                 }
                 case eAttackResult.Blocked:


### PR DESCRIPTION
* Recent fixes ended up calculating the crit damage based on AttackData.damage which need to be set on the object ahead of the calculation, other wise it asks of min/min range of 0-0