### PR TITLE
Fix console commands throwing exceptions

### DIFF
--- a/CoreServer/Actions/ConsoleStart.cs
+++ b/CoreServer/Actions/ConsoleStart.cs
@@ -36,6 +36,11 @@ namespace DOL.DOLServer.Actions
             get { return "Starts the DOL server in console mode"; }
         }
 
+        /// <summary>
+        /// Mock client for console commands
+        /// </summary>
+        private GameClient m_clientConsole;
+
         private bool crashOnFail = false;
 
 
@@ -113,17 +118,36 @@ namespace DOL.DOLServer.Actions
                         if (line[0] != '/')
                             line = $"/{line}";
 
-                        GameClient client = new(null);
-                        client.Out = new ConsolePacketLib();
-
                         try
                         {
-                            if (!ScriptMgr.HandleCommand(client, $"&{line[1..]}"))
+                            if (m_clientConsole == null)
+                            {
+                                m_clientConsole = new(null);
+                                m_clientConsole.Account = new();
+                                m_clientConsole.Account.Name = "ConsoleAdmin";
+                                m_clientConsole.Account.Language = DOL.GS.ServerProperties.Properties.SERV_LANGUAGE;
+                                m_clientConsole.Account.PrivLevel = (uint)ePrivLevel.Admin;
+                                m_clientConsole.ClientState = GameClient.eClientState.Playing;
+                                m_clientConsole.Out = new ConsolePacketLib();
+                                m_clientConsole.Player = new GamePlayer(m_clientConsole, null);
+                                m_clientConsole.Player.Name = m_clientConsole.Account.Name;
+                                m_clientConsole.Player.Realm = eRealm.None;
+                            }
+
+                            if (!ScriptMgr.HandleCommand(m_clientConsole, $"&{line[1..]}"))
+                            {
+                                ConsoleColor before = Console.ForegroundColor;
+                                Console.ForegroundColor = ConsoleColor.Cyan;
                                 Console.WriteLine($"Unknown command: {line}");
+                                Console.ForegroundColor = before;
+                            }
                         }
                         catch (Exception e)
                         {
+                            ConsoleColor before = Console.ForegroundColor;
+                            Console.ForegroundColor = ConsoleColor.Cyan;
                             Console.WriteLine(e.ToString());
+                            Console.ForegroundColor = before;
                         }
 
                         break;

--- a/CoreServer/Actions/ConsoleStart.cs
+++ b/CoreServer/Actions/ConsoleStart.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Reflection;
 using DOL.GameServerConsole;
 using DOL.GS;
+using DOL.GS.ServerProperties;
 
 namespace DOL.DOLServer.Actions
 {
@@ -39,10 +40,9 @@ namespace DOL.DOLServer.Actions
         /// <summary>
         /// Mock client for console commands
         /// </summary>
-        private GameClient m_clientConsole;
+        private GameClient _consoleClient;
 
-        private bool crashOnFail = false;
-
+        private bool _crashOnFail = false;
 
         private static bool StartServer()
         {
@@ -67,7 +67,7 @@ namespace DOL.DOLServer.Actions
                 configFile = new FileInfo(currentAssembly.DirectoryName + Path.DirectorySeparatorChar + "config" + Path.DirectorySeparatorChar + "serverconfig.xml");
             }
             if (parameters.ContainsKey("-crashonfail"))
-                crashOnFail = true;
+                _crashOnFail = true;
 
             var config = new GameServerConfiguration();
             if (configFile.Exists)
@@ -88,7 +88,7 @@ namespace DOL.DOLServer.Actions
             GameServer.CreateInstance(config);
             StartServer();
 
-            if (crashOnFail && GameServer.Instance.ServerStatus == EGameServerStatus.GSS_Closed)
+            if (_crashOnFail && GameServer.Instance.ServerStatus == EGameServerStatus.GSS_Closed)
             {
                 throw new ApplicationException("Server did not start properly.");
             }
@@ -120,21 +120,9 @@ namespace DOL.DOLServer.Actions
 
                         try
                         {
-                            if (m_clientConsole == null)
-                            {
-                                m_clientConsole = new(null);
-                                m_clientConsole.Account = new();
-                                m_clientConsole.Account.Name = "ConsoleAdmin";
-                                m_clientConsole.Account.Language = DOL.GS.ServerProperties.Properties.SERV_LANGUAGE;
-                                m_clientConsole.Account.PrivLevel = (uint)ePrivLevel.Admin;
-                                m_clientConsole.ClientState = GameClient.eClientState.Playing;
-                                m_clientConsole.Out = new ConsolePacketLib();
-                                m_clientConsole.Player = new GamePlayer(m_clientConsole, null);
-                                m_clientConsole.Player.Name = m_clientConsole.Account.Name;
-                                m_clientConsole.Player.Realm = eRealm.None;
-                            }
+                            EnsureConsoleClientIsInitialized();
 
-                            if (!ScriptMgr.HandleCommand(m_clientConsole, $"&{line[1..]}"))
+                            if (!ScriptMgr.HandleCommand(_consoleClient, $"&{line[1..]}"))
                             {
                                 ConsoleColor before = Console.ForegroundColor;
                                 Console.ForegroundColor = ConsoleColor.Cyan;
@@ -156,6 +144,29 @@ namespace DOL.DOLServer.Actions
             }
 
             GameServer.Instance?.Stop();
+        }
+
+        private void EnsureConsoleClientIsInitialized()
+        {
+            if (_consoleClient != null)
+                return;
+
+            _consoleClient = new(null)
+            {
+                Account = new()
+                {
+                    Name = "ConsoleAdmin",
+                    Language = Properties.SERV_LANGUAGE,
+                    PrivLevel = (uint) ePrivLevel.Admin
+                },
+                ClientState = GameClient.eClientState.Playing,
+                Out = new ConsolePacketLib()
+            };
+            _consoleClient.Player = new(_consoleClient, null)
+            {
+                Name = _consoleClient.Account.Name,
+                Realm = eRealm.None
+            };
         }
     }
 }

--- a/CoreServer/ConsolePacketLib.cs
+++ b/CoreServer/ConsolePacketLib.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Text;
 using DOL.AI.Brain;
 using DOL.Database;
 using DOL.GS;
@@ -24,9 +25,13 @@ namespace DOL.GameServerConsole
 
 		public void SendMessage(string msg, eChatType type, eChatLoc loc)
 		{
-			if (log.IsDebugEnabled)
-				log.Debug(string.Format("({0}, {1}): {2}", type, loc, msg));
-		}
+            //if (log.IsDebugEnabled)
+            //	log.Debug(string.Format("({0}, {1}): {2}", type, loc, msg));
+            ConsoleColor prevCol = Console.ForegroundColor;
+			Console.ForegroundColor = ConsoleColor.Cyan;
+			Console.WriteLine(msg);
+			Console.ForegroundColor = prevCol;
+        }
 
 		public void SendRawMessage(string msg, eChatType type, eChatLoc loc)
 		{
@@ -39,18 +44,38 @@ namespace DOL.GameServerConsole
 				msg = "(null)";
 			if (callback == null)
 			{
-				if (log.IsDebugEnabled)
-					log.Debug(string.Format("(info dialog): {0}", msg));
-			}
+                ConsoleColor prevCol = Console.ForegroundColor;
+                Console.ForegroundColor = ConsoleColor.Cyan;
+                Console.WriteLine(msg);
+                Console.ForegroundColor = prevCol;
+            }
 			else
 			{
-				if (log.IsDebugEnabled)
-					log.Debug(string.Format("Accepting dialog: {0} {1}\n\"{2}\"", callback.Target, callback.Method, msg));
-				callback(null, 1);
+                ConsoleColor prevCol = Console.ForegroundColor;
+                Console.ForegroundColor = ConsoleColor.Cyan;
+                Console.WriteLine(msg);
+                Console.ForegroundColor = prevCol;
+                callback(null, 1);
 			}
 		}
 
-		public byte GetPacketCode(eServerPackets packetCode) { return 0; }
+        public void SendCustomTextWindow(string caption, IList<string> text)
+		{
+			if (!String.IsNullOrEmpty(caption))
+				text.Insert(0, caption);
+			if (text.Count > 0)
+            {
+				StringBuilder msg = new();
+				foreach (string s in text)
+					msg.AppendLine(s);
+                ConsoleColor prevCol = Console.ForegroundColor;
+                Console.ForegroundColor = ConsoleColor.Cyan;
+                Console.WriteLine(msg.ToString());
+                Console.ForegroundColor = prevCol;
+            }
+        }
+
+        public byte GetPacketCode(eServerPackets packetCode) { return 0; }
 		public void SendTCP(GSTCPPacketOut packet) { }
 		public void SendUDP(GSUDPPacketOut packet) { }
 		public void SendWarlockChamberEffect(GamePlayer player) { }
@@ -124,7 +149,6 @@ namespace DOL.GameServerConsole
 		public void SendUpdatePlayer() { }
 		public void SendUpdatePlayerSkills(bool updateInternalCache) { }
 		public void SendUpdateWeaponAndArmorStats() { }
-		public void SendCustomTextWindow(string caption, IList<string> text) { }
 		public void SendEncumbrance() { }
 		public void SendAddFriends(string[] friendNames) { }
 		public void SendRemoveFriends(string[] friendNames) { }

--- a/CoreServer/ConsolePacketLib.cs
+++ b/CoreServer/ConsolePacketLib.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Text;
 using DOL.AI.Brain;
 using DOL.Database;
@@ -13,253 +12,250 @@ using DOL.GS.Quests;
 
 namespace DOL.GameServerConsole
 {
-	/// <summary>
-	/// The packetlib for dummy console clients for /commands
-	/// </summary>
-	public class ConsolePacketLib : IPacketLib
-	{
-		/// <summary>
-		/// Defines a logger for this class.
-		/// </summary>
-		private static readonly Logging.Logger log = Logging.LoggerManager.Create(MethodBase.GetCurrentMethod().DeclaringType);
-
-		public void SendMessage(string msg, eChatType type, eChatLoc loc)
-		{
-            //if (log.IsDebugEnabled)
-            //	log.Debug(string.Format("({0}, {1}): {2}", type, loc, msg));
+    /// <summary>
+    /// The packetlib for dummy console clients for /commands
+    /// </summary>
+    public class ConsolePacketLib : IPacketLib
+    {
+        public void SendMessage(string msg, eChatType type, eChatLoc loc)
+        {
             ConsoleColor prevCol = Console.ForegroundColor;
-			Console.ForegroundColor = ConsoleColor.Cyan;
-			Console.WriteLine(msg);
-			Console.ForegroundColor = prevCol;
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            Console.WriteLine(msg);
+            Console.ForegroundColor = prevCol;
         }
 
-		public void SendRawMessage(string msg, eChatType type, eChatLoc loc)
-		{
-			SendMessage(msg, type, loc);
-		}
+        public void SendRawMessage(string msg, eChatType type, eChatLoc loc)
+        {
+            SendMessage(msg, type, loc);
+        }
 
-		public void SendCustomDialog(string msg, CustomDialogResponse callback)
-		{
-			if (msg == null)
-				msg = "(null)";
-			if (callback == null)
-			{
+        public void SendCustomDialog(string msg, CustomDialogResponse callback)
+        {
+            if (string.IsNullOrEmpty(msg))
+                return;
+
+            if (callback == null)
+            {
                 ConsoleColor prevCol = Console.ForegroundColor;
                 Console.ForegroundColor = ConsoleColor.Cyan;
                 Console.WriteLine(msg);
                 Console.ForegroundColor = prevCol;
             }
-			else
-			{
+            else
+            {
                 ConsoleColor prevCol = Console.ForegroundColor;
                 Console.ForegroundColor = ConsoleColor.Cyan;
                 Console.WriteLine(msg);
                 Console.ForegroundColor = prevCol;
                 callback(null, 1);
-			}
-		}
+            }
+        }
 
         public void SendCustomTextWindow(string caption, IList<string> text)
-		{
-			if (!String.IsNullOrEmpty(caption))
-				text.Insert(0, caption);
-			if (text.Count > 0)
+        {
+            if (!string.IsNullOrEmpty(caption))
+                text.Insert(0, caption);
+
+            if (text.Count > 0)
             {
-				StringBuilder msg = new();
-				foreach (string s in text)
-					msg.AppendLine(s);
+                StringBuilder msg = new();
+
+                foreach (string s in text)
+                    msg.AppendLine(s);
+
                 ConsoleColor prevCol = Console.ForegroundColor;
                 Console.ForegroundColor = ConsoleColor.Cyan;
-                Console.WriteLine(msg.ToString());
+                Console.WriteLine(msg);
                 Console.ForegroundColor = prevCol;
             }
         }
 
         public byte GetPacketCode(eServerPackets packetCode) { return 0; }
-		public void SendTCP(GSTCPPacketOut packet) { }
-		public void SendUDP(GSUDPPacketOut packet) { }
-		public void SendWarlockChamberEffect(GamePlayer player) { }
-		public void SendVersionAndCryptKey() { }
-		public void SendLoginDenied(eLoginError et) { }
-		public void SendLoginGranted() { }
-		public void SendLoginGranted(byte color) { } // help for rvr AND pvp servers
-		public void SendSessionID() { }
-		public void SendPingReply(ulong timestamp, ushort sequence) { }
-		public void SendRealm(eRealm realm) { }
-		public void SendCharacterOverview(eRealm realm) { }
-		public void SendDupNameCheckReply(string name, byte nameExists) { }
-		public void SendBadNameCheckReply(string name, bool bad) { }
-		public void SendAttackMode(bool attackState) { }
-		public void SendCharCreateReply(string name) { }
-		public void SendCharStatsUpdate() { }
-		public void SendCharResistsUpdate() { }
-		public void SendRegions(ushort regionId) { }
-		public void SendGameOpenReply() { }
-		public void SendPlayerPositionAndObjectID() { }
-		public void SendPlayerJump(bool headingOnly) { }
-		public void SendPlayerInitFinished(byte mobs) { }
-		public void SendUDPInitReply() { }
-		public void SendTime() { }
-		public void SendPlayerCreate(GamePlayer playerToCreate) { }
-		public void SendObjectGuildID(GameObject obj, Guild guild) { }
-		public void SendPlayerQuit(bool totalOut) { }
-		public void SendDebugMode(bool on) { }
-		public void SendModelChange(GameObject obj, ushort newModel) { }
-		public void SendModelAndSizeChange(GameObject obj, ushort newModel, byte newSize) { }
-		public void SendModelAndSizeChange(ushort objectId, ushort newModel, byte newSize) { }
-		public void SendEmoteAnimation(GameObject obj, eEmote emote) { }
-		public void SendNPCCreate(GameNPC npc) { }
-		public void SendLivingEquipmentUpdate(GameLiving living) { }
-		public void SendRegionChanged() { }
-		public void SendUpdatePoints() { }
-		public void SendUpdateMoney() { }
-		public void SendUpdateMaxSpeed() { }
-		public void SendCombatAnimation(GameObject attacker, GameObject defender, ushort weaponID, ushort shieldID, int style, byte stance, byte result, byte targetHealthPercent) { }
-		public void SendStatusUpdate() { }
-		public void SendDelveInfo(string info){ }
-		public void SendStatusUpdate(byte sittingFlag) { }
-		public void SendSpellCastAnimation(GameLiving spellCaster, ushort spellID, ushort castingTime) { }
-		public void SendSpellEffectAnimation(GameObject spellCaster, GameObject spellTarget, ushort spellid, ushort boltTime, bool noSound, byte success) { }
-		public void SendRiding(GameObject rider, GameObject steed, bool dismount) { }
-		public void SendFindGroupWindowUpdate(GamePlayer[] list) { }
-		public void SendDialogBox(eDialogCode code, ushort data1, ushort data2, ushort data3, ushort data4, eDialogType type, bool autoWarpText, string message) { }
-		public void SendGroupInviteCommand(GamePlayer invitingPlayer, string inviteMessage) { }
-		public void SendGuildLeaveCommand(GamePlayer invitingPlayer, string inviteMessage) { }
-		public void SendGuildInviteCommand(GamePlayer invitingPlayer, string inviteMessage) { }
-		public void SendQuestSubscribeCommand(GameNPC invitingNPC, ushort questid, string inviteMessage) { }
-		public void SendQuestOfferWindow(GameNPC questNPC, GamePlayer player, RewardQuest quest) { }
-		public void SendQuestRewardWindow(GameNPC questNPC, GamePlayer player, RewardQuest quest) { }
-		public void SendQuestOfferWindow(GameNPC questNPC, GamePlayer player, DataQuest quest) { }
-		public void SendQuestRewardWindow(GameNPC questNPC, GamePlayer player, DataQuest quest) { }
-		public void SendQuestAbortCommand(GameNPC abortingNPC, ushort questid, string abortMessage) { }
-		public void SendGroupWindowUpdate() { }
-		public void SendGroupMemberUpdate(bool updateIcons, bool updateMap, GameLiving living) { }
-		public void SendGroupMembersUpdate(bool updateIcons, bool updateMap) { }
-		public void SendInventoryItemsUpdate(ICollection<DbInventoryItem> itemsToUpdate) { }
-		public void SendInventorySlotsUpdate(ICollection<eInventorySlot> slots) { }
-		public void SendInventoryItemsUpdate(eInventoryWindowType windowType, ICollection<DbInventoryItem> itemsToUpdate) { }
-		public void SendInventoryItemsUpdate(IDictionary<int, DbInventoryItem> updateItems, eInventoryWindowType windowType) { }
-		public void SendInventoryItemsPartialUpdate(IDictionary<int, DbInventoryItem> items, eInventoryWindowType windowType) { }
-		public void SendDoorState(Region region, GameDoorBase door) { }
-		public void SendMerchantWindow(MerchantTradeItems itemlist, eMerchantWindowType windowType) { }
-		public void SendTradeWindow() { }
-		public void SendCloseTradeWindow() { }
-		public void SendPlayerDied(GamePlayer killedPlayer, GameObject killer) { }
-		public void SendPlayerRevive(GamePlayer revivedPlayer) { }
-		public void SendUpdatePlayer() { }
-		public void SendUpdatePlayerSkills(bool updateInternalCache) { }
-		public void SendUpdateWeaponAndArmorStats() { }
-		public void SendEncumbrance() { }
-		public void SendAddFriends(string[] friendNames) { }
-		public void SendRemoveFriends(string[] friendNames) { }
-		public void SendTimerWindow(string title, int seconds) { }
-		public void SendCloseTimerWindow() { }
-		public void SendTrainerWindow() { }
+        public void SendTCP(GSTCPPacketOut packet) { }
+        public void SendUDP(GSUDPPacketOut packet) { }
+        public void SendWarlockChamberEffect(GamePlayer player) { }
+        public void SendVersionAndCryptKey() { }
+        public void SendLoginDenied(eLoginError et) { }
+        public void SendLoginGranted() { }
+        public void SendLoginGranted(byte color) { } // help for rvr AND pvp servers
+        public void SendSessionID() { }
+        public void SendPingReply(ulong timestamp, ushort sequence) { }
+        public void SendRealm(eRealm realm) { }
+        public void SendCharacterOverview(eRealm realm) { }
+        public void SendDupNameCheckReply(string name, byte nameExists) { }
+        public void SendBadNameCheckReply(string name, bool bad) { }
+        public void SendAttackMode(bool attackState) { }
+        public void SendCharCreateReply(string name) { }
+        public void SendCharStatsUpdate() { }
+        public void SendCharResistsUpdate() { }
+        public void SendRegions(ushort regionId) { }
+        public void SendGameOpenReply() { }
+        public void SendPlayerPositionAndObjectID() { }
+        public void SendPlayerJump(bool headingOnly) { }
+        public void SendPlayerInitFinished(byte mobs) { }
+        public void SendUDPInitReply() { }
+        public void SendTime() { }
+        public void SendPlayerCreate(GamePlayer playerToCreate) { }
+        public void SendObjectGuildID(GameObject obj, Guild guild) { }
+        public void SendPlayerQuit(bool totalOut) { }
+        public void SendDebugMode(bool on) { }
+        public void SendModelChange(GameObject obj, ushort newModel) { }
+        public void SendModelAndSizeChange(GameObject obj, ushort newModel, byte newSize) { }
+        public void SendModelAndSizeChange(ushort objectId, ushort newModel, byte newSize) { }
+        public void SendEmoteAnimation(GameObject obj, eEmote emote) { }
+        public void SendNPCCreate(GameNPC npc) { }
+        public void SendLivingEquipmentUpdate(GameLiving living) { }
+        public void SendRegionChanged() { }
+        public void SendUpdatePoints() { }
+        public void SendUpdateMoney() { }
+        public void SendUpdateMaxSpeed() { }
+        public void SendCombatAnimation(GameObject attacker, GameObject defender, ushort weaponID, ushort shieldID, int style, byte stance, byte result, byte targetHealthPercent) { }
+        public void SendStatusUpdate() { }
+        public void SendDelveInfo(string info){ }
+        public void SendStatusUpdate(byte sittingFlag) { }
+        public void SendSpellCastAnimation(GameLiving spellCaster, ushort spellID, ushort castingTime) { }
+        public void SendSpellEffectAnimation(GameObject spellCaster, GameObject spellTarget, ushort spellid, ushort boltTime, bool noSound, byte success) { }
+        public void SendRiding(GameObject rider, GameObject steed, bool dismount) { }
+        public void SendFindGroupWindowUpdate(GamePlayer[] list) { }
+        public void SendDialogBox(eDialogCode code, ushort data1, ushort data2, ushort data3, ushort data4, eDialogType type, bool autoWarpText, string message) { }
+        public void SendGroupInviteCommand(GamePlayer invitingPlayer, string inviteMessage) { }
+        public void SendGuildLeaveCommand(GamePlayer invitingPlayer, string inviteMessage) { }
+        public void SendGuildInviteCommand(GamePlayer invitingPlayer, string inviteMessage) { }
+        public void SendQuestSubscribeCommand(GameNPC invitingNPC, ushort questid, string inviteMessage) { }
+        public void SendQuestOfferWindow(GameNPC questNPC, GamePlayer player, RewardQuest quest) { }
+        public void SendQuestRewardWindow(GameNPC questNPC, GamePlayer player, RewardQuest quest) { }
+        public void SendQuestOfferWindow(GameNPC questNPC, GamePlayer player, DataQuest quest) { }
+        public void SendQuestRewardWindow(GameNPC questNPC, GamePlayer player, DataQuest quest) { }
+        public void SendQuestAbortCommand(GameNPC abortingNPC, ushort questid, string abortMessage) { }
+        public void SendGroupWindowUpdate() { }
+        public void SendGroupMemberUpdate(bool updateIcons, bool updateMap, GameLiving living) { }
+        public void SendGroupMembersUpdate(bool updateIcons, bool updateMap) { }
+        public void SendInventoryItemsUpdate(ICollection<DbInventoryItem> itemsToUpdate) { }
+        public void SendInventorySlotsUpdate(ICollection<eInventorySlot> slots) { }
+        public void SendInventoryItemsUpdate(eInventoryWindowType windowType, ICollection<DbInventoryItem> itemsToUpdate) { }
+        public void SendInventoryItemsUpdate(IDictionary<int, DbInventoryItem> updateItems, eInventoryWindowType windowType) { }
+        public void SendInventoryItemsPartialUpdate(IDictionary<int, DbInventoryItem> items, eInventoryWindowType windowType) { }
+        public void SendDoorState(Region region, GameDoorBase door) { }
+        public void SendMerchantWindow(MerchantTradeItems itemlist, eMerchantWindowType windowType) { }
+        public void SendTradeWindow() { }
+        public void SendCloseTradeWindow() { }
+        public void SendPlayerDied(GamePlayer killedPlayer, GameObject killer) { }
+        public void SendPlayerRevive(GamePlayer revivedPlayer) { }
+        public void SendUpdatePlayer() { }
+        public void SendUpdatePlayerSkills(bool updateInternalCache) { }
+        public void SendUpdateWeaponAndArmorStats() { }
+        public void SendEncumbrance() { }
+        public void SendAddFriends(string[] friendNames) { }
+        public void SendRemoveFriends(string[] friendNames) { }
+        public void SendTimerWindow(string title, int seconds) { }
+        public void SendCloseTimerWindow() { }
+        public void SendTrainerWindow() { }
         public void SendCustomTrainerWindow(int type, List<Tuple<Specialization, List<Tuple<Skill, byte>>>> tree) { }
         public void SendChampionTrainerWindow(int type) { }
-		public void SendInterruptAnimation(GameLiving living) { }
-		public void SendDisableSkill(ICollection<Tuple<Skill, int>> skills) { }
-		public void SendUpdateIcons(IList changedEffects, ref int lastUpdateEffectsCount) { }
-		public void SendLevelUpSound() { }
-		public void SendRegionEnterSound(byte soundId) { }
-		public void SendSoundEffect(ushort soundId, ushort zoneId, ushort x, ushort y, ushort z, ushort radius) { }
-		public void SendDebugMessage(string format, params object[] parameters) { }
-		public void SendDebugPopupMessage(string format, params object[] parameters) { }
-		public void SendEmblemDialogue() { }
-		public void SendWeather(uint x, uint width, ushort speed, ushort fogdiffusion, ushort intensity) { }
-		public void SendPlayerModelTypeChange(GamePlayer player, byte modelType) { }
-		public void SendObjectDelete(GameObject obj) { }
-		public void SendObjectDelete(ushort oid) { }
-		public void SendObjectUpdate(GameObject obj, bool udp = true) { }
-		public void SendObjectRemove(GameObject obj) { }
-		public void SendObjectCreate(GameObject obj) { }
-		public void SendQuestListUpdate() { }
-		public void SendQuestUpdate(AbstractQuest quest) { }
-		public void SendQuestRemove(byte index) { }
-		public void SendConcentrationList() { }
-		public void SendUpdateCraftingSkills() { }
-		public void SendChangeTarget(GameObject newTarget) { }
-		public void SendChangeGroundTarget(int x, int y, int z) { }
-		public void SendPetWindow(GameLiving pet, ePetWindowAction windowAction, eAggressionState aggroState, eWalkState walkState) { }
-		public void SendKeepInfo(IGameKeep keep) { }
-		public void SendKeepRealmUpdate(IGameKeep keep) { }
-		public void SendKeepRemove(IGameKeep keep) { }
-		public void SendKeepComponentInfo(IGameKeepComponent keepComponent) { }
-		public void SendKeepComponentDetailUpdate(IGameKeepComponent keepComponent) { }
-		public void SendKeepComponentRemove(IGameKeepComponent keepComponent) { }
-		public void SendKeepComponentUpdate(IGameKeep keep, bool levelup) { }
-		public void SendKeepClaim(IGameKeep keep, byte flag) { }
-		public void SendKeepComponentInteract(IGameKeepComponent component) { }
-		public void SendKeepComponentHookPoint(IGameKeepComponent component, int selectedHookPointIndex) { }
-		public void SendKeepDoorUpdate(GameKeepDoor door) { }
-		public void SendClearKeepComponentHookPoint(IGameKeepComponent component, int selectedHookPointIndex) { }
-		public void SendHookPointStore(GameKeepHookPoint hookPoint) { }
-		public void SendPlaySound(eSoundType soundType, ushort soundID) { }
+        public void SendInterruptAnimation(GameLiving living) { }
+        public void SendDisableSkill(ICollection<Tuple<Skill, int>> skills) { }
+        public void SendUpdateIcons(IList changedEffects, ref int lastUpdateEffectsCount) { }
+        public void SendLevelUpSound() { }
+        public void SendRegionEnterSound(byte soundId) { }
+        public void SendSoundEffect(ushort soundId, ushort zoneId, ushort x, ushort y, ushort z, ushort radius) { }
+        public void SendDebugMessage(string format, params object[] parameters) { }
+        public void SendDebugPopupMessage(string format, params object[] parameters) { }
+        public void SendEmblemDialogue() { }
+        public void SendWeather(uint x, uint width, ushort speed, ushort fogdiffusion, ushort intensity) { }
+        public void SendPlayerModelTypeChange(GamePlayer player, byte modelType) { }
+        public void SendObjectDelete(GameObject obj) { }
+        public void SendObjectDelete(ushort oid) { }
+        public void SendObjectUpdate(GameObject obj, bool udp = true) { }
+        public void SendObjectRemove(GameObject obj) { }
+        public void SendObjectCreate(GameObject obj) { }
+        public void SendQuestListUpdate() { }
+        public void SendQuestUpdate(AbstractQuest quest) { }
+        public void SendQuestRemove(byte index) { }
+        public void SendConcentrationList() { }
+        public void SendUpdateCraftingSkills() { }
+        public void SendChangeTarget(GameObject newTarget) { }
+        public void SendChangeGroundTarget(int x, int y, int z) { }
+        public void SendPetWindow(GameLiving pet, ePetWindowAction windowAction, eAggressionState aggroState, eWalkState walkState) { }
+        public void SendKeepInfo(IGameKeep keep) { }
+        public void SendKeepRealmUpdate(IGameKeep keep) { }
+        public void SendKeepRemove(IGameKeep keep) { }
+        public void SendKeepComponentInfo(IGameKeepComponent keepComponent) { }
+        public void SendKeepComponentDetailUpdate(IGameKeepComponent keepComponent) { }
+        public void SendKeepComponentRemove(IGameKeepComponent keepComponent) { }
+        public void SendKeepComponentUpdate(IGameKeep keep, bool levelup) { }
+        public void SendKeepClaim(IGameKeep keep, byte flag) { }
+        public void SendKeepComponentInteract(IGameKeepComponent component) { }
+        public void SendKeepComponentHookPoint(IGameKeepComponent component, int selectedHookPointIndex) { }
+        public void SendKeepDoorUpdate(GameKeepDoor door) { }
+        public void SendClearKeepComponentHookPoint(IGameKeepComponent component, int selectedHookPointIndex) { }
+        public void SendHookPointStore(GameKeepHookPoint hookPoint) { }
+        public void SendPlaySound(eSoundType soundType, ushort soundID) { }
         public void SendNPCsQuestEffect(GameNPC npc, eQuestIndicator indicator) { }
-		public void SendMasterLevelWindow(byte ml) { }
-		public void SendHexEffect(GamePlayer player, byte effect1, byte effect2, byte effect3, byte effect4, byte effect5) { }
+        public void SendMasterLevelWindow(byte ml) { }
+        public void SendHexEffect(GamePlayer player, byte effect1, byte effect2, byte effect3, byte effect4, byte effect5) { }
 
-		public void SendSiegeWeaponAnimation(GameSiegeWeapon siegeWeapon) { }
-		public void SendSiegeWeaponFireAnimation(GameSiegeWeapon siegeWeapon, int timer) { }
-		public void SendSiegeWeaponCloseInterface() { }
-		public void SendSiegeWeaponInterface(GameSiegeWeapon siegeWeapon, int time) { }
-		public void SendHouse(House house) { }
-		public void SendHouseOccupied(House house, bool flagHouseOccuped) { }
-		public void SendHousePermissions(House house) { }
-		public void SendRemoveHouse(House house) { }
-		public void SendGarden(House house, int i) { }
-		public void SendHousePayRentDialog(string title) { }
-		public void SendGarden(House house) { }
-		public void SendEnterHouse(House house) { }
-		public void SendExitHouse(House house, ushort unknown = 0) { }
-		public void SendHouseUsersPermissions(House house) { }
-		public void SendFurniture(House house) { }
-		public void SendFurniture(House house, int i) { }
-		public void SendToggleHousePoints(House house) { }
-		public void SendRentReminder(House house) { }
-		public void SendMovingObjectCreate(GameMovingObject obj) { }
-		public void SendWarmapUpdate(ICollection<IGameKeep> list) { }
-		public void SendWarmapDetailUpdate(List<List<byte>> fights, List<List<byte>> groups) { }
-		public void SendWarmapBonuses() { }
-		public bool SendLosCheckRequest(GameObject source, GameObject target, ILosCheckListener listener) { return true; }
-		public void SendLivingDataUpdate(GameLiving living, bool updateStrings) { }
-		public void SendPlayerTitles() { }
-		public void SendPlayerTitleUpdate(GamePlayer player) { }
-		public void SendSetControlledHorse(GamePlayer player) { }
-		public void SendControlledHorse(GamePlayer player, bool flag) { }
-		public void CheckLengthHybridSkillsPacket(ref GSTCPPacketOut pak, ref int maxSkills, ref int first) { }
-		public void SendNonHybridSpellLines() { }
-		public void SendCrash(string str) { }
-		public void SendRvRGuildBanner(GamePlayer player, bool show) { }
-		public void SendPlayerFreeLevelUpdate() { }
-		public void SendRegionColorScheme() { }
-		public void SendRegionColorScheme(byte color) { }
-		public void SendStarterHelp() { }
-		public void SendVampireEffect(GameLiving living, bool show) { }
-		public void SendXFireInfo(byte flag) { }
-		public void SendMarketExplorerWindow() { }
-		public void SendMarketExplorerWindow(IList<DbInventoryItem> items, byte page, byte maxpage) { }
-		public void SendConsignmentMerchantMoney(long money) { }
+        public void SendSiegeWeaponAnimation(GameSiegeWeapon siegeWeapon) { }
+        public void SendSiegeWeaponFireAnimation(GameSiegeWeapon siegeWeapon, int timer) { }
+        public void SendSiegeWeaponCloseInterface() { }
+        public void SendSiegeWeaponInterface(GameSiegeWeapon siegeWeapon, int time) { }
+        public void SendHouse(House house) { }
+        public void SendHouseOccupied(House house, bool flagHouseOccuped) { }
+        public void SendHousePermissions(House house) { }
+        public void SendRemoveHouse(House house) { }
+        public void SendGarden(House house, int i) { }
+        public void SendHousePayRentDialog(string title) { }
+        public void SendGarden(House house) { }
+        public void SendEnterHouse(House house) { }
+        public void SendExitHouse(House house, ushort unknown = 0) { }
+        public void SendHouseUsersPermissions(House house) { }
+        public void SendFurniture(House house) { }
+        public void SendFurniture(House house, int i) { }
+        public void SendToggleHousePoints(House house) { }
+        public void SendRentReminder(House house) { }
+        public void SendMovingObjectCreate(GameMovingObject obj) { }
+        public void SendWarmapUpdate(ICollection<IGameKeep> list) { }
+        public void SendWarmapDetailUpdate(List<List<byte>> fights, List<List<byte>> groups) { }
+        public void SendWarmapBonuses() { }
+        public bool SendLosCheckRequest(GameObject source, GameObject target, ILosCheckListener listener) { return true; }
+        public void SendLivingDataUpdate(GameLiving living, bool updateStrings) { }
+        public void SendPlayerTitles() { }
+        public void SendPlayerTitleUpdate(GamePlayer player) { }
+        public void SendSetControlledHorse(GamePlayer player) { }
+        public void SendControlledHorse(GamePlayer player, bool flag) { }
+        public void CheckLengthHybridSkillsPacket(ref GSTCPPacketOut pak, ref int maxSkills, ref int first) { }
+        public void SendNonHybridSpellLines() { }
+        public void SendCrash(string str) { }
+        public void SendRvRGuildBanner(GamePlayer player, bool show) { }
+        public void SendPlayerFreeLevelUpdate() { }
+        public void SendRegionColorScheme() { }
+        public void SendRegionColorScheme(byte color) { }
+        public void SendStarterHelp() { }
+        public void SendVampireEffect(GameLiving living, bool show) { }
+        public void SendXFireInfo(byte flag) { }
+        public void SendMarketExplorerWindow() { }
+        public void SendMarketExplorerWindow(IList<DbInventoryItem> items, byte page, byte maxpage) { }
+        public void SendConsignmentMerchantMoney(long money) { }
         public void SendMinotaurRelicMapRemove(byte id) { }
         public void SendMinotaurRelicMapUpdate(byte id, ushort region, int x, int y, int z) { }
         public virtual void SendMinotaurRelicWindow(GamePlayer player, int spell, bool flag) { }
         public virtual void SendMinotaurRelicBarUpdate(GamePlayer player, int xp) { }
         public virtual void SendBlinkPanel(byte flag) { }
-		/// <summary>
-		/// The bow prepare animation
-		/// </summary>
-		public int BowPrepare { get { return 0; } }
-		/// <summary>
-		/// The bow shoot animation
-		/// </summary>
-		public int BowShoot { get { return 0; } }
-		/// <summary>
-		/// one dual weapon hit animation
-		/// </summary>
-		public int OneDualWeaponHit { get { return 0; } }
-		/// <summary>
-		/// both dual weapons hit animation
-		/// </summary>
-		public int BothDualWeaponHit { get { return 0; } }
-	}
+        /// <summary>
+        /// The bow prepare animation
+        /// </summary>
+        public int BowPrepare { get { return 0; } }
+        /// <summary>
+        /// The bow shoot animation
+        /// </summary>
+        public int BowShoot { get { return 0; } }
+        /// <summary>
+        /// one dual weapon hit animation
+        /// </summary>
+        public int OneDualWeaponHit { get { return 0; } }
+        /// <summary>
+        /// both dual weapons hit animation
+        /// </summary>
+        public int BothDualWeaponHit { get { return 0; } }
+    }
 }


### PR DESCRIPTION
ConsoleStart.HandleCommand() was creating a simple mock client every time a console command was run.  It lacked a player and account, leading to null exceptions whenever a command was run.

I have replaced that with a more complete mock client, with attached account and player, that prevents exceptions and makes many commands usable from the command line.  I have also named both the account and player ConsoleAdmin, so it's obvious who is executing the commands.

ConsolePacketLib was using the logger to output command results to the console, which added a lot of unnecessary information that impeding readability.  I have changed it to output to the console directly instead, and implemented SendCustomTextWindow(), as some commands use it to send back command results.

Lastly, I changed the text colour for command responses in the console to make them pop visually.