### PR TITLE
[codex] Refactor player quest list locking

### DIFF
--- a/GameServer/commands/playercommands/QuestCommands.cs
+++ b/GameServer/commands/playercommands/QuestCommands.cs
@@ -39,31 +39,20 @@ namespace DOL.GS.Commands
 			if (player == null)
 				return;
 
-			bool searched = false;
+			bool searched = player.CommandActiveQuests(AbstractQuest.eQuestCommand.SEARCH);
 
-			foreach (AbstractQuest quest in player.QuestList.Keys)
+			// Also check for DataQuests started via searching
+			if (searched == false)
 			{
-				if (quest.Command(player, AbstractQuest.eQuestCommand.SEARCH))
+				foreach (AbstractArea area in player.CurrentAreas)
 				{
-					searched = true;
+					if (area is not QuestSearchArea questSearchArea || questSearchArea.DataQuest == null || questSearchArea.Step != 0)
+						continue;
+
+					if (questSearchArea.DataQuest.Command(player, AbstractQuest.eQuestCommand.SEARCH_START, area))
+						searched = true;
 				}
 			}
-
-            // Also check for DataQuests started via searching
-
-            if (searched == false)
-            {
-                foreach (AbstractArea area in player.CurrentAreas)
-                {
-                    if (area is QuestSearchArea && (area as QuestSearchArea).DataQuest != null && (area as QuestSearchArea).Step == 0)
-                    {
-                        if ((area as QuestSearchArea).DataQuest.Command(player, AbstractQuest.eQuestCommand.SEARCH_START, area))
-                        {
-                            searched = true;
-                        }
-                    }
-                }
-            }
 
 			if (searched == false)
 			{

--- a/GameServer/commands/playercommands/quest.cs
+++ b/GameServer/commands/playercommands/quest.cs
@@ -36,7 +36,7 @@ namespace DOL.GS.Commands
                 return;
 
             string message = string.Empty;
-            List<AbstractQuest> activeQuests = client.Player.QuestList.Keys.ToList();
+            List<AbstractQuest> activeQuests = client.Player.GetActiveQuests();
             List<AbstractQuest> finishedQuests = client.Player.GetFinishedQuests();
 
             if (activeQuests.Count == 0)

--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -1685,38 +1685,7 @@ namespace DOL.GS
 		/// <returns>true if this npc is the last step of one quest, false otherwise</returns>
 		public bool CanFinishOneQuest(GamePlayer player)
 		{
-			foreach (var pair in player.QuestList)
-			{
-				AbstractQuest quest = pair.Key;
-
-				// Handle Data Quest here.
-				if (quest is DataQuest dataQuest && dataQuest.TargetName == Name && (dataQuest.TargetRegion == 0 || dataQuest.TargetRegion == CurrentRegionID))
-				{
-					switch (dataQuest.StepType)
-					{
-						case DataQuest.eStepType.DeliverFinish:
-						case DataQuest.eStepType.InteractFinish:
-						case DataQuest.eStepType.KillFinish:
-						case DataQuest.eStepType.WhisperFinish:
-						case DataQuest.eStepType.CollectFinish:
-							return true;
-					}
-				}
-
-				// Handle Reward Quest here.
-				if (quest is RewardQuest rewardQuest && rewardQuest.QuestGiver == this)
-				{
-					bool done = true;
-
-					foreach (RewardQuest.QuestGoal goal in rewardQuest.Goals)
-						done &= goal.IsAchieved;
-
-					if (done)
-						return true;
-				}
-			}
-
-			return false;
+			return player.HasQuestToFinishAt(this);
 		}
 
 		/// <summary>

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -11149,6 +11149,8 @@ namespace DOL.GS
         }
 
         private readonly Dictionary<AbstractQuest, byte> _questList = new(); // Value is the index to send to clients.
+        private readonly Dictionary<int, DataQuest> _activeDataQuestsById = new();
+        private readonly Dictionary<Type, AbstractQuest> _activeQuestsByType = new();
         private readonly Lock _questListLock = new();
         private List<AbstractQuest> _questListFinished = new();
         private readonly Lock _questListFinishedLock = new();
@@ -11184,32 +11186,6 @@ namespace DOL.GS
             return null;
         }
 
-        internal bool TrySetQuestIndex(AbstractQuest quest, byte index)
-        {
-            lock (_questListLock)
-            {
-                bool found = false;
-
-                foreach (KeyValuePair<AbstractQuest, byte> entry in _questList)
-                {
-                    if (EqualityComparer<AbstractQuest>.Default.Equals(entry.Key, quest))
-                    {
-                        found = true;
-                        continue;
-                    }
-
-                    if (entry.Value == index)
-                        return false;
-                }
-
-                if (!found)
-                    return false;
-
-                _questList[quest] = index;
-                return true;
-            }
-        }
-
         internal bool NeedsQuestListRefreshAfterRemove(byte visibleQuestCount)
         {
             lock (_questListLock)
@@ -11231,28 +11207,16 @@ namespace DOL.GS
         {
             lock (_questListLock)
             {
-                foreach (AbstractQuest quest in _questList.Keys)
-                {
-                    if (quest is DataQuest dataQuest && dataQuest.ID == id)
-                        return true;
-                }
+                return _activeDataQuestsById.ContainsKey(id);
             }
-
-            return false;
         }
 
         public bool IsDoingDataQuest(int id, int step)
         {
             lock (_questListLock)
             {
-                foreach (AbstractQuest quest in _questList.Keys)
-                {
-                    if (quest is DataQuest dataQuest && dataQuest.ID == id && dataQuest.Step == step)
-                        return true;
-                }
+                return _activeDataQuestsById.TryGetValue(id, out DataQuest dataQuest) && dataQuest.Step == step;
             }
-
-            return false;
         }
 
         public bool HasQuestToFinishAt(GameNPC npc)
@@ -11320,32 +11284,49 @@ namespace DOL.GS
             return handled;
         }
 
-        internal KeyValuePair<AbstractQuest, byte>[] RentActiveQuestEntries(out int count)
+        internal void SendQuestListUpdate(byte indexOffset, int visibleQuestCount, Action<AbstractQuest, byte> sendQuestPacket)
         {
             lock (_questListLock)
             {
-                count = _questList.Count;
-
-                if (count == 0)
-                    return null;
-
-                KeyValuePair<AbstractQuest, byte>[] snapshot = ArrayPool<KeyValuePair<AbstractQuest, byte>>.Shared.Rent(count);
-                int index = 0;
+                int lastIndex = visibleQuestCount + indexOffset;
+                Span<bool> sentIndexes = stackalloc bool[visibleQuestCount];
 
                 foreach (KeyValuePair<AbstractQuest, byte> entry in _questList)
-                    snapshot[index++] = entry;
+                {
+                    int adjustedQuestIndex = entry.Value + indexOffset;
 
-                return snapshot;
+                    if (adjustedQuestIndex < lastIndex)
+                    {
+                        sendQuestPacket(entry.Key, (byte) adjustedQuestIndex);
+                        sentIndexes[adjustedQuestIndex - indexOffset] = true;
+                    }
+                }
+
+                // If possible, move and send quests whose indexes are too high.
+                for (int questIndex = indexOffset; questIndex < lastIndex; questIndex++)
+                {
+                    int sentIndex = questIndex - indexOffset;
+
+                    if (sentIndexes[sentIndex])
+                        continue;
+
+                    AbstractQuest quest = GetFirstQuestAtOrAboveIndexUnsafe(visibleQuestCount);
+
+                    if (quest == null)
+                        continue;
+
+                    _questList[quest] = (byte) sentIndex;
+                    sendQuestPacket(quest, (byte) questIndex);
+                    sentIndexes[sentIndex] = true;
+                }
+
+                // Send null for unused indexes.
+                for (int questIndex = indexOffset; questIndex < lastIndex; questIndex++)
+                {
+                    if (!sentIndexes[questIndex - indexOffset])
+                        sendQuestPacket(null, (byte) questIndex);
+                }
             }
-        }
-
-        internal static void ReturnActiveQuestEntries(KeyValuePair<AbstractQuest, byte>[] snapshot)
-        {
-            if (snapshot == null)
-                return;
-
-            Array.Clear(snapshot, 0, snapshot.Length);
-            ArrayPool<KeyValuePair<AbstractQuest, byte>>.Shared.Return(snapshot);
         }
 
         private void ClearActiveQuests()
@@ -11353,6 +11334,8 @@ namespace DOL.GS
             lock (_questListLock)
             {
                 _questList.Clear();
+                _activeDataQuestsById.Clear();
+                _activeQuestsByType.Clear();
             }
         }
 
@@ -11361,18 +11344,56 @@ namespace DOL.GS
             lock (_questListLock)
             {
                 _questList[quest] = index;
+                AddActiveQuestIndexesUnsafe(quest);
             }
         }
 
         private AbstractQuest IsDoingQuestUnsafe(AbstractQuest quest)
         {
-            foreach (AbstractQuest questInList in _questList.Keys)
+            if (quest is DataQuest dataQuest)
             {
-                if (questInList.GetType().Equals(quest.GetType()) && questInList.IsDoingQuest())
-                    return questInList;
+                if (_activeDataQuestsById.TryGetValue(dataQuest.ID, out DataQuest activeDataQuest) && activeDataQuest.IsDoingQuest())
+                    return activeDataQuest;
+            }
+            else if (_activeQuestsByType.TryGetValue(quest.GetType(), out AbstractQuest activeQuest) && activeQuest.IsDoingQuest())
+                return activeQuest;
+
+            return null;
+        }
+
+        private AbstractQuest GetFirstQuestAtOrAboveIndexUnsafe(int index)
+        {
+            foreach (KeyValuePair<AbstractQuest, byte> entry in _questList)
+            {
+                if (entry.Value >= index)
+                    return entry.Key;
             }
 
             return null;
+        }
+
+        private void AddActiveQuestIndexesUnsafe(AbstractQuest quest)
+        {
+            if (quest is DataQuest dataQuest)
+                _activeDataQuestsById[dataQuest.ID] = dataQuest;
+            else
+                _activeQuestsByType[quest.GetType()] = quest;
+        }
+
+        private void RemoveActiveQuestIndexesUnsafe(AbstractQuest quest)
+        {
+            if (quest is DataQuest dataQuest)
+            {
+                if (_activeDataQuestsById.TryGetValue(dataQuest.ID, out DataQuest activeQuest) && ReferenceEquals(activeQuest, dataQuest))
+                    _activeDataQuestsById.Remove(dataQuest.ID);
+            }
+            else
+            {
+                Type questType = quest.GetType();
+
+                if (_activeQuestsByType.TryGetValue(questType, out AbstractQuest activeQuest) && ReferenceEquals(activeQuest, quest))
+                    _activeQuestsByType.Remove(questType);
+            }
         }
 
         private AbstractQuest[] RentActiveQuestSnapshot(out int count)
@@ -11584,6 +11605,9 @@ namespace DOL.GS
             lock (_questListLock)
             {
                 removed = _questList.Remove(quest, out index);
+
+                if (removed)
+                    RemoveActiveQuestIndexesUnsafe(quest);
             }
 
             if (removed && notifyPlayer)
@@ -11616,6 +11640,9 @@ namespace DOL.GS
                     return false;
 
                 added = _questList.TryAdd(quest, index);
+
+                if (added)
+                    AddActiveQuestIndexesUnsafe(quest);
             }
 
             if (!added)
@@ -11649,17 +11676,9 @@ namespace DOL.GS
         {
             lock (_questListLock)
             {
-                foreach (AbstractQuest quest in _questList.Keys)
-                {
-                    if (quest is not DataQuest)
-                    {
-                        if (quest.GetType().Equals(questType))
-                            return quest;
-                    }
-                }
+                _activeQuestsByType.TryGetValue(questType, out AbstractQuest quest);
+                return quest;
             }
-
-            return null;
         }
 
         #endregion

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -1,6 +1,6 @@
 using System;
+using System.Buffers;
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -10408,9 +10408,12 @@ namespace DOL.GS
 
             void HandleQuests(IList<DbQuest> scriptedQuests, DataQuest[] dataQuests)
             {
-                AvailableQuestIndexes.Clear();
-                QuestList.Clear();
-                _questListFinished.Clear();
+                ClearActiveQuests();
+                lock (_questListFinishedLock)
+                {
+                    _questListFinished.Clear();
+                }
+
                 int activeQuestCount = 0;
 
                 foreach (DbQuest dbQuest in scriptedQuests)
@@ -10423,7 +10426,7 @@ namespace DOL.GS
                     if (quest.Step < 0)
                         AddFinishedQuest(quest);
                     else
-                        QuestList.TryAdd(quest, (byte) activeQuestCount++);
+                        SetActiveQuest(quest, (byte) activeQuestCount++);
 
                     switch (quest)
                     {
@@ -10448,9 +10451,9 @@ namespace DOL.GS
                 foreach (DataQuest dataQuest in dataQuests)
                 {
                     if (dataQuest.Step > 0)
-                        QuestList.TryAdd(dataQuest, (byte) activeQuestCount++);
+                        SetActiveQuest(dataQuest, (byte) activeQuestCount++);
                     else if (dataQuest.Count > 0)
-                        _questListFinished.Add(dataQuest);
+                        AddFinishedQuest(dataQuest);
                 }
             }
 
@@ -10581,17 +10584,7 @@ namespace DOL.GS
                 if (cachedCharacter != null)
                     cachedCharacter = DBCharacter;
 
-                foreach (AbstractQuest quest in QuestList.Keys)
-                {
-                    if (quest is Quests.DailyQuest dq)
-                        dq.SaveQuestParameters();
-
-                    if (quest is Quests.WeeklyQuest wq)
-                        wq.SaveQuestParameters();
-
-                    if (quest is Quests.MonthlyQuest mq)
-                        mq.SaveQuestParameters();
-                }
+                SaveActiveQuestParameters();
 
                 if (m_mlSteps != null)
                     GameServer.Database.SaveObject(m_mlSteps.OfType<DbCharacterXMasterLevel>());
@@ -11155,11 +11148,306 @@ namespace DOL.GS
             get { return InternalID; }
         }
 
+        private readonly Dictionary<AbstractQuest, byte> _questList = new(); // Value is the index to send to clients.
+        private readonly Lock _questListLock = new();
         private List<AbstractQuest> _questListFinished = new();
         private readonly Lock _questListFinishedLock = new();
-        public virtual ConcurrentDictionary<AbstractQuest, byte> QuestList { get; } = new(); // Value is the index to send to clients.
-        public ConcurrentQueue<byte> AvailableQuestIndexes { get; } = new(); // If empty, 'QuestList.Count' will be used when adding a quest to 'QuestList'
         public ECSGameTimer QuestActionTimer;
+
+        public List<AbstractQuest> GetActiveQuests()
+        {
+            lock (_questListLock)
+            {
+                return _questList.Keys.ToList();
+            }
+        }
+
+        internal bool TryGetQuestIndex(AbstractQuest quest, out byte index)
+        {
+            lock (_questListLock)
+            {
+                return _questList.TryGetValue(quest, out index);
+            }
+        }
+
+        public AbstractQuest GetQuestByIndex(int index)
+        {
+            lock (_questListLock)
+            {
+                foreach (KeyValuePair<AbstractQuest, byte> entry in _questList)
+                {
+                    if (entry.Value == index)
+                        return entry.Key;
+                }
+            }
+
+            return null;
+        }
+
+        internal bool TrySetQuestIndex(AbstractQuest quest, byte index)
+        {
+            lock (_questListLock)
+            {
+                bool found = false;
+
+                foreach (KeyValuePair<AbstractQuest, byte> entry in _questList)
+                {
+                    if (EqualityComparer<AbstractQuest>.Default.Equals(entry.Key, quest))
+                    {
+                        found = true;
+                        continue;
+                    }
+
+                    if (entry.Value == index)
+                        return false;
+                }
+
+                if (!found)
+                    return false;
+
+                _questList[quest] = index;
+                return true;
+            }
+        }
+
+        internal bool NeedsQuestListRefreshAfterRemove(byte visibleQuestCount)
+        {
+            lock (_questListLock)
+            {
+                if (_questList.Count > visibleQuestCount)
+                    return true;
+
+                foreach (byte questIndex in _questList.Values)
+                {
+                    if (questIndex >= visibleQuestCount)
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool IsDoingDataQuest(int id)
+        {
+            lock (_questListLock)
+            {
+                foreach (AbstractQuest quest in _questList.Keys)
+                {
+                    if (quest is DataQuest dataQuest && dataQuest.ID == id)
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool IsDoingDataQuest(int id, int step)
+        {
+            lock (_questListLock)
+            {
+                foreach (AbstractQuest quest in _questList.Keys)
+                {
+                    if (quest is DataQuest dataQuest && dataQuest.ID == id && dataQuest.Step == step)
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool HasQuestToFinishAt(GameNPC npc)
+        {
+            string npcName = npc.Name;
+            ushort regionID = npc.CurrentRegionID;
+
+            lock (_questListLock)
+            {
+                foreach (AbstractQuest quest in _questList.Keys)
+                {
+                    if (quest is DataQuest dataQuest && dataQuest.TargetName == npcName && (dataQuest.TargetRegion == 0 || dataQuest.TargetRegion == regionID))
+                    {
+                        switch (dataQuest.StepType)
+                        {
+                            case DataQuest.eStepType.DeliverFinish:
+                            case DataQuest.eStepType.InteractFinish:
+                            case DataQuest.eStepType.KillFinish:
+                            case DataQuest.eStepType.WhisperFinish:
+                            case DataQuest.eStepType.CollectFinish:
+                                return true;
+                        }
+                    }
+
+                    if (quest is RewardQuest rewardQuest && rewardQuest.QuestGiver == npc)
+                    {
+                        bool done = true;
+
+                        foreach (RewardQuest.QuestGoal goal in rewardQuest.Goals)
+                        {
+                            if (!goal.IsAchieved)
+                            {
+                                done = false;
+                                break;
+                            }
+                        }
+
+                        if (done)
+                            return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public bool CommandActiveQuests(AbstractQuest.eQuestCommand command, AbstractArea area = null)
+        {
+            bool handled = false;
+            AbstractQuest[] snapshot = RentActiveQuestSnapshot(out int count);
+
+            try
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    if (snapshot[i].Command(this, command, area))
+                        handled = true;
+                }
+            }
+            finally
+            {
+                ReturnActiveQuestSnapshot(snapshot);
+            }
+
+            return handled;
+        }
+
+        internal KeyValuePair<AbstractQuest, byte>[] RentActiveQuestEntries(out int count)
+        {
+            lock (_questListLock)
+            {
+                count = _questList.Count;
+
+                if (count == 0)
+                    return null;
+
+                KeyValuePair<AbstractQuest, byte>[] snapshot = ArrayPool<KeyValuePair<AbstractQuest, byte>>.Shared.Rent(count);
+                int index = 0;
+
+                foreach (KeyValuePair<AbstractQuest, byte> entry in _questList)
+                    snapshot[index++] = entry;
+
+                return snapshot;
+            }
+        }
+
+        internal static void ReturnActiveQuestEntries(KeyValuePair<AbstractQuest, byte>[] snapshot)
+        {
+            if (snapshot == null)
+                return;
+
+            Array.Clear(snapshot, 0, snapshot.Length);
+            ArrayPool<KeyValuePair<AbstractQuest, byte>>.Shared.Return(snapshot);
+        }
+
+        private void ClearActiveQuests()
+        {
+            lock (_questListLock)
+            {
+                _questList.Clear();
+            }
+        }
+
+        private void SetActiveQuest(AbstractQuest quest, byte index)
+        {
+            lock (_questListLock)
+            {
+                _questList[quest] = index;
+            }
+        }
+
+        private AbstractQuest IsDoingQuestUnsafe(AbstractQuest quest)
+        {
+            foreach (AbstractQuest questInList in _questList.Keys)
+            {
+                if (questInList.GetType().Equals(quest.GetType()) && questInList.IsDoingQuest())
+                    return questInList;
+            }
+
+            return null;
+        }
+
+        private AbstractQuest[] RentActiveQuestSnapshot(out int count)
+        {
+            lock (_questListLock)
+            {
+                count = _questList.Count;
+
+                if (count == 0)
+                    return null;
+
+                AbstractQuest[] snapshot = ArrayPool<AbstractQuest>.Shared.Rent(count);
+                int index = 0;
+
+                foreach (AbstractQuest quest in _questList.Keys)
+                    snapshot[index++] = quest;
+
+                return snapshot;
+            }
+        }
+
+        private static void ReturnActiveQuestSnapshot(AbstractQuest[] snapshot)
+        {
+            if (snapshot == null)
+                return;
+
+            Array.Clear(snapshot, 0, snapshot.Length);
+            ArrayPool<AbstractQuest>.Shared.Return(snapshot);
+        }
+
+        private void SaveActiveQuestParameters()
+        {
+            AbstractQuest[] snapshot = RentActiveQuestSnapshot(out int count);
+
+            try
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    AbstractQuest quest = snapshot[i];
+
+                    if (quest is Quests.DailyQuest dq)
+                        dq.SaveQuestParameters();
+
+                    if (quest is Quests.WeeklyQuest wq)
+                        wq.SaveQuestParameters();
+
+                    if (quest is Quests.MonthlyQuest mq)
+                        mq.SaveQuestParameters();
+                }
+            }
+            finally
+            {
+                ReturnActiveQuestSnapshot(snapshot);
+            }
+        }
+
+        private bool TryGetNextQuestIndexUnsafe(out byte index)
+        {
+            Span<bool> usedIndexes = stackalloc bool[byte.MaxValue + 1];
+
+            foreach (byte questIndex in _questList.Values)
+                usedIndexes[questIndex] = true;
+
+            for (int i = byte.MinValue; i <= byte.MaxValue; i++)
+            {
+                if (!usedIndexes[i])
+                {
+                    index = (byte) i;
+                    return true;
+                }
+            }
+
+            index = 0;
+            return false;
+        }
 
         public List<AbstractQuest> GetFinishedQuests()
         {
@@ -11285,6 +11573,30 @@ namespace DOL.GS
             return false;
         }
 
+        public bool RemoveQuest(AbstractQuest quest, bool notifyPlayer)
+        {
+            if (quest == null)
+                return false;
+
+            bool removed;
+            byte index;
+
+            lock (_questListLock)
+            {
+                removed = _questList.Remove(quest, out index);
+            }
+
+            if (removed && notifyPlayer)
+            {
+                if (quest is DataQuest)
+                    Out.SendQuestListUpdate();
+                else
+                    Out.SendQuestRemove(index);
+            }
+
+            return removed;
+        }
+
         /// <summary>
         /// Adds a quest to the players questlist
         /// Can be used by both scripted quests and data quests
@@ -11293,15 +11605,22 @@ namespace DOL.GS
         /// <returns>true if added, false if player is already doing the quest!</returns>
         public bool AddQuest(AbstractQuest quest)
         {
-            if (QuestList.Count > 25)
+            bool added;
 
-            if (IsDoingQuest(quest) != null)
+            lock (_questListLock)
+            {
+                if (IsDoingQuestUnsafe(quest) != null)
+                    return false;
+
+                if (!TryGetNextQuestIndexUnsafe(out byte index))
+                    return false;
+
+                added = _questList.TryAdd(quest, index);
+            }
+
+            if (!added)
                 return false;
 
-            if (!AvailableQuestIndexes.TryDequeue(out byte index))
-                index = (byte) QuestList.Count;
-
-            QuestList.TryAdd(quest, index);
             quest.OnQuestAssigned(this);
             Out.SendQuestUpdate(quest);
             return true;
@@ -11314,13 +11633,10 @@ namespace DOL.GS
         /// <returns>the quest if player is doing the quest or null if not</returns>
         public AbstractQuest IsDoingQuest(AbstractQuest quest)
         {
-            foreach (AbstractQuest questInList in QuestList.Keys)
+            lock (_questListLock)
             {
-                if (questInList.GetType().Equals(quest.GetType()) && questInList.IsDoingQuest())
-                    return questInList;
+                return IsDoingQuestUnsafe(quest);
             }
-
-            return null;
         }
 
         /// <summary>
@@ -11331,12 +11647,15 @@ namespace DOL.GS
         /// <returns>the quest if player is doing the quest or null if not</returns>
         public AbstractQuest IsDoingQuest(Type questType)
         {
-            foreach (AbstractQuest quest in QuestList.Keys)
+            lock (_questListLock)
             {
-                if (quest is not DataQuest)
+                foreach (AbstractQuest quest in _questList.Keys)
                 {
-                    if (quest.GetType().Equals(questType))
-                        return quest;
+                    if (quest is not DataQuest)
+                    {
+                        if (quest.GetType().Equals(questType))
+                            return quest;
+                    }
                 }
             }
 
@@ -11351,10 +11670,19 @@ namespace DOL.GS
             CharacterClass.Notify(e, sender, args);
             base.Notify(e, sender, args);
 
-            foreach (AbstractQuest quest in QuestList.Keys)
+            AbstractQuest[] activeQuests = RentActiveQuestSnapshot(out int activeQuestCount);
+
+            try
             {
-                // player forwards every single notify message to all active quests
-                quest.Notify(e, sender, args);
+                for (int i = 0; i < activeQuestCount; i++)
+                {
+                    // player forwards every single notify message to all active quests
+                    activeQuests[i].Notify(e, sender, args);
+                }
+            }
+            finally
+            {
+                ReturnActiveQuestSnapshot(activeQuests);
             }
 
             if (GameTask != null)

--- a/GameServer/gameutils/Group.cs
+++ b/GameServer/gameutils/Group.cs
@@ -120,6 +120,14 @@ namespace DOL.GS
             {
                 player.Duel?.Stop();
                 player.Out.SendGroupMembersUpdate(true, true);
+                AbstractMission groupMission = Mission;
+
+                if (groupMission != null)
+                {
+                    // Quest list updates also carry task/mission text for newer clients.
+                    player.Out.SendQuestListUpdate();
+                    player.Out.SendMessage(groupMission.Description, eChatType.CT_System, eChatLoc.CL_SystemWindow);
+                }
 
                 // Part of the hack to make friendly pets untargetable (or targetable again) with TAB on a PvP server.
                 // We could also check for non controlled pets (turrets for example) around the player, but it isn't very important.
@@ -174,11 +182,14 @@ namespace DOL.GS
 
         public bool RemoveMember(GameLiving living)
         {
+            AbstractMission groupMission;
+
             lock (_groupMembersLock)
             {
                 if (!_groupMembers.Remove(living))
                     return false;
 
+                groupMission = Mission;
                 living.Group = null;
                 living.GroupIndex = 0xFF;
 
@@ -192,7 +203,12 @@ namespace DOL.GS
             if (living is GamePlayer player)
             {
                 player.Out.SendGroupWindowUpdate();
-                player.Out.SendQuestListUpdate();
+
+                if (groupMission != null)
+                {
+                    // Quest list updates also carry task/mission text for newer clients.
+                    player.Out.SendQuestListUpdate();
+                }
 
                 List<ECSGameAbilityEffect> abilityEffects = player.effectListComponent.GetAbilityEffects();
 

--- a/GameServer/packets/Client/168/QuestRemoveRequestHandler.cs
+++ b/GameServer/packets/Client/168/QuestRemoveRequestHandler.cs
@@ -10,14 +10,7 @@ namespace DOL.GS.PacketHandler.Client.v168
             _ = packet.ReadShort();
             _ = packet.ReadShort();
 
-            foreach (var entry in client.Player.QuestList)
-            {
-                if (questIndex != entry.Value)
-                    continue;
-
-                entry.Key.AbortQuest();
-                return;
-            }
+            client.Player.GetQuestByIndex(questIndex)?.AbortQuest();
         }
     }
 }

--- a/GameServer/packets/Server/PacketLib168.cs
+++ b/GameServer/packets/Server/PacketLib168.cs
@@ -1552,67 +1552,7 @@ namespace DOL.GS.PacketHandler
 
 		public virtual void SendQuestListUpdate(byte indexOffset)
 		{
-			// Send up to JOURNAL_MAX_QUEST_COUNT quests.
-			// `indexOffset` is used to accommodate for the client version and represents the first index it accepts.
-			// Our dictionary's value doesn't change and starts a 0.
-			int lastIndex = JOURNAL_MAX_QUEST_COUNT + indexOffset;
-			Span<bool> sentIndexes = stackalloc bool[JOURNAL_MAX_QUEST_COUNT];
-			KeyValuePair<AbstractQuest, byte>[] entries = m_gameClient.Player.RentActiveQuestEntries(out int entryCount);
-
-			try
-			{
-				for (int i = 0; i < entryCount; i++)
-				{
-					KeyValuePair<AbstractQuest, byte> entry = entries[i];
-					int adjustedQuestIndex = entry.Value + indexOffset;
-
-					if (adjustedQuestIndex < lastIndex)
-					{
-						SendQuestPacket(entry.Key, (byte) adjustedQuestIndex);
-						sentIndexes[adjustedQuestIndex - indexOffset] = true;
-					}
-				}
-
-				// If possible, move and send quests which indexes are too high.
-				int questIndex = indexOffset;
-
-				for (int i = 0; i < entryCount; i++)
-				{
-					KeyValuePair<AbstractQuest, byte> entry = entries[i];
-
-					if (entry.Value + indexOffset < lastIndex)
-						continue;
-
-					for ( ; questIndex < lastIndex; questIndex++)
-					{
-						int sentIndex = questIndex - indexOffset;
-
-						if (sentIndexes[sentIndex])
-							continue;
-
-						if (!m_gameClient.Player.TrySetQuestIndex(entry.Key, (byte) sentIndex))
-							continue;
-
-						SendQuestPacket(entry.Key, (byte) questIndex);
-						sentIndexes[sentIndex] = true;
-						break;
-					}
-
-					if (questIndex == lastIndex)
-						break;
-				}
-			}
-			finally
-			{
-				GamePlayer.ReturnActiveQuestEntries(entries);
-			}
-
-			// Send null for unused indexes.
-			for (int questIndexToClear = indexOffset; questIndexToClear < lastIndex; questIndexToClear++)
-			{
-				if (!sentIndexes[questIndexToClear - indexOffset])
-					SendQuestPacket(null, (byte) questIndexToClear);
-			}
+			m_gameClient.Player.SendQuestListUpdate(indexOffset, JOURNAL_MAX_QUEST_COUNT, SendQuestPacket);
 		}
 
 		public virtual void SendQuestUpdate(AbstractQuest quest)

--- a/GameServer/packets/Server/PacketLib168.cs
+++ b/GameServer/packets/Server/PacketLib168.cs
@@ -1555,42 +1555,46 @@ namespace DOL.GS.PacketHandler
 			// Send up to JOURNAL_MAX_QUEST_COUNT quests.
 			// `indexOffset` is used to accommodate for the client version and represents the first index it accepts.
 			// Our dictionary's value doesn't change and starts a 0.
-			byte questIndex;
-			byte lastIndex = (byte) (JOURNAL_MAX_QUEST_COUNT + indexOffset);
-			HashSet<byte> sentIndexes = [];
-			HashSet<AbstractQuest> questsWithTooHighIndex = null;
+			int lastIndex = JOURNAL_MAX_QUEST_COUNT + indexOffset;
+			Span<bool> sentIndexes = stackalloc bool[JOURNAL_MAX_QUEST_COUNT];
+			KeyValuePair<AbstractQuest, byte>[] entries = m_gameClient.Player.RentActiveQuestEntries(out int entryCount);
 
-			foreach (var entry in m_gameClient.Player.QuestList)
+			try
 			{
-				questIndex = (byte) (entry.Value + indexOffset);
-
-				if (questIndex < lastIndex)
+				for (int i = 0; i < entryCount; i++)
 				{
-					SendQuestPacket(entry.Key, questIndex);
-					sentIndexes.Add(questIndex);
+					KeyValuePair<AbstractQuest, byte> entry = entries[i];
+					int adjustedQuestIndex = entry.Value + indexOffset;
+
+					if (adjustedQuestIndex < lastIndex)
+					{
+						SendQuestPacket(entry.Key, (byte) adjustedQuestIndex);
+						sentIndexes[adjustedQuestIndex - indexOffset] = true;
+					}
 				}
-				else
-				{
-					questsWithTooHighIndex ??= [];
-					questsWithTooHighIndex.Add(entry.Key);
-				}
-			}
 
-			// If possible, move and send quests which indexes are too high.
-			if (questsWithTooHighIndex != null)
-			{
-				questIndex = indexOffset;
+				// If possible, move and send quests which indexes are too high.
+				int questIndex = indexOffset;
 
-				foreach (AbstractQuest questWithTooHighIndex in questsWithTooHighIndex)
+				for (int i = 0; i < entryCount; i++)
 				{
+					KeyValuePair<AbstractQuest, byte> entry = entries[i];
+
+					if (entry.Value + indexOffset < lastIndex)
+						continue;
+
 					for ( ; questIndex < lastIndex; questIndex++)
 					{
-						if (sentIndexes.Contains(questIndex))
+						int sentIndex = questIndex - indexOffset;
+
+						if (sentIndexes[sentIndex])
 							continue;
 
-						m_gameClient.Player.QuestList[questWithTooHighIndex] = (byte) (questIndex - indexOffset);
-						SendQuestPacket(questWithTooHighIndex, questIndex);
-						sentIndexes.Add(questIndex);
+						if (!m_gameClient.Player.TrySetQuestIndex(entry.Key, (byte) sentIndex))
+							continue;
+
+						SendQuestPacket(entry.Key, (byte) questIndex);
+						sentIndexes[sentIndex] = true;
 						break;
 					}
 
@@ -1598,12 +1602,16 @@ namespace DOL.GS.PacketHandler
 						break;
 				}
 			}
+			finally
+			{
+				GamePlayer.ReturnActiveQuestEntries(entries);
+			}
 
 			// Send null for unused indexes.
-			for (questIndex = indexOffset; questIndex < lastIndex; questIndex++)
+			for (int questIndexToClear = indexOffset; questIndexToClear < lastIndex; questIndexToClear++)
 			{
-				if (!sentIndexes.Contains(questIndex))
-					SendQuestPacket(null, questIndex);
+				if (!sentIndexes[questIndexToClear - indexOffset])
+					SendQuestPacket(null, (byte) questIndexToClear);
 			}
 		}
 
@@ -1614,7 +1622,7 @@ namespace DOL.GS.PacketHandler
 
 		public virtual void SendQuestUpdate(AbstractQuest quest, byte indexOffset)
 		{
-			if (!m_gameClient.Player.QuestList.TryGetValue(quest, out byte index))
+			if (!m_gameClient.Player.TryGetQuestIndex(quest, out byte index))
 				return;
 
 			if (index + indexOffset >= JOURNAL_MAX_QUEST_COUNT + indexOffset)
@@ -1625,7 +1633,7 @@ namespace DOL.GS.PacketHandler
 
 		public virtual void SendQuestRemove(byte index)
 		{
-			if (m_gameClient.Player.QuestList.Count > JOURNAL_MAX_QUEST_COUNT)
+			if (m_gameClient.Player.NeedsQuestListRefreshAfterRemove(JOURNAL_MAX_QUEST_COUNT))
 				SendQuestListUpdate();
 			else
 				SendQuestPacket(null, index);

--- a/GameServer/quests/QuestsMgr/AbstractQuest.cs
+++ b/GameServer/quests/QuestsMgr/AbstractQuest.cs
@@ -171,13 +171,11 @@ namespace DOL.GS.Quests
             m_questPlayer.Out.SendMessage(string.Format(LanguageMgr.GetTranslation(m_questPlayer.Client, "AbstractQuest.FinishQuest.Completed", Name)), eChatType.CT_ScreenCenter, eChatLoc.CL_SystemWindow);
 
             // Move quest from active list to finished list.
-            if (m_questPlayer.QuestList.TryRemove(this, out byte value))
-                m_questPlayer.AvailableQuestIndexes.Enqueue(value);
+            m_questPlayer.RemoveQuest(this, notifyPlayer: true);
 
             if (m_questPlayer.HasFinishedQuest(GetType()) == 0)
                 m_questPlayer.AddFinishedQuest(this);
 
-            m_questPlayer.Out.SendQuestRemove(value);
             m_questPlayer.SaveIntoDatabase();
         }
 
@@ -185,11 +183,9 @@ namespace DOL.GS.Quests
         {
             Step = -1;
 
-            if (m_questPlayer.QuestList.TryRemove(this, out byte value))
-                m_questPlayer.AvailableQuestIndexes.Enqueue(value);
+            m_questPlayer.RemoveQuest(this, notifyPlayer: true);
 
             DeleteFromDatabase();
-            m_questPlayer.Out.SendQuestRemove(value);
             m_questPlayer.Out.SendMessage(LanguageMgr.GetTranslation(m_questPlayer.Client, "AbstractQuest.AbortQuest"), eChatType.CT_System, eChatLoc.CL_SystemWindow);
         }
 

--- a/GameServer/quests/QuestsMgr/DataQuest.cs
+++ b/GameServer/quests/QuestsMgr/DataQuest.cs
@@ -1001,11 +1001,8 @@ namespace DOL.GS.Quests
 				return true;
 			}
 
-			foreach (AbstractQuest quest in player.QuestList.Keys)
-			{
-				if (quest is DataQuest dataQuest && dataQuest.ID == ID)
-					return false; // player is currently doing this quest
-			}
+			if (player.IsDoingDataQuest(ID))
+				return false; // player is currently doing this quest
 
 			List<AbstractQuest> finishedQuests = player.GetFinishedQuests();
 
@@ -3043,8 +3040,7 @@ namespace DOL.GS.Quests
 			// Remove this quest from the players active quest list and either
 			// Add or update the quest in the players finished list
 
-			if (m_questPlayer.QuestList.TryRemove(this, out byte value))
-				m_questPlayer.AvailableQuestIndexes.Enqueue(value);
+			m_questPlayer.RemoveQuest(this, notifyPlayer: false);
 
 			bool add = true;
 
@@ -3124,8 +3120,7 @@ namespace DOL.GS.Quests
 		{
 			if (m_questPlayer == null || m_charQuest == null || m_charQuest.IsPersisted == false) return;
 
-			if (m_questPlayer.QuestList.TryRemove(this, out byte value))
-				m_questPlayer.AvailableQuestIndexes.Enqueue(value);
+			m_questPlayer.RemoveQuest(this, notifyPlayer: false);
 
 			if (m_charQuest.Count == 0)
 			{

--- a/GameServer/quests/QuestsMgr/Utility/QuestSearchArea.cs
+++ b/GameServer/quests/QuestsMgr/Utility/QuestSearchArea.cs
@@ -148,16 +148,8 @@ namespace DOL.GS.Quests
                 ChatUtil.SendDebugMessage(player, "Entered QuestSearchArea for DataQuest ID:" + m_dataQuest.ID + ", Step " + Step);
 
                 // first check active data quests
-   			    foreach (AbstractQuest quest in player.QuestList.Keys)
-			    {
-				    if (quest is DataQuest)
-				    {
-                        if ((quest as DataQuest).ID == m_dataQuest.ID && quest.Step == Step && m_popupText != string.Empty)
-                        {
-                            showText = true;
-                        }
-				    }
-			    }
+                if (player.IsDoingDataQuest(m_dataQuest.ID, Step) && m_popupText != string.Empty)
+                    showText = true;
 
                 // next check for searches that start a dataquest
                 if (Step == 0 && DataQuest.CheckQuestQualification(player))

--- a/GameServer/quests/QuestsMgr/Utility/QuestSearchArea.cs
+++ b/GameServer/quests/QuestsMgr/Utility/QuestSearchArea.cs
@@ -162,7 +162,9 @@ namespace DOL.GS.Quests
                 ChatUtil.SendDebugMessage(player, "Entered QuestSearchArea for " + m_questType.Name + ", Step " + Step);
 
                 // popup a dialog telling the player they should search here
-                if (player.IsDoingQuest(m_questType) != null && player.IsDoingQuest(m_questType).Step == m_validStep && PopupText != string.Empty)
+                AbstractQuest quest = player.IsDoingQuest(m_questType);
+
+                if (quest != null && quest.Step == m_validStep && PopupText != string.Empty)
                 {
                     showText = true;
                 }

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Hardcore/HardcoreKillAPlayerAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Hardcore/HardcoreKillAPlayerAlb.cs
@@ -372,8 +372,7 @@ namespace DOL.GS.DailyQuest
 			PlayerKilled = 0;
 			Step = -1;
 
-			if (m_questPlayer.QuestList.TryRemove(this, out byte value))
-				m_questPlayer.AvailableQuestIndexes.Enqueue(value);
+			m_questPlayer.RemoveQuest(this, notifyPlayer: false);
 
 			m_questPlayer.AddFinishedQuest(this);
 			m_questPlayer.Out.SendQuestListUpdate();

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Hardcore/HardcoreKillNPCInFrontiersAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Hardcore/HardcoreKillNPCInFrontiersAlb.cs
@@ -385,8 +385,7 @@ namespace DOL.GS.DailyQuest
 			FrontierMobsKilled = 0;
 			Step = -1;
 
-			if (m_questPlayer.QuestList.TryRemove(this, out byte value))
-				m_questPlayer.AvailableQuestIndexes.Enqueue(value);
+			m_questPlayer.RemoveQuest(this, notifyPlayer: false);
 
 			m_questPlayer.AddFinishedQuest(this);
 			m_questPlayer.Out.SendQuestListUpdate();

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Hardcore/HardcoreKillOrangesAlb.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Albion/Hardcore/HardcoreKillOrangesAlb.cs
@@ -385,8 +385,7 @@ namespace DOL.GS.DailyQuest
 			m_questPlayer.Out.SendMessage(questTitle + " failed.", eChatType.CT_ScreenCenter_And_CT_System, eChatLoc.CL_SystemWindow);
 			Step = -1;
 
-			if (m_questPlayer.QuestList.TryRemove(this, out byte value))
-				m_questPlayer.AvailableQuestIndexes.Enqueue(value);
+			m_questPlayer.RemoveQuest(this, notifyPlayer: false);
 
 			m_questPlayer.AddFinishedQuest(this);
 			m_questPlayer.Out.SendQuestListUpdate();

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Hardcore/Daily/HardcoreKillAPlayerHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Hardcore/Daily/HardcoreKillAPlayerHib.cs
@@ -378,8 +378,7 @@ namespace DOL.GS.DailyQuest
 			PlayerKilled = 0;
 			Step = -1;
 
-			if (m_questPlayer.QuestList.TryRemove(this, out byte value))
-				m_questPlayer.AvailableQuestIndexes.Enqueue(value);
+			m_questPlayer.RemoveQuest(this, notifyPlayer: false);
 
 			m_questPlayer.AddFinishedQuest(this);
 			m_questPlayer.Out.SendQuestListUpdate();

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Hardcore/Daily/HardcoreKillNPCInFrontiersHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Hardcore/Daily/HardcoreKillNPCInFrontiersHib.cs
@@ -389,8 +389,7 @@ namespace DOL.GS.DailyQuest
 			FrontierMobsKilled = 0;
 			Step = -1;
 
-			if (m_questPlayer.QuestList.TryRemove(this, out byte value))
-				m_questPlayer.AvailableQuestIndexes.Enqueue(value);
+			m_questPlayer.RemoveQuest(this, notifyPlayer: false);
 
 			m_questPlayer.AddFinishedQuest(this);
 			m_questPlayer.Out.SendQuestListUpdate();

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Hardcore/Daily/HardcoreKillOrangesHib.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Hibernia/Hardcore/Daily/HardcoreKillOrangesHib.cs
@@ -393,8 +393,7 @@ namespace DOL.GS.DailyQuest
 			m_questPlayer.Out.SendMessage(questTitle + " failed.", eChatType.CT_ScreenCenter_And_CT_System, eChatLoc.CL_SystemWindow);
 			Step = -1;
 
-			if (m_questPlayer.QuestList.TryRemove(this, out byte value))
-				m_questPlayer.AvailableQuestIndexes.Enqueue(value);
+			m_questPlayer.RemoveQuest(this, notifyPlayer: false);
 
 			m_questPlayer.AddFinishedQuest(this);
 			m_questPlayer.Out.SendQuestListUpdate();

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Hardcore/HardcoreKillAPlayerMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Hardcore/HardcoreKillAPlayerMid.cs
@@ -372,8 +372,7 @@ namespace DOL.GS.DailyQuest
 			PlayerKilled = 0;
 			Step = -1;
 
-			if (m_questPlayer.QuestList.TryRemove(this, out byte value))
-				m_questPlayer.AvailableQuestIndexes.Enqueue(value);
+			m_questPlayer.RemoveQuest(this, notifyPlayer: false);
 
 			m_questPlayer.AddFinishedQuest(this);
 			m_questPlayer.Out.SendQuestListUpdate();

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Hardcore/HardcoreKillNPCInFrontiersMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Hardcore/HardcoreKillNPCInFrontiersMid.cs
@@ -388,8 +388,7 @@ namespace DOL.GS.DailyQuest
 			FrontierMobsKilled = 0;
 			Step = -1;
 
-			if (m_questPlayer.QuestList.TryRemove(this, out byte value))
-				m_questPlayer.AvailableQuestIndexes.Enqueue(value);
+			m_questPlayer.RemoveQuest(this, notifyPlayer: false);
 
 			m_questPlayer.AddFinishedQuest(this);
 			m_questPlayer.Out.SendQuestListUpdate();

--- a/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Hardcore/HardcoreKillOrangesMid.cs
+++ b/GameServer/scripts/quests/AtlasQuests/DailyQuests/Midgard/Hardcore/HardcoreKillOrangesMid.cs
@@ -385,8 +385,7 @@ namespace DOL.GS.DailyQuest
 			m_questPlayer.Out.SendMessage(questTitle + " failed.", eChatType.CT_ScreenCenter_And_CT_System, eChatLoc.CL_SystemWindow);
 			Step = -1;
 
-			if (m_questPlayer.QuestList.TryRemove(this, out byte value))
-				m_questPlayer.AvailableQuestIndexes.Enqueue(value);
+			m_questPlayer.RemoveQuest(this, notifyPlayer: false);
 
 			m_questPlayer.AddFinishedQuest(this);
 			m_questPlayer.Out.SendQuestListUpdate();


### PR DESCRIPTION
## Summary

Refactors `GamePlayer` active quest storage from the public `ConcurrentDictionary` plus reusable-index queue into a private `Dictionary<AbstractQuest, byte>` guarded by a dedicated lock.

The change adds focused `GamePlayer` helpers for quest removal, manual cancel lookup by journal index, active DataQuest checks, quest-command dispatch, NPC completion checks, and packet-facing index management. Callers no longer manipulate active quest indexes directly.

## Details

- Centralizes active quest removal in `GamePlayer.RemoveQuest`, preserving full `SendQuestListUpdate` behavior for DataQuest-style flows while using `SendQuestRemove` for normal scripted quest removal.
- Updates manual quest cancellation to resolve through `GamePlayer.GetQuestByIndex` instead of enumerating the active quest dictionary.
- Reworks `SendQuestListUpdate` to use a pooled snapshot plus stack-allocated sent-index tracking instead of per-update `HashSet` allocations.
- Handles quest-index rebasing through `GamePlayer.TrySetQuestIndex`, with packet-only helpers kept `internal`.
- Keeps whole-list copies limited to display-oriented callers such as `/quest`; command dispatch, save parameter handling, notify fanout, and packet updates use inline or pooled snapshots.
- Updates DataQuest/hardcore quest abort paths so they no longer manually enqueue reusable quest indexes.

## Review notes

During review I fixed an edge case in the packet list refresh path where adding the client-version index offset before bounds validation could wrap a byte index for newer clients. Adjusted packet indexes now stay as `int` until they are known to fit in the visible quest journal range.

## Validation

- `dotnet build GameServer\GameServer.csproj --no-restore -p:Configuration=Debug -clp:ErrorsOnly`
- `git diff --check blackthorn/master..HEAD`

Solution-level build was also attempted, but this checkout is missing `CoreServer/config/serverconfig.xml`, so `dotnet build "Dawn of Light.sln" --no-restore -p:Configuration=Debug -clp:ErrorsOnly` stops on that existing missing file.