### PR TITLE
additional dotnet envvar to fix server startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
       SERVER_PORT: "10300"
       UDP_IP: "0.0.0.0"
       UDP_PORT: "10400"
+      DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: "False"
     volumes:
       - base-db:/tmp/opendaoc-db
     networks:


### PR DESCRIPTION
the opendaoc-core docker setup on the website will not start properly without this envvar.

the error:

>  ---> System.Globalization.CultureNotFoundException: Only the invariant culture is supported in globalization-invariant mode. See https://aka.ms/GlobalizationInvariantMode for more information. (Parameter 'name')
en-US is an invalid culture identifier.

@claitz