### PR TITLE
Minor fixes to CI

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -79,9 +79,8 @@ jobs:
       - name: 📝 Generate release notes
         id: release_notes
         run: |
-          VERSION=$(git tag --sort=-committerdate | head -1)
-          PREVIOUS_VERSION=$(git tag --sort=-committerdate | head -2 | tail -1)
-          CHANGES=$(git log --pretty="- %s" $VERSION...$PREVIOUS_VERSION | sed -n '1,20p')
+          PREVIOUS_VERSION=$(git tag --sort=-committerdate | head -1)
+          CHANGES=$(git log --pretty="%h - %s - (%an)" $PREVIOUS_VERSION...HEAD | sed -n '1,20p')
           echo "# 🎁 Release Notes for $VERSION" > release_notes.txt
           echo "" >> release_notes.txt
           echo "## 🐳 Docker" > release_notes.txt

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -80,7 +80,7 @@ jobs:
         id: release_notes
         run: |
           PREVIOUS_VERSION=$(git tag --sort=-committerdate | head -1)
-          CHANGES=$(git log --pretty="%h - %s - (%an)" $PREVIOUS_VERSION...HEAD | sed -n '1,20p')
+          CHANGES=$(git log --pretty="%h - %s" $PREVIOUS_VERSION...HEAD | sed -n '1,20p')
           echo "# 🎁 Release Notes for $VERSION" > release_notes.txt
           echo "" >> release_notes.txt
           echo "## 🐳 Docker" > release_notes.txt


### PR DESCRIPTION
Small fix on how the changelog for GitHub releases gets generated. 
When we fetch the changes with `git log`, the new version isn't published yet and the tail is subsequently empty.

Additionally changed the output format to show the commit hash alongside the message.