### PR TITLE
Fix immunity time for StyleStun handler

### DIFF
--- a/GameServer/ECS-Effects/CrowdControlECSEffect.cs
+++ b/GameServer/ECS-Effects/CrowdControlECSEffect.cs
@@ -63,6 +63,11 @@ namespace DOL.GS
     /// </summary>
     public class StunECSGameEffect : AbstractCrowdControlECSEffect
     {
+        public StunECSGameEffect(ECSGameEffectInitParams initParams, int immunityTime)
+            : this(initParams)
+        {
+            ImmunityDuration = immunityTime;
+        }
         public StunECSGameEffect(ECSGameEffectInitParams initParams)
             : base(initParams)
         {

--- a/GameServer/spells/StyleStun.cs
+++ b/GameServer/spells/StyleStun.cs
@@ -30,7 +30,7 @@ namespace DOL.GS.Spells
 	{
 		public override void CreateECSEffect(ECSGameEffectInitParams initParams)
 		{
-			new StunECSGameEffect(initParams);
+			new StunECSGameEffect(initParams, initParams.Duration * 5);
 		}
 		
 		public override int CalculateSpellResistChance(GameLiving target)


### PR DESCRIPTION
* Since stuns are handled by ECS effects the old OnEffectExpires has no real meaning, and we need to ensure that the created effect has the proper duration * 5 immunity timer associated

Steps to reproduce:

Load up 2 characters, one with a shield spec
use Numb or any other shield style 
Observe 60 second immunity