### PR TITLE
Tweak to max HP, HP regen, AF, WS formulas

### DIFF
--- a/GameServer/ECS-Components/AttackComponent.cs
+++ b/GameServer/ECS-Components/AttackComponent.cs
@@ -24,6 +24,7 @@ namespace DOL.GS
     public class AttackComponent : IManagedEntity
     {
         private static int CHECK_ATTACKERS_INTERVAL = 1000;
+        private static int INHERENT_AF_WS = 15;
 
         public GameLiving owner;
         public WeaponAction weaponAction;
@@ -1663,7 +1664,7 @@ namespace DOL.GS
 
         public double CalculateWeaponSkill(double baseWeaponSkill, double relicBonus, double specModifier)
         {
-            double weaponSkill = baseWeaponSkill * specModifier;
+            double weaponSkill = (baseWeaponSkill + INHERENT_AF_WS) * specModifier;
 
             if (owner is GamePlayer)
                 weaponSkill *= relicBonus;
@@ -1713,16 +1714,12 @@ namespace DOL.GS
             }
         }
 
-        public static double CalculateTargetArmor(GameLiving target, eArmorSlot armorSlot)
-        {
-            return CalculateTargetArmor(target, armorSlot, out _, out _);
-        }
 
         public static double CalculateTargetArmor(GameLiving target, eArmorSlot armorSlot, out double armorFactor, out double absorb)
         {
-            armorFactor = target.GetArmorAF(armorSlot);
+            armorFactor = target.GetArmorAF(armorSlot) + INHERENT_AF_WS;
 
-            // Gives 0.5~25 bonus AF to players.
+            // Gives an extra 0.5~25 bonus AF to players. Ideally AF scaling should be tweaked instead.
             if (target is GamePlayer)
                 armorFactor += target.Level * 25 / 50.0;
 

--- a/GameServer/ECS-Components/AttackComponent.cs
+++ b/GameServer/ECS-Components/AttackComponent.cs
@@ -1210,7 +1210,7 @@ namespace DOL.GS
 
                     double specModifier = CalculateSpecModifier(ad.Target, spec);
                     double weaponSkill = CalculateWeaponSkill(weapon, specModifier, out double baseWeaponSkill);
-                    double armorMod = CalculateTargetArmor(ad.Target, ad.ArmorHitLocation, out double bonusArmorFactor, out double armorFactor, out double absorb);
+                    double armorMod = CalculateTargetArmor(ad.Target, ad.ArmorHitLocation, out double armorFactor, out double absorb);
                     double damageMod = weaponSkill / armorMod;
 
                     if (action.RangedAttackType == eRangedAttackType.Critical)
@@ -1713,17 +1713,19 @@ namespace DOL.GS
             }
         }
 
-        private const int ARMOR_FACTOR_LEVEL_SCALAR = 25;
-
-        public double CalculateTargetArmor(GameLiving target, eArmorSlot armorSlot)
+        public static double CalculateTargetArmor(GameLiving target, eArmorSlot armorSlot)
         {
-            return CalculateTargetArmor(target, armorSlot, out _, out _, out _);
+            return CalculateTargetArmor(target, armorSlot, out _, out _);
         }
 
-        public double CalculateTargetArmor(GameLiving target, eArmorSlot armorSlot, out double bonusArmorFactor, out double armorFactor, out double absorb)
+        public static double CalculateTargetArmor(GameLiving target, eArmorSlot armorSlot, out double armorFactor, out double absorb)
         {
-            bonusArmorFactor = owner is GamePlayer && target is not GamePlayer ? 2 : target.Level * ARMOR_FACTOR_LEVEL_SCALAR / 50.0;
-            armorFactor = bonusArmorFactor + target.GetArmorAF(armorSlot);
+            armorFactor = target.GetArmorAF(armorSlot);
+
+            // Gives 0.5~25 bonus AF to players.
+            if (target is GamePlayer)
+                armorFactor += target.Level * 25 / 50.0;
+
             absorb = target.GetArmorAbsorb(armorSlot);
             return absorb >= 1 ? double.MaxValue : armorFactor / (1 - absorb);
         }

--- a/GameServer/commands/gmcommands/GMinfo.cs
+++ b/GameServer/commands/gmcommands/GMinfo.cs
@@ -183,8 +183,8 @@ namespace DOL.GS.Commands
 					info.Add(" + Damage type: " + target.MeleeDamageType);
 					if (target.LeftHandSwingChance > 0)
 						info.Add(" + Left Swing %: " + target.LeftHandSwingChance);
-					if(target.ScalingFactor > 0)
-						info.Add(" + DamageTableScalingFactor: " + target.ScalingFactor);
+					if(target.WeaponSkillScalingFactor > 0)
+						info.Add(" + DamageTableScalingFactor: " + target.WeaponSkillScalingFactor);
 					if(target.GetModified(eProperty.MeleeDamage) > 0) 
 						info.Add(" + MeleeDamage bonus %: " + target.GetModified(eProperty.MeleeDamage));
 					if (target.GetWeaponSkill(new DbInventoryItem()) > 0)

--- a/GameServer/commands/gmcommands/mob.cs
+++ b/GameServer/commands/gmcommands/mob.cs
@@ -260,8 +260,8 @@ namespace DOL.GS.Commands
 
 			try {
 				scaleFactor = Convert.ToInt16(args[2]);
-				targetMob.ScalingFactor = scaleFactor;
-				client.Out.SendMessage("Mob Scaling changed to: " + targetMob.ScalingFactor, eChatType.CT_System, eChatLoc.CL_SystemWindow);
+				targetMob.WeaponSkillScalingFactor = scaleFactor;
+				client.Out.SendMessage("Mob Scaling changed to: " + targetMob.WeaponSkillScalingFactor, eChatType.CT_System, eChatLoc.CL_SystemWindow);
 			}
 			catch (Exception) {
 				DisplaySyntax(client, args[1]);

--- a/GameServer/gameobjects/Animist/TurretFnfPet.cs
+++ b/GameServer/gameobjects/Animist/TurretFnfPet.cs
@@ -1,0 +1,9 @@
+﻿namespace DOL.GS
+{
+    public class TurretFnfPet : TurretPet
+    {
+        public override double MaxHealthScalingFactor => 0.36;
+
+        public TurretFnfPet(INpcTemplate template) : base(template) { }
+    }
+}

--- a/GameServer/gameobjects/Animist/TurretMainPetCaster.cs
+++ b/GameServer/gameobjects/Animist/TurretMainPetCaster.cs
@@ -1,0 +1,9 @@
+﻿namespace DOL.GS
+{
+    public class TurretMainPetCaster : TurretPet
+    {
+        public override double MaxHealthScalingFactor => 0.8;
+
+        public TurretMainPetCaster(INpcTemplate template) : base(template) { }
+    }
+}

--- a/GameServer/gameobjects/Animist/TurretMainPetTank.cs
+++ b/GameServer/gameobjects/Animist/TurretMainPetTank.cs
@@ -1,0 +1,7 @@
+﻿namespace DOL.GS
+{
+    public class TurretMainPetTank : TurretPet
+    {
+        public TurretMainPetTank(INpcTemplate template) : base(template) { }
+    }
+}

--- a/GameServer/gameobjects/Animist/TurretPet.cs
+++ b/GameServer/gameobjects/Animist/TurretPet.cs
@@ -5,11 +5,9 @@ namespace DOL.GS
 {
     public class TurretPet : GameSummonedPet
     {
-        public TurretPet(INpcTemplate template) : base(template) { }
-
         public Spell TurretSpell;
 
-        public override int Health { get => base.Health; set => base.Health = value; }
+        public TurretPet(INpcTemplate template) : base(template) { }
 
         protected override void BuildAmbientTexts()
         {

--- a/GameServer/gameobjects/GameEpicBoss.cs
+++ b/GameServer/gameobjects/GameEpicBoss.cs
@@ -14,7 +14,7 @@ namespace DOL.GS
 
         public GameEpicBoss() : base()
         {
-            ScalingFactor = 80;
+            WeaponSkillScalingFactor = 80;
             ArmorFactorScalingFactor = DefaultArmorFactorScalingFactor;
             OrbsReward = Properties.EPICBOSS_ORBS;
         }

--- a/GameServer/gameobjects/GameEpicBoss.cs
+++ b/GameServer/gameobjects/GameEpicBoss.cs
@@ -8,6 +8,7 @@ namespace DOL.GS
 {
     public class GameEpicBoss : GameNPC, IGameEpicNpc
     {
+        public override double MaxHealthScalingFactor => 1.5;
         public double DefaultArmorFactorScalingFactor => 1.6;
         public int ArmorFactorScalingFactorPetCap => 24;
         public double ArmorFactorScalingFactor { get; set; }

--- a/GameServer/gameobjects/GameEpicDungeonNPC.cs
+++ b/GameServer/gameobjects/GameEpicDungeonNPC.cs
@@ -1,8 +1,10 @@
-﻿namespace DOL.GS {
-    public class GameEpicDungeonNPC : GameEpicNPC {
+﻿namespace DOL.GS
+{
+    public class GameEpicDungeonNPC : GameEpicNPC
+    {
         public GameEpicDungeonNPC() : base()
         {
-            ScalingFactor = 80;
+            WeaponSkillScalingFactor = 80;
         }
     }
 }

--- a/GameServer/gameobjects/GameEpicNPC.cs
+++ b/GameServer/gameobjects/GameEpicNPC.cs
@@ -7,6 +7,7 @@ namespace DOL.GS
 {
     public class GameEpicNPC : GameNPC, IGameEpicNpc
     {
+        public override double MaxHealthScalingFactor => 1.25;
         public double DefaultArmorFactorScalingFactor => 0.8;
         public int ArmorFactorScalingFactorPetCap => 16;
         public double ArmorFactorScalingFactor { get; set; }

--- a/GameServer/gameobjects/GameEpicNPC.cs
+++ b/GameServer/gameobjects/GameEpicNPC.cs
@@ -13,7 +13,7 @@ namespace DOL.GS
 
         public GameEpicNPC() : base()
         {
-            ScalingFactor = 60;
+            WeaponSkillScalingFactor = 60;
             ArmorFactorScalingFactor = DefaultArmorFactorScalingFactor;
         }
 

--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -4509,6 +4509,7 @@ namespace DOL.GS
 		private double m_campBonus = 1;
 
 		public virtual double CampBonus { get => m_campBonus; set => m_campBonus = value; }
+		public virtual double MaxHealthScalingFactor => 1.0;
 		public double WeaponSkillScalingFactor { get => weaponSkillScalingFactor; set => weaponSkillScalingFactor = value; }
 		public int OrbsReward { get => orbsReward; set => orbsReward = value; }
 	}

--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -2686,13 +2686,13 @@ namespace DOL.GS
 			attackComponent.RequestStartAttack(target);
 		}
 
-		private int scalingFactor = Properties.GAMENPC_SCALING;
+		private double weaponSkillScalingFactor = 15;
 		private int orbsReward = 0;
 		
 		public override double GetWeaponSkill(DbInventoryItem weapon)
 		{
-			double weaponSkill = (Level + 1) * (ScalingFactor / 7.5) * (1 + 0.01 * GetWeaponStat(weapon) / 2);
-			return Math.Max(0, weaponSkill * GetModified(eProperty.WeaponSkill) * 0.01);
+			double weaponSkill = Math.Max(1, (int) Level) * (WeaponSkillScalingFactor / 5.75) * (1 + 0.01 * (GetWeaponStat(weapon) + 30) / 2);
+			return Math.Max(1, weaponSkill * GetModified(eProperty.WeaponSkill) * 0.01);
 		}
 
 		public void SetLastMeleeAttackTick()
@@ -4509,7 +4509,7 @@ namespace DOL.GS
 		private double m_campBonus = 1;
 
 		public virtual double CampBonus { get => m_campBonus; set => m_campBonus = value; }
-		public int ScalingFactor { get => scalingFactor; set => scalingFactor = value; }
+		public double WeaponSkillScalingFactor { get => weaponSkillScalingFactor; set => weaponSkillScalingFactor = value; }
 		public int OrbsReward { get => orbsReward; set => orbsReward = value; }
 	}
 }

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -6595,7 +6595,7 @@ namespace DOL.GS
 
             int classBaseWeaponSkill = weapon.SlotPosition == (int)eInventorySlot.DistanceWeapon ? CharacterClass.WeaponSkillRangedBase : CharacterClass.WeaponSkillBase;
             double weaponSkill = Level * classBaseWeaponSkill / 200.0 * (1 + 0.01 * GetWeaponStat(weapon) / 2) * Effectiveness;
-            return Math.Max(0, weaponSkill * GetModified(eProperty.WeaponSkill) * 0.01);
+            return Math.Max(1, weaponSkill * GetModified(eProperty.WeaponSkill) * 0.01);
         }
 
         /// <summary>

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -41,21 +41,11 @@ namespace DOL.GS
         private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
         public override eGameObjectType GameObjectType => eGameObjectType.PLAYER;
-        private readonly object m_LockObject = new object();
-        public int Regen { get; set; }
-        public int Endchant { get; set; }
-        public long LastEnduTick { get; set; }
-        public int RegenRateAtChange { get; set; }
-        public int EnduDebuff { get; set; }
-        public double RegenBuff { get; set; }
-        public double RegenAfterTireless { get; set; }
-        public double NonCombatNonSprintRegen { get; set; }
-        public double CombatRegen { get; set; }
+        private readonly object m_LockObject = new();
         public double SpecLock { get; set; }
         public long LastWorldUpdate { get; set; }
         public ChainedActions ChainedActions { get; }
 
-        public ECSGameTimer EnduRegenTimer { get { return m_enduRegenerationTimer; } }
         public ECSGameTimer PredatorTimeoutTimer
         {
             get
@@ -2654,8 +2644,6 @@ namespace DOL.GS
             if (Client.ClientState != GameClient.eClientState.Playing)
                 return EnduranceRegenerationPeriod;
 
-            LastEnduTick = GameLoop.GameLoopTime;
-
             bool sprinting = IsSprinting;
 
             if (Endurance < MaxEndurance || sprinting)
@@ -2663,11 +2651,8 @@ namespace DOL.GS
                 int regen = GetModified(eProperty.EnduranceRegenerationRate);  //default is 1
                 int endchant = GetModified(eProperty.FatigueConsumption);      //Pull chant/buff value
                 var charge = EffectListService.GetEffectOnTarget(this, eEffect.Charge);
-
-                Regen = regen;
-                Endchant = endchant;
-
                 int longwind = 5;
+
                 if (sprinting && IsMoving)
                 {
                     if (charge is null)
@@ -2692,7 +2677,7 @@ namespace DOL.GS
                         }
                     }
                 }
-                RegenRateAtChange = regen;
+
                 if (regen != 0)
                 {
                     ChangeEndurance(this, eEnduranceChangeType.Regenerate, regen);

--- a/GameServer/gameobjects/GameSummonedPet.cs
+++ b/GameServer/gameobjects/GameSummonedPet.cs
@@ -1,22 +1,3 @@
-/*
- * DAWN OF LIGHT - The first free open source DAoC server emulator
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- *
- */
-
 using System;
 using DOL.AI;
 using DOL.AI.Brain;
@@ -41,10 +22,7 @@ namespace DOL.GS
 			set { m_targetInView = value; }
 		}
 
-		public GameSummonedPet(INpcTemplate template) : base(template)
-		{
-			ScalingFactor = 14;
-		}
+		public GameSummonedPet(INpcTemplate template) : base(template) { }
 
 		public GameSummonedPet(ABrain brain) : base(brain) { }
 

--- a/GameServer/gameobjects/Theurgist/TheurgistAirPet.cs
+++ b/GameServer/gameobjects/Theurgist/TheurgistAirPet.cs
@@ -1,26 +1,28 @@
 ﻿namespace DOL.GS
 {
-	public class TheurgistAirPet : TheurgistPet
-	{
-		public TheurgistAirPet(INpcTemplate npcTemplate) : base(npcTemplate)
-		{
-			WeaponSkillScalingFactor = 11;
+    public class TheurgistAirPet : TheurgistPet
+    {
+        public override double MaxHealthScalingFactor => 0.4115;
 
-			foreach (Spell spell in Spells)
-			{
-				if (spell.IsInstantCast)
-					DisableSkill(spell, 0);
-			}
-		}
+        public TheurgistAirPet(INpcTemplate npcTemplate) : base(npcTemplate)
+        {
+            WeaponSkillScalingFactor = 11;
 
-		public override void DisableSkill(Skill skill, int duration)
-		{
-			// Make air pet's instant stun a bit more random.
-			// Should ideally be in its own class.
-			if (skill is Spell spell && spell.IsInstantCast)
-				duration += Util.Random((int)(spell.RecastDelay / 2.5));
+            foreach (Spell spell in Spells)
+            {
+                if (spell.IsInstantCast)
+                    DisableSkill(spell, 0);
+            }
+        }
 
-			base.DisableSkill(skill, duration);
-		}
-	}
+        public override void DisableSkill(Skill skill, int duration)
+        {
+            // Make air pet's instant stun a bit more random.
+            // Should ideally be in its own class.
+            if (skill is Spell spell && spell.IsInstantCast)
+                duration += Util.Random((int)(spell.RecastDelay / 2.5));
+
+            base.DisableSkill(skill, duration);
+        }
+    }
 }

--- a/GameServer/gameobjects/Theurgist/TheurgistAirPet.cs
+++ b/GameServer/gameobjects/Theurgist/TheurgistAirPet.cs
@@ -4,7 +4,7 @@
 	{
 		public TheurgistAirPet(INpcTemplate npcTemplate) : base(npcTemplate)
 		{
-			ScalingFactor = 11;
+			WeaponSkillScalingFactor = 11;
 
 			foreach (Spell spell in Spells)
 			{

--- a/GameServer/gameobjects/Theurgist/TheurgistEarthPet.cs
+++ b/GameServer/gameobjects/Theurgist/TheurgistEarthPet.cs
@@ -4,7 +4,7 @@
 	{
 		public TheurgistEarthPet(INpcTemplate npcTemplate) : base(npcTemplate)
 		{
-			ScalingFactor = 17;
+			WeaponSkillScalingFactor = 17;
 		}
 	}
 }

--- a/GameServer/gameobjects/Theurgist/TheurgistEarthPet.cs
+++ b/GameServer/gameobjects/Theurgist/TheurgistEarthPet.cs
@@ -1,10 +1,12 @@
 ﻿namespace DOL.GS
 {
-	public class TheurgistEarthPet : TheurgistPet
-	{
-		public TheurgistEarthPet(INpcTemplate npcTemplate) : base(npcTemplate)
-		{
-			WeaponSkillScalingFactor = 17;
-		}
-	}
+    public class TheurgistEarthPet : TheurgistPet
+    {
+        public override double MaxHealthScalingFactor => 0.18;
+
+        public TheurgistEarthPet(INpcTemplate npcTemplate) : base(npcTemplate)
+        {
+            WeaponSkillScalingFactor = 17;
+        }
+    }
 }

--- a/GameServer/gameobjects/Theurgist/TheurgistIcePet.cs
+++ b/GameServer/gameobjects/Theurgist/TheurgistIcePet.cs
@@ -1,20 +1,22 @@
 ﻿namespace DOL.GS
 {
-	public class TheurgistIcePet : TheurgistPet
-	{
-		public TheurgistIcePet(INpcTemplate npcTemplate) : base(npcTemplate) { }
+    public class TheurgistIcePet : TheurgistPet
+    {
+        public override double MaxHealthScalingFactor => 0.2575;
 
-		// Ice pets stay permanently interrupted after their first one.
-		// This will break if these values are reset for any reason.
-		public override bool IsBeingInterrupted => InterruptTime > 0 || SelfInterruptTime > 0;
-		public override bool IsBeingInterruptedIgnoreSelfInterrupt => InterruptTime > 0;
+        public TheurgistIcePet(INpcTemplate npcTemplate) : base(npcTemplate) { }
 
-		// They are however able to cast after hitting someone in melee but not getting interrupted.
-		// So it's important that it doesn't add an interrupt timer on itself.
-		// TODO: Maybe find a way to differentiate both.
-		public override bool StartInterruptTimerOnItselfOnMeleeAttack()
-		{
-			return false;
-		}
-	}
+        // Ice pets stay permanently interrupted after their first one.
+        // This will break if these values are reset for any reason.
+        public override bool IsBeingInterrupted => InterruptTime > 0 || SelfInterruptTime > 0;
+        public override bool IsBeingInterruptedIgnoreSelfInterrupt => InterruptTime > 0;
+
+        // They are however able to cast after hitting someone in melee but not getting interrupted.
+        // So it's important that it doesn't add an interrupt timer on itself.
+        // TODO: Maybe find a way to differentiate both.
+        public override bool StartInterruptTimerOnItselfOnMeleeAttack()
+        {
+            return false;
+        }
+    }
 }

--- a/GameServer/gameobjects/Theurgist/TheurgistPet.cs
+++ b/GameServer/gameobjects/Theurgist/TheurgistPet.cs
@@ -2,20 +2,20 @@ using DOL.Database;
 
 namespace DOL.GS
 {
-	public class TheurgistPet : GameSummonedPet
-	{
-		public TheurgistPet(INpcTemplate npcTemplate) : base(npcTemplate) { }
+    public class TheurgistPet : GameSummonedPet
+    {
+        public TheurgistPet(INpcTemplate npcTemplate) : base(npcTemplate) { }
 
-		protected override void BuildAmbientTexts()
-		{
-			base.BuildAmbientTexts();
+        protected override void BuildAmbientTexts()
+        {
+            base.BuildAmbientTexts();
 
-			// Not each summoned pet will fire ambient sentences.
-			if (ambientTexts.Count > 0)
-			{
-				foreach (DbMobXAmbientBehavior ambientText in ambientTexts)
-					ambientText.Chance /= 10;
-			}
-		}
-	}
+            // Not each summoned pet will fire ambient sentences.
+            if (ambientTexts.Count > 0)
+            {
+                foreach (DbMobXAmbientBehavior ambientText in ambientTexts)
+                    ambientText.Chance /= 10;
+            }
+        }
+    }
 }

--- a/GameServer/keeps/Managers/GuardTemplateManager.cs
+++ b/GameServer/keeps/Managers/GuardTemplateManager.cs
@@ -1467,43 +1467,41 @@ namespace DOL.GS.Keeps
         {
             if (guard is GuardLord)
             {
-                guard.Strength = (short)(20 + (guard.Level * 8));
-                guard.Dexterity = (short)(guard.Level * 2);
-                guard.Constitution = (short)(DOL.GS.ServerProperties.Properties.GAMENPC_BASE_CON);
+                guard.Strength = (short) (20 + guard.Level * 8);
+                guard.Dexterity = (short) (guard.Level * 2);
+                guard.Constitution = 30;
                 guard.Quickness = 60;
             }
             else if (guard is GuardFighterRK)
             {
-                guard.Strength = (short)(20 + (guard.Level * 9));
-                guard.Dexterity = (short)(guard.Level * 2);
-                guard.Constitution = (short)(DOL.GS.ServerProperties.Properties.GAMENPC_BASE_CON);
+                guard.Strength = (short) (20 + guard.Level * 9);
+                guard.Dexterity = (short) (guard.Level * 2);
+                guard.Constitution = 30;
                 guard.Quickness = 60;
             }
             else if (guard is GuardCaster)
             {
-                guard.Strength = (short)(20 + (guard.Level * 4));
-                //guard.Strength = (short)(20 + (guard.Level * 6));
-                guard.Dexterity = (short)(guard.Level);
-                guard.Constitution = (short)(DOL.GS.ServerProperties.Properties.GAMENPC_BASE_CON - 5);
+                guard.Strength = (short) (20 + guard.Level * 4);
+                guard.Dexterity = guard.Level;
+                guard.Constitution = 25;
                 guard.Quickness = 40;
             }
             else if (guard.IsPortalKeepGuard || guard.Level == 255)
             {
-                guard.Strength = (short)(20 + (guard.Level / 4));
-                guard.Dexterity = (short)(guard.Level);
-                guard.Constitution = (short)(guard.Level);
-                guard.Quickness = (short)(guard.Level / 2);
-                guard.Intelligence = (short)(guard.Level);
-                guard.Empathy = (short)(guard.Level);
-                guard.Piety = (short)(guard.Level);
-                guard.Charisma = (short)(guard.Level);
+                guard.Strength = (short) (20 + guard.Level / 4);
+                guard.Dexterity = guard.Level;
+                guard.Constitution = guard.Level;
+                guard.Quickness = (short) (guard.Level / 2);
+                guard.Intelligence = guard.Level;
+                guard.Empathy = guard.Level;
+                guard.Piety = guard.Level;
+                guard.Charisma = guard.Level;
             }
             else
             {
-                guard.Strength = (short)(20 + (guard.Level * 5));
-                //guard.Strength = (short)(20 + (guard.Level * 7));
-                guard.Dexterity = (short)(guard.Level);
-                guard.Constitution = (short)(DOL.GS.ServerProperties.Properties.GAMENPC_BASE_CON);
+                guard.Strength = (short) (20 + guard.Level * 5);
+                guard.Dexterity = guard.Level;
+                guard.Constitution = 30;
                 guard.Quickness = 40;
             }
         }

--- a/GameServer/propertycalc/ArmorFactorCalculator.cs
+++ b/GameServer/propertycalc/ArmorFactorCalculator.cs
@@ -28,10 +28,14 @@ namespace DOL.GS.PropertyCalc
                     return CalculateKeepComponentArmorFactor(living);
                 case IGameEpicNpc:
                     return CalculateLivingArmorFactor(living, property, 12.0 * (living as IGameEpicNpc).ArmorFactorScalingFactor, 50.0, false);
+                case NecromancerPet:
+                    return CalculateLivingArmorFactor(living, property, 12.0, 121.0, true);
                 case GameSummonedPet:
-                    return CalculateLivingArmorFactor(living, property, 12.0, living is NecromancerPet ? 121.0 : 175.0, true);
+                    return CalculateLivingArmorFactor(living, property, 12.0, 175.0, true);
+                case GuardLord:
+                    return CalculateLivingArmorFactor(living, property, 12.0, 134.0, false);
                 default:
-                    return CalculateLivingArmorFactor(living, property, 12.0, living is GuardLord ? 134.0 : 200.0, false);
+                    return CalculateLivingArmorFactor(living, property, 12.0, 200.0, false);
             }
         }
 

--- a/GameServer/propertycalc/ArmorFactorCalculator.cs
+++ b/GameServer/propertycalc/ArmorFactorCalculator.cs
@@ -37,48 +37,48 @@ namespace DOL.GS.PropertyCalc
                 default:
                     return CalculateLivingArmorFactor(living, property, 12.0, 200.0, false);
             }
-        }
 
-        private static int CalculatePlayerArmorFactor(GameLiving living, eProperty property)
-        {
-            // Base AF buffs are calculated in the item's armor calc since they have the same cap.
-            int armorFactor = Math.Min((int) (living.Level * 1.875), living.SpecBuffBonusCategory[(int) property]);
-            armorFactor -= Math.Abs(living.DebuffCategory[(int) property]);
-            armorFactor += Math.Min(living.Level, living.ItemBonus[(int) property]);
-            armorFactor += living.BuffBonusCategory4[(int) property];
-            armorFactor /= 6;
-            return Math.Max(1, armorFactor);
-        }
+            static int CalculatePlayerArmorFactor(GameLiving living, eProperty property)
+            {
+                // Base AF buffs are calculated in the item's armor calc since they have the same cap.
+                int armorFactor = Math.Min((int) (living.Level * 1.875), living.SpecBuffBonusCategory[(int) property]);
+                armorFactor -= Math.Abs(living.DebuffCategory[(int) property]);
+                armorFactor += Math.Min(living.Level, living.ItemBonus[(int) property]);
+                armorFactor += living.BuffBonusCategory4[(int) property];
+                armorFactor /= 6;
+                return Math.Max(1, armorFactor);
+            }
 
-        private static int CalculateLivingArmorFactor(GameLiving living, eProperty property, double factor, double divisor, bool useBaseBuff)
-        {
-            int armorFactor = (int) ((1 + living.Level / divisor) * (living.Level * factor));
+            static int CalculateLivingArmorFactor(GameLiving living, eProperty property, double factor, double divisor, bool useBaseBuff)
+            {
+                int armorFactor = (int) ((1 + living.Level / divisor) * (living.Level * factor));
 
-            if (useBaseBuff)
-                armorFactor += living.BaseBuffBonusCategory[(int) property];
+                if (useBaseBuff)
+                    armorFactor += living.BaseBuffBonusCategory[(int) property];
 
-            armorFactor += living.SpecBuffBonusCategory[(int) property];
-            armorFactor -= Math.Abs(living.DebuffCategory[(int) property]);
-            armorFactor += living.BuffBonusCategory4[(int) property];
-            armorFactor /= 6;
-            return Math.Max(1, armorFactor);
-        }
+                armorFactor += living.SpecBuffBonusCategory[(int) property];
+                armorFactor -= Math.Abs(living.DebuffCategory[(int) property]);
+                armorFactor += living.BuffBonusCategory4[(int) property];
+                armorFactor /= 6;
+                return Math.Max(1, armorFactor);
+            }
 
-        private static int CalculateKeepComponentArmorFactor(GameLiving living)
-        {
-            GameKeepComponent component = null;
+            static int CalculateKeepComponentArmorFactor(GameLiving living)
+            {
+                GameKeepComponent component = null;
 
-            if (living is GameKeepDoor keepDoor)
-                component = keepDoor.Component;
-            else if (living is GameKeepComponent)
-                component = living as GameKeepComponent;
+                if (living is GameKeepDoor keepDoor)
+                    component = keepDoor.Component;
+                else if (living is GameKeepComponent)
+                    component = living as GameKeepComponent;
 
-            if (component == null)
-                return 1;
+                if (component == null)
+                    return 1;
 
-            double keepLevelMod = 1 + component.Keep.Level * 0.1;
-            int typeMod = component.Keep is GameKeep ? 4 : 2;
-            return Math.Max(1, (int) (component.Keep.BaseLevel * keepLevelMod * typeMod));
+                double keepLevelMod = 1 + component.Keep.Level * 0.1;
+                int typeMod = component.Keep is GameKeep ? 4 : 2;
+                return Math.Max(1, (int) (component.Keep.BaseLevel * keepLevelMod * typeMod));
+            }
         }
     }
 }

--- a/GameServer/propertycalc/EnduranceRegenerationRateCalculator.cs
+++ b/GameServer/propertycalc/EnduranceRegenerationRateCalculator.cs
@@ -1,129 +1,81 @@
-/*
- * DAWN OF LIGHT - The first free open source DAoC server emulator
- * 
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- *
- */
-using System;
 using DOL.GS.RealmAbilities;
 
 namespace DOL.GS.PropertyCalc
 {
-	/// <summary>
-	/// The health regen rate calculator
-	/// 
-	/// BuffBonusCategory1 is used for all buffs
-	/// BuffBonusCategory2 is used for all debuffs (positive values expected here)
-	/// BuffBonusCategory3 unused
-	/// BuffBonusCategory4 unused
-	/// BuffBonusMultCategory1 unused
-	/// </summary>
-	[PropertyCalculator(eProperty.EnduranceRegenerationRate)]
-	public class EnduranceRegenerationRateCalculator : PropertyCalculator
-	{
-		public EnduranceRegenerationRateCalculator() {}
+    /// <summary>
+    /// The health regen rate calculator
+    /// 
+    /// BuffBonusCategory1 is used for all buffs
+    /// BuffBonusCategory2 is used for all debuffs (positive values expected here)
+    /// BuffBonusCategory3 unused
+    /// BuffBonusCategory4 unused
+    /// BuffBonusMultCategory1 unused
+    /// </summary>
+    [PropertyCalculator(eProperty.EnduranceRegenerationRate)]
+    public class EnduranceRegenerationRateCalculator : PropertyCalculator
+    {
+        public EnduranceRegenerationRateCalculator() { }
 
-		/// <summary>
-		/// calculates the final property value
-		/// </summary>
-		/// <param name="living"></param>
-		/// <param name="property"></param>
-		/// <returns></returns>
-		public override int CalcValue(GameLiving living, eProperty property)
-		{
-			int debuff = living.SpecBuffBonusCategory[(int)property];
-			if (debuff < 0)
-				debuff = -debuff;
+        public override int CalcValue(GameLiving living, eProperty property)
+        {
+            GamePlayer player = living as GamePlayer;
+            int debuff = living.SpecBuffBonusCategory[(int) property];
 
-			var p = living as GamePlayer;
-			if (p != null)
-				p.EnduDebuff = debuff;
-			// buffs allow to regenerate endurance even in combat and while moving			
-			double regenBuff =
-				 living.BaseBuffBonusCategory[(int)property]
-				+living.ItemBonus[(int)property];
-			if (p != null)
-				p.RegenBuff = regenBuff;
-			double regen = regenBuff;
-			if (regen == 0 && living is GamePlayer) //&& ((GamePlayer)living).HasAbility(Abilities.Tireless))
-				regen++;
-			// if (living is GamePlayer && living.HasAbility(Abilities.Tireless))
-			// 	regen++;
-			
-			// --- [START] --- AtlasOF_Tireless ---------------------------------------------------------
-			var raTireless = living.GetAbility<AtlasOF_RAEndRegenEnhancer>();
+            if (debuff < 0)
+                debuff = -debuff;
 
-			if (raTireless != null)
-			{
-				regen++;
-			}
-			// --- [ END ] --- AtlasOF_Tireless ---------------------------------------------------------
+            // Buffs allow to regenerate endurance even in combat and while moving.
+            double regenBuff = living.BaseBuffBonusCategory[(int) property] + living.ItemBonus[(int) property];
+            double regen = regenBuff;
 
-			if (p != null)
-				p.RegenAfterTireless = regen;
-			/*    Patch 1.87 - COMBAT AND REGENERATION CHANGES
-				- The bonus to regeneration while standing out of combat has been greatly increased. The amount of ticks 
-					a player receives while standing has been doubled and it will now match the bonus to regeneration while sitting.
-					Players will no longer need to sit to regenerate faster.
-				- Fatigue now regenerates at the standing rate while moving.
-			*/
-			if (p != null)
-			{
-				p.NonCombatNonSprintRegen = 0;
-				p.CombatRegen = 0;
-			}
-			if (!living.InCombat)
-			{
-				if (living is GamePlayer)
-				{
-					if (!((GamePlayer)living).IsSprinting)
-					{
-						regen += 4;
-					}
-				}
-				if (p != null)
-					p.NonCombatNonSprintRegen = regen;
-			}
+            if (regen == 0 && player != null)
+                regen++;
+
+            AtlasOF_RAEndRegenEnhancer raTireless = living.GetAbility<AtlasOF_RAEndRegenEnhancer>();
+
+            if (raTireless != null)
+                regen++;
+
+            /*    Patch 1.87 - COMBAT AND REGENERATION CHANGES
+                - The bonus to regeneration while standing out of combat has been greatly increased. The amount of ticks 
+                    a player receives while standing has been doubled and it will now match the bonus to regeneration while sitting.
+                    Players will no longer need to sit to regenerate faster.
+                - Fatigue now regenerates at the standing rate while moving.
+            */
+
+            if (!living.InCombat)
+            {
+                if (player != null && !player.IsSprinting)
+                    regen += 4;
+            }
             else
             {
-				regen -= 3;
-				if (regen <= 0)
-					regen = 0.1;
-				if (regenBuff > 0)
-					regen = regenBuff;
-				if (p != null && raTireless != null)
-					regen++;
-				if (p != null)
-					p.CombatRegen = regen;
-			}
-				
+                regen -= 3;
 
-			regen -= debuff;
+                if (regen <= 0)
+                    regen = 0.1;
 
-			if (regen < 0)
-				regen = 0;
+                if (regenBuff > 0)
+                    regen = regenBuff;
 
-			if (regen != 0 && ServerProperties.Properties.ENDURANCE_REGEN_RATE != 1)
-				regen *= ServerProperties.Properties.ENDURANCE_REGEN_RATE;
+                if (player != null && raTireless != null)
+                    regen++;
+            }
 
-			double decimals = regen - (int)regen;
-			if (Util.ChanceDouble(decimals))
-			{
-				regen += 1;	// compensate int rounding error
-			}
-			return (int)regen;
-		}
-	}
+            regen -= debuff;
+
+            if (regen < 0)
+                regen = 0;
+            else
+                regen *= ServerProperties.Properties.ENDURANCE_REGEN_RATE;
+
+            double decimals = regen - (int) regen;
+
+            // Compensate for int rounding.
+            if (Util.ChanceDouble(decimals))
+                regen += 1;
+
+            return (int) regen;
+        }
+    }
 }

--- a/GameServer/propertycalc/HealthRegenerationRateCalculator.cs
+++ b/GameServer/propertycalc/HealthRegenerationRateCalculator.cs
@@ -1,104 +1,66 @@
-/*
- * DAWN OF LIGHT - The first free open source DAoC server emulator
- * 
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- *
- */
-using System;
-
-using DOL.GS.Keeps;
-
 namespace DOL.GS.PropertyCalc
 {
-	/// <summary>
-	/// The health regen rate calculator
-	/// 
-	/// BuffBonusCategory1 is used for all buffs
-	/// BuffBonusCategory2 is used for all debuffs (positive values expected here)
-	/// BuffBonusCategory3 unused
-	/// BuffBonusCategory4 unused
-	/// BuffBonusMultCategory1 unused
-	/// </summary>
-	[PropertyCalculator(eProperty.HealthRegenerationRate)]
-	public class HealthRegenerationRateCalculator : PropertyCalculator
-	{
-		public HealthRegenerationRateCalculator() {}
+    /// <summary>
+    /// The health regen rate calculator
+    /// 
+    /// BuffBonusCategory1 is used for all buffs
+    /// BuffBonusCategory2 is used for all debuffs (positive values expected here)
+    /// BuffBonusCategory3 unused
+    /// BuffBonusCategory4 unused
+    /// BuffBonusMultCategory1 unused
+    /// </summary>
+    [PropertyCalculator(eProperty.HealthRegenerationRate)]
+    public class HealthRegenerationRateCalculator : PropertyCalculator
+    {
+        public HealthRegenerationRateCalculator() { }
 
-		/// <summary>
-		/// calculates the final property value
-		/// </summary>
-		/// <param name="living"></param>
-		/// <param name="property"></param>
-		/// <returns></returns>
-		public override int CalcValue(GameLiving living, eProperty property)
-		{
-			if (living.IsDiseased || living.effectListComponent.ContainsEffectForEffectType(eEffect.Bleed))
-				return 0; // no HP regen if diseased
-			if (living is GameKeepDoor)
-				return (int)(living.MaxHealth * 0.05); //5% each time for keep door
+        public override int CalcValue(GameLiving living, eProperty property)
+        {
+            if (living.IsDiseased || living.effectListComponent.ContainsEffectForEffectType(eEffect.Bleed))
+                return 0;
 
-			double regen = 1;
-
-			/* PATCH 1.87 COMBAT AND REGENERATION
-			  - While in combat, health and power regeneration ticks will happen twice as often.
-    		  - Each tick of health and power is now twice as effective.
+            /* PATCH 1.87 COMBAT AND REGENERATION
+              - While in combat, health and power regeneration ticks will happen twice as often.
+              - Each tick of health and power is now twice as effective.
               - All health and power regeneration aids are now twice as effective.
              */
 
-			if (living.Level < 26)
-			{
-				regen = 10 + (living.Level * 0.2);
-			}
-			else
-			{
-				regen = living.Level * 0.6;
-			}
+            double regen = 5 + living.Level * 0.5;
 
-			// assumes NPC regen is now half as effective as GamePlayer (as noted above) - tolakram
-			// http://www.dolserver.net/viewtopic.php?f=16&t=13197
+            if (living is GameNPC npc)
+            {
+                if (npc.InCombat)
+                    regen /= 2.0;
+                else if (npc is not NecromancerPet)
+                    regen *= 5;
+            }
+            else if (living is GamePlayer)
+            {
+                if (living.IsSitting)
+                    regen *= 1.75;
+            }
 
-			if (living is GameNPC)
-			{
-				if (living.InCombat)
-					regen /= 2.0;
-			}
-            
-			if (regen != 0 && ServerProperties.Properties.HEALTH_REGEN_RATE != 1)
-				regen *= ServerProperties.Properties.HEALTH_REGEN_RATE;
+            regen *= ServerProperties.Properties.HEALTH_REGEN_RATE;
 
-			if (living.IsSitting && living is GamePlayer)
-				regen *= 1.75;
+            double decimals = regen - (int) regen;
 
-			double decimals = regen - (int)regen;
-			if (Util.ChanceDouble(decimals)) 
-			{
-				regen += 1;	// compensate int rounding error
-			}
+            // Compensate for int rounding.
+            if (Util.ChanceDouble(decimals))
+                regen += 1;
 
-			regen += living.ItemBonus[(int)property];
+            regen += living.ItemBonus[(int)property];
 
-			int debuff = living.SpecBuffBonusCategory[(int)property];
-			if (debuff < 0)
-				debuff = -debuff;
+            int debuff = living.SpecBuffBonusCategory[(int) property];
 
-			regen += living.BaseBuffBonusCategory[(int)property] - debuff;
+            if (debuff < 0)
+                debuff = -debuff;
 
-			if (regen < 1)
-				regen = 1;
+            regen += living.BaseBuffBonusCategory[(int) property] - debuff;
 
-			return (int)regen;
-		}
-	}
+            if (regen < 1)
+                regen = 1;
+
+            return (int) regen;
+        }
+    }
 }

--- a/GameServer/propertycalc/PowerRegenerationRateCalculator.cs
+++ b/GameServer/propertycalc/PowerRegenerationRateCalculator.cs
@@ -1,73 +1,52 @@
-/*
- * DAWN OF LIGHT - The first free open source DAoC server emulator
- * 
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- *
- */
-using System;
-
 namespace DOL.GS.PropertyCalc
 {
-	/// <summary>
-	/// The power regen rate calculator
-	/// 
-	/// BuffBonusCategory1 is used for all buffs
-	/// BuffBonusCategory2 is used for all debuffs (positive values expected here)
-	/// BuffBonusCategory3 unused
-	/// BuffBonusCategory4 unused
-	/// BuffBonusMultCategory1 unused
-	/// </summary>
-	[PropertyCalculator(eProperty.PowerRegenerationRate)]
-	public class PowerRegenerationRateCalculator : PropertyCalculator
-	{
-		public PowerRegenerationRateCalculator() {}
+    /// <summary>
+    /// The power regen rate calculator
+    /// 
+    /// BuffBonusCategory1 is used for all buffs
+    /// BuffBonusCategory2 is used for all debuffs (positive values expected here)
+    /// BuffBonusCategory3 unused
+    /// BuffBonusCategory4 unused
+    /// BuffBonusMultCategory1 unused
+    /// </summary>
+    [PropertyCalculator(eProperty.PowerRegenerationRate)]
+    public class PowerRegenerationRateCalculator : PropertyCalculator
+    {
+        public PowerRegenerationRateCalculator() {}
 
-		public override int CalcValue(GameLiving living, eProperty property) 
-		{
-			/* PATCH 1.87 COMBAT AND REGENERATION
-			  - While in combat, health and power regeneration ticks will happen twice as often.
-    		  - Each tick of health and power is now twice as effective.
+        public override int CalcValue(GameLiving living, eProperty property) 
+        {
+            /* PATCH 1.87 COMBAT AND REGENERATION
+              - While in combat, health and power regeneration ticks will happen twice as often.
+              - Each tick of health and power is now twice as effective.
               - All health and power regeneration aids are now twice as effective.
              */
 
-			double regen = living.Level / 10 + (living.Level / 2.75);
+            double regen = living.Level / 10.0 + living.Level / 2.75;
 
-			if (living is GameNPC && living.InCombat)
-				regen /= 2.0;
+            // What is this? NPCs don't have power.
+            if (living is GameNPC && living.InCombat)
+                regen /= 2.0;
 
-			// tolakram - there is no difference per tic between combat and non combat
+            regen *= ServerProperties.Properties.MANA_REGEN_RATE;
 
-			if (regen != 0 && ServerProperties.Properties.MANA_REGEN_RATE != 1)
-				regen *= ServerProperties.Properties.MANA_REGEN_RATE;
+            double decimals = regen - (int) regen;
 
-			double decimals = regen - (int)regen;
-			if (Util.ChanceDouble(decimals)) 
-			{
-				regen += 1;	// compensate int rounding error
-			}
+            // Compensate for int rounding.
+            if (Util.ChanceDouble(decimals))
+                regen += 1;
 
-			int debuff = living.SpecBuffBonusCategory[(int)property];
-			if (debuff < 0)
-				debuff = -debuff;
+            int debuff = living.SpecBuffBonusCategory[(int) property];
 
-			regen += living.BaseBuffBonusCategory[(int)property] + living.AbilityBonus[(int)property] + living.ItemBonus[(int)property] - debuff;
+            if (debuff < 0)
+                debuff = -debuff;
 
-			if (regen < 1)
-				regen = 1;
+            regen += living.BaseBuffBonusCategory[(int) property] + living.AbilityBonus[(int) property] + living.ItemBonus[(int) property] - debuff;
 
-			return (int)regen;
-		}
-	}
+            if (regen < 1)
+                regen = 1;
+
+            return (int) regen;
+        }
+    }
 }

--- a/GameServer/scripts/customnpc/HitbackDummy.cs
+++ b/GameServer/scripts/customnpc/HitbackDummy.cs
@@ -29,7 +29,7 @@
             Name = "Hitback Dummy - Right Click to Reset";
             Model = 34;
             Strength = 10;
-            ScalingFactor = 4;
+            WeaponSkillScalingFactor = 4;
             FixedSpeed = true;
             return base.AddToWorld();
         }

--- a/GameServer/scripts/namedmobs/Archilus.cs
+++ b/GameServer/scripts/namedmobs/Archilus.cs
@@ -14,7 +14,7 @@ namespace DOL.GS.Scripts
 		{
 			m_SpawnAnnounce = "{0} will start to \'shake violently\' and spawns out some {1}!";
 			TetherRange = 4500;
-			ScalingFactor = 25;
+			WeaponSkillScalingFactor = 25;
 		}
 
 		public override bool AddToWorld()

--- a/GameServer/scripts/namedmobs/Dodens/ArosTheSpiritmaster.cs
+++ b/GameServer/scripts/namedmobs/Dodens/ArosTheSpiritmaster.cs
@@ -35,7 +35,7 @@ namespace DOL.GS.Scripts
             Intelligence = npcTemplate.Intelligence;
             Empathy = npcTemplate.Empathy;
 
-            ScalingFactor = 40;
+            WeaponSkillScalingFactor = 40;
             Faction = FactionMgr.GetFactionByID(779);
             LoadedFromScript = false; //load from database
             SaveIntoDatabase();

--- a/GameServer/scripts/namedmobs/Dodens/Gudlaugr.cs
+++ b/GameServer/scripts/namedmobs/Dodens/Gudlaugr.cs
@@ -31,7 +31,7 @@ namespace DOL.GS.Scripts
 			RespawnInterval = ServerProperties.Properties.SET_EPIC_GAME_ENCOUNTER_RESPAWNINTERVAL * 60000;//1min is 60000 miliseconds
 
 			BodyType = 1;
-			ScalingFactor = 40;
+			WeaponSkillScalingFactor = 40;
 			GudlaugrBrain sbrain = new GudlaugrBrain();
 			SetOwnBrain(sbrain);
 			base.AddToWorld();
@@ -145,7 +145,7 @@ namespace DOL.GS.Scripts
 				if (!rage)
 				{
 					// transmorph to little white wolf
-					Body.ScalingFactor = 40;
+					Body.WeaponSkillScalingFactor = 40;
 					Body.Model = 650;
 					Body.Size = 40;
 					Body.Strength = Body.NPCTemplate.Strength;
@@ -153,7 +153,7 @@ namespace DOL.GS.Scripts
 				else
 				{
 					// transmorph to demon wolf
-					Body.ScalingFactor = 60;
+					Body.WeaponSkillScalingFactor = 60;
 					Body.Strength = 330;
 					Body.Model = 649;
 					Body.Size = 110;

--- a/GameServer/scripts/namedmobs/Dodens/Hamar.cs
+++ b/GameServer/scripts/namedmobs/Dodens/Hamar.cs
@@ -42,7 +42,7 @@ namespace DOL.GS.Scripts
 			VisibleActiveWeaponSlots = 16;
 			RespawnInterval = ServerProperties.Properties.SET_EPIC_GAME_ENCOUNTER_RESPAWNINTERVAL * 60000;//1min is 60000 miliseconds
 
-			ScalingFactor = 40;
+			WeaponSkillScalingFactor = 40;
 			base.SetOwnBrain(new HamarBrain());
 			LoadedFromScript = false; //load from database
 			SaveIntoDatabase();

--- a/GameServer/scripts/namedmobs/Dodens/JarlOrmarr.cs
+++ b/GameServer/scripts/namedmobs/Dodens/JarlOrmarr.cs
@@ -35,7 +35,7 @@ namespace DOL.GS.Scripts
 
 			// right hand
 			VisibleActiveWeaponSlots = (byte) eActiveWeaponSlot.Standard;			
-			ScalingFactor = 40;
+			WeaponSkillScalingFactor = 40;
 			base.SetOwnBrain(new JarlOrmarrBrain());
 			LoadedFromScript = false; //load from database
 			SaveIntoDatabase();

--- a/GameServer/scripts/namedmobs/Dodens/ThaneDyggve.cs
+++ b/GameServer/scripts/namedmobs/Dodens/ThaneDyggve.cs
@@ -34,7 +34,7 @@ namespace DOL.GS.Scripts
 			Faction = FactionMgr.GetFactionByID(779);
 			RespawnInterval = ServerProperties.Properties.SET_EPIC_GAME_ENCOUNTER_RESPAWNINTERVAL * 60000;//1min is 60000 miliseconds
 
-			ScalingFactor = 60;
+			WeaponSkillScalingFactor = 60;
 			base.SetOwnBrain(new ThaneDyggveBrain());
 			LoadedFromScript = false; //load from database
 			SaveIntoDatabase();

--- a/GameServer/scripts/namedmobs/ElroTheAncient.cs
+++ b/GameServer/scripts/namedmobs/ElroTheAncient.cs
@@ -12,7 +12,7 @@ namespace DOL.GS.Scripts
 		public ElroTheAncient()
 		{
 			TetherRange = 4500;
-			ScalingFactor = 55;
+			WeaponSkillScalingFactor = 55;
 		}
 		public override int GetResist(eDamageType damageType)
 		{

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/Hord.cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/Hord.cs
@@ -40,7 +40,7 @@ namespace DOL.GS.Scripts
             Level = 77;
             // Giant
             BodyType = 5;
-            ScalingFactor = 45;
+            WeaponSkillScalingFactor = 45;
             
             HordBrain sBrain = new HordBrain();
             SetOwnBrain(sBrain);

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/Ozur.cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/Ozur.cs
@@ -47,7 +47,7 @@ namespace DOL.GS.Scripts
             Level = 77;
             // Giant
             BodyType = 5;
-            ScalingFactor = 45;
+            WeaponSkillScalingFactor = 45;
 
             OzurBrain sBrain = new OzurBrain();
             SetOwnBrain(sBrain);
@@ -198,14 +198,14 @@ namespace DOL.AI.Brain
 
                 if (countPlayer >= _GettingFirstPlayerStage && countPlayer < _GettingSecondPlayerStage)
                 {
-                    Body.ScalingFactor += 10;
+                    Body.WeaponSkillScalingFactor += 10;
                     Body.Strength = 200;
                     Resists(false);
                 }
 
                 if (countPlayer >= _GettingSecondPlayerStage)
                 {
-                    Body.ScalingFactor += 25;
+                    Body.WeaponSkillScalingFactor += 25;
                     Body.Strength = 350;
                     Weak(true);
                 }

--- a/GameServer/scripts/quests/Albion/shrouded isles/LostStoneOfArawn.cs
+++ b/GameServer/scripts/quests/Albion/shrouded isles/LostStoneOfArawn.cs
@@ -319,7 +319,7 @@ public class LostStoneofArawn : BaseQuest
         Nyaegha.CurrentRegionID = 51;
         Nyaegha.Size = 150;
         Nyaegha.Level = 65;
-        Nyaegha.ScalingFactor = ServerProperties.Properties.NECK_BOSS_SCALING;
+        Nyaegha.WeaponSkillScalingFactor = 80;
         Nyaegha.X = 348381;
         Nyaegha.Y = 479838;
         Nyaegha.Z = 3320;

--- a/GameServer/scripts/quests/Hibernia/shrouded isles/TheLostSeed.cs
+++ b/GameServer/scripts/quests/Hibernia/shrouded isles/TheLostSeed.cs
@@ -314,7 +314,7 @@ namespace DOL.GS.Quests.Hibernia
 			Feairna_Athar.CurrentRegionID = 181;
 			Feairna_Athar.Size = 100;
 			Feairna_Athar.Level = 65;
-			Feairna_Athar.ScalingFactor = ServerProperties.Properties.NECK_BOSS_SCALING;
+			Feairna_Athar.WeaponSkillScalingFactor = 80;
 			Feairna_Athar.X = 288348;
 			Feairna_Athar.Y = 319950;
 			Feairna_Athar.Z = 2328;

--- a/GameServer/scripts/quests/Midgard/shrouded isles/AncestralSecrets.cs
+++ b/GameServer/scripts/quests/Midgard/shrouded isles/AncestralSecrets.cs
@@ -341,7 +341,7 @@ namespace DOL.GS.Quests.Hibernia
 			AncestralKeeper.CurrentRegionID = 151;
 			AncestralKeeper.Size = 140;
 			AncestralKeeper.Level = 65;
-			AncestralKeeper.ScalingFactor = ServerProperties.Properties.NECK_BOSS_SCALING;
+			AncestralKeeper.WeaponSkillScalingFactor = 80;
 			AncestralKeeper.X = player.X;
 			AncestralKeeper.Y = player.Y;
 			AncestralKeeper.Z = player.Z;

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -424,67 +424,55 @@ namespace DOL.GS.ServerProperties
 		/// </summary>
 		[ServerProperty("atlas", "Discord_RVR_Webhook_ID", "The id of the webhook for RvR updates", "")]
 		public static string DISCORD_RVR_WEBHOOK_ID;
-		
+
 		/// <summary>
 		/// RvRWebhook ID
 		/// </summary>
 		[ServerProperty("atlas", "Discord_AlbChat_Webhook_ID", "The id of the webhook for all Albion chat", "")]
 		public static string DISCORD_ALBCHAT_WEBHOOK_ID;
-		
+
 		/// <summary>
 		/// RvRWebhook ID
 		/// </summary>
 		[ServerProperty("atlas", "Discord_HibChat_Webhook_ID", "The id of the webhook for Hibernia chat", "")]
 		public static string DISCORD_HIBCHAT_WEBHOOK_ID;
-		
+
 		/// <summary>
 		/// RvRWebhook ID
 		/// </summary>
 		[ServerProperty("atlas", "Discord_MidChat_Webhook_ID", "The id of the webhook for Midgard chat", "")]
 		public static string DISCORD_MIDCHAT_WEBHOOK_ID;
-		
+
 		/// <summary>
 		/// Tester Role
 		/// </summary>
 		[ServerProperty("atlas", "tester_login", "Allow only testers and staff to login", false)]
 		public static bool TESTER_LOGIN;
-		
-		/// <summary>
-		/// The toughness of the boss for the SI necklace quest
-		/// </summary>
-		[ServerProperty("atlas", "neck_boss_scaling", "The toughness of the boss for the SI necklace quest", 80)]
-		public static int NECK_BOSS_SCALING;
-		
+
 		/// <summary>
 		/// The slowmode duration for /advice in seconds
 		/// </summary>
 		[ServerProperty("atlas", "advice_slowmode_length", "The slowmode duration for /advice in seconds", 60)]
 		public static int ADVICE_SLOWMODE_LENGTH;
-		
+
 		/// <summary>
 		/// The slowmode duration for /trade in seconds
 		/// </summary>
 		[ServerProperty("atlas", "trade_slowmode_length", "The slowmode duration for /trade in seconds", 60)]
 		public static int TRADE_SLOWMODE_LENGTH;
-		
+
 		/// <summary>
 		/// The slowmode duration for /lfg in seconds
 		/// </summary>
 		[ServerProperty("atlas", "lfg_slowmode_length", "The slowmode duration for /lfg in seconds", 60)]
 		public static int LFG_SLOWMODE_LENGTH;
-		
-		/// <summary>
-		/// The toughness of GameNPCs
-		/// </summary>
-		[ServerProperty("atlas", "gamenpc_scaling", "The toughness of GameNPCs", 15)]
-		public static int GAMENPC_SCALING;
 
 		/// <summary>
 		/// The first factor in the PVE mob damage equation. Lower hits harder.
 		/// </summary>
 		[ServerProperty("atlas", "pve_mob_damage_f1", "The first factor in the PVE mob damage equation. Lower hits harder.", 3.2)]
 		public static double PVE_MOB_DAMAGE_F1;
-		
+
 		/// <summary>
 		/// The second factor in the PVE mob damage equation. Lower hits harder.
 		/// </summary>

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -1283,25 +1283,6 @@ namespace DOL.GS.ServerProperties
 		public static bool ALLOW_ROAM;
 
 		/// <summary>
-		/// This is to set the baseHP For NPCs
-		/// </summary>
-		[ServerProperty("npc", "gamenpc_base_hp", "GameNPC's base HP * level", 500)]
-		public static int GAMENPC_BASE_HP;
-
-		/// <summary>
-		/// How many hitpoints per point of CON above gamenpc_base_con should an NPC gain.
-		/// This modification is applied prior to any buffs
-		/// </summary>
-		[ServerProperty("npc", "gamenpc_hp_gain_per_con", "How many hitpoints per point of CON above gamenpc_base_con should an NPC gain", 2)]
-		public static int GAMENPC_HP_GAIN_PER_CON;
-
-		/// <summary>
-		/// What is the base contitution for npc's
-		/// </summary>
-		[ServerProperty("npc", "gamenpc_base_con", "GameNPC's base Constitution", 30)]
-		public static int GAMENPC_BASE_CON;
-
-		/// <summary>
 		/// Chance for NPC to roam.
 		/// </summary>
 		[ServerProperty("npc", "gamenpc_roam_cooldown_min", "Minimum duration in seconds between two roams.", 5)]

--- a/GameServer/spells/Animist/SummonAnimistFnF.cs
+++ b/GameServer/spells/Animist/SummonAnimistFnF.cs
@@ -1,22 +1,3 @@
-/*
- * DAWN OF LIGHT - The first free open source DAoC server emulator
- * 
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- *
- */
-
 using System;
 using System.Linq;
 using DOL.AI.Brain;
@@ -153,11 +134,16 @@ namespace DOL.GS.Spells
 			return base.OnEffectExpires(effect, noMessages);
 		}
 
+		protected override GameSummonedPet GetGamePet(INpcTemplate template)
+		{
+			return new TurretFnfPet(template);
+		}
+
 		protected override IControlledBrain GetPetBrain(GameLiving owner)
 		{
 			return new TurretFNFBrain(owner);
 		}
-		
+
 		/// <summary>
 		/// Do not trigger SubSpells
 		/// </summary>

--- a/GameServer/spells/Animist/SummonAnimistMainPet.cs
+++ b/GameServer/spells/Animist/SummonAnimistMainPet.cs
@@ -1,65 +1,49 @@
-/*
- * DAWN OF LIGHT - The first free open source DAoC server emulator
- * 
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- *
- */
-/*
- * [Ganrod] Nidel 2008-07-08
- * - Useless using removed
- * - Get Main Pet tank or Main Pet caster by spell damage type
- */
 using DOL.AI.Brain;
 using DOL.GS.PacketHandler;
 using DOL.Language;
 
 namespace DOL.GS.Spells
 {
-  /// <summary>
-  /// Spell handler to summon a animist pet.
-  /// </summary>
-  /// <author>IST</author>
-  [SpellHandler("SummonAnimistPet")]
-  public class SummonAnimistMainPet : SummonAnimistPet
-  {
-    public SummonAnimistMainPet(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line)
+    /// <summary>
+    /// Spell handler to summon a animist pet.
+    /// </summary>
+    /// <author>IST</author>
+    [SpellHandler("SummonAnimistPet")]
+    public class SummonAnimistMainPet : SummonAnimistPet
     {
-    }
+        public SummonAnimistMainPet(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
 
-    public override bool CheckEndCast(GameLiving selectedTarget)
-    {
-      if(Caster is GamePlayer && Caster.ControlledBrain != null)
-      {
-        MessageToCaster(LanguageMgr.GetTranslation((Caster as GamePlayer).Client, "SummonAnimistPet.CheckBeginCast.AlreadyHaveaPet"), eChatType.CT_SpellResisted);
-        return false;
-      }
-      return base.CheckEndCast(selectedTarget);
-    }
+        public override bool CheckEndCast(GameLiving selectedTarget)
+        {
+            if (Caster is GamePlayer && Caster.ControlledBrain != null)
+            {
+                MessageToCaster(LanguageMgr.GetTranslation((Caster as GamePlayer).Client, "SummonAnimistPet.CheckBeginCast.AlreadyHaveaPet"), eChatType.CT_SpellResisted);
+                return false;
+            }
 
-    protected override IControlledBrain GetPetBrain(GameLiving owner)
-    {
-      if(Spell.DamageType == 0)
-      {
-        return new TurretMainPetCasterBrain(owner);
-      }
-      //[Ganrod] Nidel: Spell.DamageType : 1 for tank pet
-      if(Spell.DamageType == (eDamageType) 1)
-      {
-        return new TurretMainPetTankBrain(owner);
-      }
-      return base.GetPetBrain(owner);
+            return base.CheckEndCast(selectedTarget);
+        }
+
+        protected override GameSummonedPet GetGamePet(INpcTemplate template)
+        {
+            if (Spell.DamageType == 0)
+                return new TurretMainPetCaster(template);
+
+            if (Spell.DamageType == (eDamageType) 1)
+                return new TurretMainPetTank(template);
+
+            return base.GetGamePet(template);
+        }
+
+        protected override IControlledBrain GetPetBrain(GameLiving owner)
+        {
+            if (Spell.DamageType == 0)
+                return new TurretMainPetCasterBrain(owner);
+
+            if (Spell.DamageType == (eDamageType) 1)
+                return new TurretMainPetTankBrain(owner);
+
+            return base.GetPetBrain(owner);
+        }
     }
-  }
 }

--- a/GameServer/spells/BoltSpellHandler.cs
+++ b/GameServer/spells/BoltSpellHandler.cs
@@ -72,7 +72,7 @@ namespace DOL.GS.Spells
                 // We need a fake weapon skill for the target's armor to have something to be compared with.
                 // Since 'damage' is already modified by intelligence, power relics, spell variance, and everything else; we can use a constant only modified by the caster's level.
                 double weaponSkill = Caster.attackComponent.CalculateWeaponSkill(Caster.Level * 5, 1.0, 1.0);
-                double targetArmor = Caster.attackComponent.CalculateTargetArmor(ad.Target, ad.ArmorHitLocation);
+                double targetArmor = AttackComponent.CalculateTargetArmor(ad.Target, ad.ArmorHitLocation);
                 damage += (int) (weaponSkill / targetArmor * damage / 2);
             }
             else

--- a/GameServer/spells/BoltSpellHandler.cs
+++ b/GameServer/spells/BoltSpellHandler.cs
@@ -71,7 +71,7 @@ namespace DOL.GS.Spells
 
                 // We need a fake weapon skill for the target's armor to have something to be compared with.
                 // Since 'damage' is already modified by intelligence, power relics, spell variance, and everything else; we can use a constant only modified by the caster's level.
-                double weaponSkill = Caster.attackComponent.CalculateWeaponSkill(ad.Target, Caster.Level * 5, 1.0, 1.0);
+                double weaponSkill = Caster.attackComponent.CalculateWeaponSkill(Caster.Level * 5, 1.0, 1.0);
                 double targetArmor = Caster.attackComponent.CalculateTargetArmor(ad.Target, ad.ArmorHitLocation);
                 damage += (int) (weaponSkill / targetArmor * damage / 2);
             }

--- a/GameServer/spells/BoltSpellHandler.cs
+++ b/GameServer/spells/BoltSpellHandler.cs
@@ -72,7 +72,7 @@ namespace DOL.GS.Spells
                 // We need a fake weapon skill for the target's armor to have something to be compared with.
                 // Since 'damage' is already modified by intelligence, power relics, spell variance, and everything else; we can use a constant only modified by the caster's level.
                 double weaponSkill = Caster.attackComponent.CalculateWeaponSkill(Caster.Level * 5, 1.0, 1.0);
-                double targetArmor = AttackComponent.CalculateTargetArmor(ad.Target, ad.ArmorHitLocation);
+                double targetArmor = AttackComponent.CalculateTargetArmor(ad.Target, ad.ArmorHitLocation, out _, out _);
                 damage += (int) (weaponSkill / targetArmor * damage / 2);
             }
             else

--- a/GameServer/styles/StyleProcessor.cs
+++ b/GameServer/styles/StyleProcessor.cs
@@ -390,6 +390,14 @@ namespace DOL.GS.Styles
 						double modifiedGrowthRate = talyGrowth * talySpec * talySpeed / unstyledDamageCap;
 						styleDamage = modifiedGrowthRate * unstyledDamage;
 						styleDamageCap = modifiedGrowthRate * unstyledDamageCap;
+
+						// Force styles do at least 1 damage to make level 2 styles actually do something.
+						// Don't forget to ignore the cap. Do it only if the style has a GR.
+						if (styleDamage < 1 && talyGrowth > 0)
+						{
+							styleDamage = 1;
+							styleDamageCap = 0;
+						}
 					}
 
 					if (player != null)


### PR DESCRIPTION
This started as an attempt to fix inconsistent HP scaling at low levels (e.g., a level 19 NPC having more HP than a level 23 or 24). But it quickly became clear that there was a lot of special handling code, especially for low-level fights, added to address issues created by other formulas, making everything quite messy.

These commits greatly simplify those, ensure a more consistent progression through levels, and fix oddities like excessive HP regeneration at low levels. While these changes mainly affect low-level fights, they also impact pets: Animist's main pets now have more HP (FnF should be about the same), and Theurgist's pets have less starting from level 2 (with no change at level 44). Additionally, pets now regenerate HP faster out of combat. This is just an example. For more details, see the commit messages.

Note that this rework is based on NPCs using auto stats (30 base + 1 per level with default server properties), since this change affects how much HP is gained from base constitution.

Auto stats are set when NPC templates have 0 in their stats and ReplaceMobValues is set to true, or when mobs have 0 in their stats and ReplaceMobValues is set to false (generally, ReplaceMobValues should almost always be set to true).

If you're using OD's database, most NPCs don't use auto-set stats, which is problematic because some low-level NPCs have much more strength than higher-level ones. Keep this in mind. In fact, I'd suggest removing stats from NPC templates altogether. This also applies to summoned pets (they always use auto-set stats but them apply the ones in their NPC templates as a percentage (e.g., a value of 50 effectively halves their auto stats)).

Related commit removing stats from Animist and Theurgist pets, so that they use the full amount of their auto stats: https://github.com/OpenDAoC/OpenDAoC-Database/commit/ad4d5129480c564af4f0ddfa64ca9338ffc1a284