### PR TITLE
PvE/PvP Hastener Fixes

### DIFF
--- a/GameServer/keeps/Gameobjects/Guards/Hastener.cs
+++ b/GameServer/keeps/Gameobjects/Guards/Hastener.cs
@@ -39,7 +39,7 @@ namespace DOL.GS.Keeps
 			{
 				return;
 			}
-			switch (Realm)
+			switch (ModelRealm)
 			{
 				case eRealm.None:
 				case eRealm.Albion:
@@ -84,7 +84,7 @@ namespace DOL.GS.Keeps
 			if (!base.Interact(player))
 				return false;
 
-			if (player.Realm != Realm)
+			if (!GameServer.ServerRules.IsSameRealm(player, this, true))
 				return false;
 
 			TurnTo(player, 5000);


### PR DESCRIPTION
Hastener model is now displayed properly for keeps with realm=None, and hasteners now check server rules rather than realm so they now work on PvE and PvP servers.