### PR TITLE
Supersede DummyDB

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+﻿*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,20 @@ WORKDIR /build
 # Copy the source code to the build container
 COPY . .
 
-# Install unzip
+# Install required tools: unzip, git, and the text processing utilities we might need
 RUN apt-get update && \
-    apt-get install -y unzip
+    apt-get install -y unzip git sed
 
-# Extract the DummyDB.zip file
-RUN unzip DummyDB.zip -d /tmp/dummy-db
+# Clone the database repository
+RUN git config --global http.sslVerify false
+RUN git clone https://github.com/OpenDAoC/OpenDAoC-Database.git /tmp/opendaoc-db
+
+# Combine the SQL files
+WORKDIR /tmp/opendaoc-db/opendaoc-db-core
+RUN cat *.sql > combined.sql
 
 # Restore NuGet packages
+WORKDIR /build
 RUN dotnet restore DOLLinux.sln
 
 # Copy serverconfig.example.xml to serverconfig.xml
@@ -40,8 +46,8 @@ WORKDIR /app
 # Copy the build output from the build stage
 COPY --from=build /build/Release .
 
-# Copy the dummydb.sql file from the build stage
-COPY --from=build /tmp/dummy-db/DummyDB.sql /tmp/dummy-db/DummyDB.sql
+# Copy the combined.sql file from the build stage
+COPY --from=build /tmp/opendaoc-db/opendaoc-db-core/combined.sql /tmp/opendaoc-db/combined.sql
 
 # Copy the entrypoint script
 COPY --from=build /build/entrypoint.sh /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,67 @@
+﻿version: "3.3"
+
+networks:
+  opendaoc-network:
+    driver: bridge
+
+services:
+  db:
+    image: mariadb:10.6
+    stdin_open: true # docker run -i
+    tty: true        # docker run -t
+    command: --default-authentication-plugin=mysql_native_password --lower_case_table_names=1 --character-set-server=utf8mb3 --collation-server=utf8mb3_general_ci --innodb_large_prefix=1 --innodb_file_format=Barracuda --innodb_file_per_table=1
+    restart: always
+    environment:
+      MYSQL_DATABASE: opendaoc
+      MYSQL_ROOT_PASSWORD: my-secret-pw
+    volumes:
+      - opendaoc-db-data:/var/lib/mysql
+      - base-db:/docker-entrypoint-initdb.d
+    networks:
+      - opendaoc-network
+
+  gameserver:
+    stdin_open: true # docker run -i
+    tty: true        # docker run -t
+    #image: claitz/opendaoc:latest
+    image: opendaoc:test
+    ports:
+      - "10300:10300"
+      - "10400:10400"
+    depends_on:
+      - db
+    environment:
+      DB_CONNECTION_STRING: "server=db;port=3306;database=opendaoc;userid=root;password=my-secret-pw;treattinyasboolean=true"
+      SERVER_PORT: "10300"
+      SERVER_IP: "0.0.0.0"
+      REGION_IP: "0.0.0.0"
+      REGION_PORT: "10400"
+      UDP_IP: "0.0.0.0"
+      UDP_PORT: "10400"
+      ENABLE_UPNP: "False"
+      DETECT_REGION_IP: "True"
+      SERVER_NAME: "OpenDAoC"
+      SERVER_NAME_SHORT: "OPENDAOC"
+      LOG_CONFIG_FILE: "./config/logconfig.xml"
+      SCRIPT_COMPILATION_TARGET: "./lib/GameServerScripts.dll"
+      SCRIPT_ASSEMBLIES: ""
+      ENABLE_COMPILATION: "True"
+      AUTO_ACCOUNT_CREATION: "True"
+      GAME_TYPE: "Normal"
+      CHEAT_LOGGER_NAME: "cheats"
+      GM_ACTION_LOGGER_NAME: "gmactions"
+      INVALID_NAMES_FILE: "./config/invalidnames.txt"
+      DB_TYPE: "MYSQL"
+      DB_AUTOSAVE: "True"
+      DB_AUTOSAVE_INTERVAL: "10"
+      CPU_USE: "8"
+
+    volumes:
+      - base-db:/tmp/opendaoc-db
+
+    networks:
+      - opendaoc-network
+
+volumes:
+  opendaoc-db-data:
+  base-db:


### PR DESCRIPTION
Dockerfile has been updated to pull from the [OpenDAoC-Database](https://github.com/OpenDAoC/OpenDAoC-Database) repository instead of relying on a DummyDB that needed to be kept updated.
Not breaking for existing instances.