### PR TITLE
Extract NPC brain scheduling

### DIFF
--- a/GameServer/ECS-Effects/CrowdControlECSEffect.cs
+++ b/GameServer/ECS-Effects/CrowdControlECSEffect.cs
@@ -42,7 +42,7 @@ namespace DOL.GS
 
             // Re-schedule the next think so that the NPC can resume its attack immediately for example.
             if (Owner is GameNPC npc && npc.Brain is ABrain brain)
-                brain.NextThinkTick = GameLoop.GameLoopTime;
+                brain.WakeNow();
 
             if (SpellHandler.Caster.Realm == 0 || Owner.Realm == 0)
                 Owner.LastAttackedByEnemyTickPvE = GameLoop.GameLoopTime;

--- a/GameServer/ECS-Services/NpcService.cs
+++ b/GameServer/ECS-Services/NpcService.cs
@@ -66,7 +66,7 @@ namespace DOL.GS
                 if (monitor.IsLongTick(out long elapsedMs) && log.IsWarnEnabled)
                     log.Warn($"Long {Instance.ServiceName}.{nameof(Tick)} for {npc.Name}({npc.ObjectID}) Interval: {brain.ThinkInterval} BrainType: {brain.GetType()} Time: {elapsedMs}ms");
 
-                brain.NextThinkTick = GameLoop.GameLoopTime + brain.ThinkInterval;
+                brain.ScheduleNextThink(GameLoop.GameLoopTime + brain.ThinkInterval);
             }
             catch (Exception e)
             {

--- a/GameServer/Managers/ServiceObject/SchedulableServiceObjectArray.cs
+++ b/GameServer/Managers/ServiceObject/SchedulableServiceObjectArray.cs
@@ -17,16 +17,18 @@ namespace DOL.GS
         private const int WHEEL_BITS = 16;
         private const int WHEEL_SIZE = 1 << WHEEL_BITS;
         private const int WHEEL_MASK = WHEEL_SIZE - 1;
-        private const int SKIP_SCHEDULE_THRESHOLD_TICK = 30;
+        private const int DEFAULT_SKIP_SCHEDULE_THRESHOLD_TICK = 30;
 
         private readonly List<SleepTicket>[] _sleepWheel;
         private readonly Stack<List<SleepTicket>> _listPool = new();
         private readonly PriorityQueue<SleepTicket, long> _farFuture = new();
+        private readonly int _skipScheduleThresholdTick;
         private long _lastProcessedWheelTick = -1;
         private long _currentUpdateTick;
 
-        public SchedulableServiceObjectArray(int capacity) : base(capacity)
+        public SchedulableServiceObjectArray(int capacity, int skipScheduleThresholdTick = DEFAULT_SKIP_SCHEDULE_THRESHOLD_TICK) : base(capacity)
         {
+            _skipScheduleThresholdTick = skipScheduleThresholdTick;
             _sleepWheel = new List<SleepTicket>[WHEEL_SIZE];
 
             for (int i = 0; i < WHEEL_SIZE; i++)
@@ -37,9 +39,10 @@ namespace DOL.GS
         {
             long now = GameLoop.GameLoopTime;
             SchedulableServiceObjectId id = item.ServiceObjectId;
+            long scheduleToken = id.NextScheduleToken();
 
             // Bypass the wheel entirely if wakeUpTimeMs is close.
-            if (wakeUpTimeMs - now <= SKIP_SCHEDULE_THRESHOLD_TICK * GameLoop.TickDuration)
+            if (wakeUpTimeMs - now <= _skipScheduleThresholdTick * GameLoop.TickDuration)
             {
                 if (id.IsRunning)
                 {
@@ -55,7 +58,7 @@ namespace DOL.GS
 
             long currentTick = now / WHEEL_RESOLUTION_MS;
             long targetTick = Math.Max(currentTick, wakeUpTimeMs / WHEEL_RESOLUTION_MS);
-            _itemsToSchedule.Add(new(item, targetTick));
+            _itemsToSchedule.Add(new(item, targetTick, scheduleToken));
         }
 
         protected override void ProcessItemsToRemove(long now)
@@ -80,9 +83,13 @@ namespace DOL.GS
             SchedulableServiceObjectId id = item.ServiceObjectId;
             long targetTick = request.TargetTick;
 
-            if (!id.TryConsumeAction(ServiceObjectId.PendingAction.Schedule) ||
-                targetTick < _lastProcessedWheelTick)
+            if (request.Token != id.ScheduleToken ||
+                !id.TryConsumeAction(ServiceObjectId.PendingAction.Schedule))
+                return;
+
+            if (targetTick < _lastProcessedWheelTick)
             {
+                AddToList(item);
                 return;
             }
 
@@ -122,9 +129,7 @@ namespace DOL.GS
                         // Do not wake if the sleep token changed or if there's a pending action.
                         if (id.SleepToken != ticket.Token ||
                             id.PeekAction() is not ServiceObjectId.PendingAction.None)
-                        {
                             continue;
-                        }
 
                         AddToList(item);
                     }
@@ -164,7 +169,7 @@ namespace DOL.GS
             _listPool.Push(currentSwapList);
         }
 
-        private readonly record struct ScheduleRequest(T Item, long TargetTick);
+        private readonly record struct ScheduleRequest(T Item, long TargetTick, long Token);
 
         private readonly record struct SleepTicket(T Item, long Token);
     }

--- a/GameServer/Managers/ServiceObject/SchedulableServiceObjectId.cs
+++ b/GameServer/Managers/ServiceObject/SchedulableServiceObjectId.cs
@@ -1,17 +1,33 @@
-﻿namespace DOL.GS
+using System.Threading;
+
+namespace DOL.GS
 {
     public class SchedulableServiceObjectId : ServiceObjectId
     {
         public const int SLEEPING_ID = -2;
 
+        private long _scheduleToken;
+        private long _sleepToken;
+
         public bool IsSleeping => Value == SLEEPING_ID;
-        public long SleepToken { get; private set; } = 0;
+        public long SleepToken => Volatile.Read(ref _sleepToken);
+        public long ScheduleToken => Volatile.Read(ref _scheduleToken);
 
         public SchedulableServiceObjectId(ServiceObjectType type) : base(type) { }
 
+        public long NextScheduleToken()
+        {
+            return Interlocked.Increment(ref _scheduleToken);
+        }
+
+        public void InvalidateScheduleRequests()
+        {
+            Interlocked.Increment(ref _scheduleToken);
+        }
+
         public override void MoveTo(int index)
         {
-            SleepToken++;
+            Interlocked.Increment(ref _sleepToken);
             base.MoveTo(index);
         }
     }

--- a/GameServer/Managers/ServiceObject/ServiceObjectId.cs
+++ b/GameServer/Managers/ServiceObject/ServiceObjectId.cs
@@ -1,12 +1,15 @@
-﻿namespace DOL.GS
+using System.Threading;
+
+namespace DOL.GS
 {
     public class ServiceObjectId
     {
         public const int UNSET_ID = -1;
 
-        private PendingAction _action = PendingAction.None;
+        private int _action = (int) PendingAction.None;
+        private int _value = UNSET_ID;
 
-        public int Value { get; private set; } = UNSET_ID;
+        public int Value => Volatile.Read(ref _value);
         public ServiceObjectType Type { get; }
 
         public bool IsRegistered => Value != UNSET_ID;
@@ -20,35 +23,27 @@
 
         public bool TrySetAction(PendingAction action)
         {
-            if (_action == action)
-                return false;
-
-            _action = action;
-            return true;
+            return Interlocked.Exchange(ref _action, (int) action) != (int) action;
         }
 
         public bool TryConsumeAction(PendingAction expectedAction)
         {
-            if (_action != expectedAction)
-                return false;
-
-            _action = PendingAction.None;
-            return true;
+            return Interlocked.CompareExchange(ref _action, (int) PendingAction.None, (int) expectedAction) == (int) expectedAction;
         }
 
         public PendingAction PeekAction()
         {
-            return _action;
+            return (PendingAction) Volatile.Read(ref _action);
         }
 
         public virtual void MoveTo(int index)
         {
-            Value = index;
+            Volatile.Write(ref _value, index);
         }
 
         public void Unset()
         {
-            _action = PendingAction.None;
+            Volatile.Write(ref _action, (int) PendingAction.None);
             MoveTo(UNSET_ID); // Ensure MoveTo overrides are called.
         }
 

--- a/GameServer/Managers/ServiceObject/ServiceObjectStore.cs
+++ b/GameServer/Managers/ServiceObject/ServiceObjectStore.cs
@@ -38,7 +38,7 @@ namespace DOL.GS
             new Dictionary<ServiceObjectType, IServiceObjectArray>()
             {
                 { ServiceObjectType.Client, new ServiceObjectArray<GameClient>(Properties.MAX_PLAYERS) },
-                { ServiceObjectType.Brain, new ServiceObjectArray<ABrain>(Properties.MAX_ENTITIES) },
+                { ServiceObjectType.Brain, new ShardedServiceObjectArray<ABrain>(Properties.MAX_ENTITIES, 1) },
                 { ServiceObjectType.AttackComponent, new ServiceObjectArray<AttackComponent>(1250) },
                 { ServiceObjectType.CastingComponent, new ServiceObjectArray<CastingComponent>(1250) },
                 { ServiceObjectType.Effect, new ServiceObjectArray<ECSGameEffect>(10000) },
@@ -68,15 +68,48 @@ namespace DOL.GS
 
         // Schedule an object to be returned at a later time.
         // Scheduling in the past is allowed (the item will be returned immediately), and it's the caller's responsibility to ensure this makes sense.
-        public static bool Schedule<T>(T serviceObject, long nextTickMs) where T : class, ISchedulableServiceObject
+        public static bool Schedule<T>(T serviceObject, long nextTickMs, bool allowPendingRemove = false) where T : class, ISchedulableServiceObject
         {
             SchedulableServiceObjectId id = serviceObject.ServiceObjectId;
 
-            // Prevent re-entry if the object is already being scheduled.
-            if (!id.TrySetAction(ServiceObjectId.PendingAction.Schedule))
+            if (id.PeekAction() is ServiceObjectId.PendingAction.Remove && !allowPendingRemove)
+                return false;
+
+            // Re-scheduling is allowed. The schedulable array uses request tokens so stale
+            // schedule requests cannot override a newer wake/schedule request.
+            if (id.PeekAction() is not ServiceObjectId.PendingAction.Schedule &&
+                !id.TrySetAction(ServiceObjectId.PendingAction.Schedule))
                 return false;
 
             (_serviceObjectArrays[id.Type] as ServiceObjectArrayBase<T>).Schedule(serviceObject, nextTickMs);
+            return true;
+        }
+
+        public static bool Wake<T>(T serviceObject) where T : class, ISchedulableServiceObject
+        {
+            SchedulableServiceObjectId id = serviceObject.ServiceObjectId;
+
+            if (id.PeekAction() is ServiceObjectId.PendingAction.Remove)
+                return false;
+
+            if (!id.IsRegistered && id.PeekAction() is not ServiceObjectId.PendingAction.Add and not ServiceObjectId.PendingAction.Schedule)
+                return false;
+
+            id.InvalidateScheduleRequests();
+
+            if (id.IsRunning)
+            {
+                id.TryConsumeAction(ServiceObjectId.PendingAction.Schedule);
+                return true;
+            }
+
+            if (id.PeekAction() is ServiceObjectId.PendingAction.Add)
+                return true;
+
+            if (!id.TrySetAction(ServiceObjectId.PendingAction.Add))
+                return false;
+
+            (_serviceObjectArrays[id.Type] as ServiceObjectArrayBase<T>).Add(serviceObject);
             return true;
         }
 

--- a/GameServer/Managers/ServiceObject/ShardedServiceObjectArray.cs
+++ b/GameServer/Managers/ServiceObject/ShardedServiceObjectArray.cs
@@ -9,6 +9,7 @@ namespace DOL.GS
         private readonly List<SchedulableServiceObjectArray<T>> _shards;
         private readonly List<T>[] _shardsView;
         private readonly int[] _shardStartIndices;
+        private readonly int _skipScheduleThresholdTick;
         private int _roundRobinCounter;
         private int _totalValidCount;
 
@@ -19,8 +20,9 @@ namespace DOL.GS
         public override int[] ShardStartIndices => _shardStartIndices;
         public override int TotalValidCount => _totalValidCount;
 
-        public ShardedServiceObjectArray(int initialCapacity)
+        public ShardedServiceObjectArray(int initialCapacity, int skipScheduleThresholdTick = 30)
         {
+            _skipScheduleThresholdTick = skipScheduleThresholdTick;
             int shardCount = GameLoop.DegreeOfParallelism;
             _shards = new(shardCount);
             _shardsView = new List<T>[shardCount];
@@ -29,7 +31,7 @@ namespace DOL.GS
 
             for (int i = 0; i < shardCount; i++)
             {
-                _shards.Add(new(capacityPerShard));
+                _shards.Add(new(capacityPerShard, _skipScheduleThresholdTick));
                 _shardsView[i] = _shards[i].Items;
             }
 
@@ -39,11 +41,15 @@ namespace DOL.GS
         private SchedulableServiceObjectArray<T> RouteItem(T item)
         {
             ShardedServiceObjectId id = item.ServiceObjectId;
+            int shardIndex = id.ShardIndex;
 
-            if (id.ShardIndex == -1)
-                id.ShardIndex = (int) ((uint) Interlocked.Increment(ref _roundRobinCounter) % _shards.Count);
+            if (shardIndex == -1)
+            {
+                int nextShardIndex = (int) ((uint) Interlocked.Increment(ref _roundRobinCounter) % _shards.Count);
+                shardIndex = id.TryAssignShardIndex(nextShardIndex);
+            }
 
-            return _shards[id.ShardIndex];
+            return _shards[shardIndex];
         }
 
         public override void Add(T item)

--- a/GameServer/Managers/ServiceObject/ShardedServiceObjectId.cs
+++ b/GameServer/Managers/ServiceObject/ShardedServiceObjectId.cs
@@ -1,9 +1,23 @@
-﻿namespace DOL.GS
+using System.Threading;
+
+namespace DOL.GS
 {
     public class ShardedServiceObjectId : SchedulableServiceObjectId
     {
-        public int ShardIndex { get; set; } = -1;
+        private int _shardIndex = -1;
+
+        public int ShardIndex
+        {
+            get => Volatile.Read(ref _shardIndex);
+            set => Volatile.Write(ref _shardIndex, value);
+        }
 
         public ShardedServiceObjectId(ServiceObjectType type) : base(type) { }
+
+        public int TryAssignShardIndex(int shardIndex)
+        {
+            int currentShardIndex = Interlocked.CompareExchange(ref _shardIndex, shardIndex, -1);
+            return currentShardIndex == -1 ? shardIndex : currentShardIndex;
+        }
     }
 }

--- a/GameServer/ai/ABrain.cs
+++ b/GameServer/ai/ABrain.cs
@@ -8,14 +8,17 @@ namespace DOL.AI
     /// <summary>
     /// This class is the base of all artificial intelligence in game objects
     /// </summary>
-    public abstract class ABrain : IServiceObject
+    public abstract class ABrain : IShardedServiceObject
     {
         public FSM FSM { get; set; }
-        public ServiceObjectId ServiceObjectId { get; } = new(ServiceObjectType.Brain);
+        public ShardedServiceObjectId ServiceObjectId { get; } = new(ServiceObjectType.Brain);
+        ServiceObjectId IServiceObject.ServiceObjectId => ServiceObjectId;
+        SchedulableServiceObjectId ISchedulableServiceObject.ServiceObjectId => ServiceObjectId;
+        ShardedServiceObjectId IShardedServiceObject.ServiceObjectId => ServiceObjectId;
         public virtual GameNPC Body { get; set; }
         public virtual int ThinkInterval { get; set; } = 2500;
         public bool IsActive => Body != null && Body.IsAlive && Body.ObjectState is GameObject.eObjectState.Active && Body.IsVisibleToPlayers;
-        public long NextThinkTick { get; set; }
+        public long NextThinkTick { get; private set; }
         protected virtual int ThinkOffsetOnStart => Util.Random(750, 3000);
 
         /// <summary>
@@ -38,15 +41,31 @@ namespace DOL.AI
         /// <returns>true if started</returns>
         public virtual bool Start()
         {
-            if (ServiceObjectStore.Add(this))
-            {
-                // Offset the first think tick by a random amount so that not too many are grouped in one server tick.
-                // We also delay the first think tick a bit because clients tend to send positive LoS checks when they shouldn't.
-                NextThinkTick = GameLoop.GameLoopTime + ThinkOffsetOnStart;
-                return true;
-            }
+            DOL.GS.ServiceObjectId.PendingAction pendingAction = ServiceObjectId.PeekAction();
 
-            return false;
+            if (ServiceObjectId.IsRegistered && pendingAction is not DOL.GS.ServiceObjectId.PendingAction.Remove)
+                return false;
+
+            if (!ServiceObjectId.IsRegistered && pendingAction is DOL.GS.ServiceObjectId.PendingAction.Add or DOL.GS.ServiceObjectId.PendingAction.Schedule)
+                return false;
+
+            // Offset the first think tick by a random amount so that not too many are grouped in one server tick.
+            // We also delay the first think tick a bit because clients tend to send positive LoS checks when they shouldn't.
+            NextThinkTick = GameLoop.GameLoopTime + ThinkOffsetOnStart;
+
+            return ServiceObjectStore.Schedule(this, NextThinkTick, allowPendingRemove: true);
+        }
+
+        public bool ScheduleNextThink(long nextThinkTick)
+        {
+            NextThinkTick = nextThinkTick;
+            return ServiceObjectStore.Schedule(this, nextThinkTick);
+        }
+
+        public bool WakeNow()
+        {
+            NextThinkTick = GameLoop.GameLoopTime;
+            return ServiceObjectStore.Wake(this);
         }
 
         /// <summary>
@@ -55,7 +74,7 @@ namespace DOL.AI
         /// <returns>true if stopped</returns>
         public virtual bool Stop()
         {
-            if (ServiceObjectId.PeekAction() is ServiceObjectId.PendingAction.Remove)
+            if (ServiceObjectId.PeekAction() is DOL.GS.ServiceObjectId.PendingAction.Remove)
                 return false; // Prevents overrides from doing any redundant work. Maybe counter intuitive.
 
             // Without `IsActive` check, charming a NPC that's returning to spawn would teleport it.

--- a/GameServer/ai/brain/StandardMob/StandardMobBrain.cs
+++ b/GameServer/ai/brain/StandardMob/StandardMobBrain.cs
@@ -323,7 +323,7 @@ namespace DOL.AI.Brain
             if (FSM.GetCurrentState() != FSM.GetState(eFSMStateType.AGGRO) && HasAggro)
             {
                 FSM.SetCurrentState(eFSMStateType.AGGRO);
-                NextThinkTick = GameLoop.GameLoopTime;
+                WakeNow();
             }
 
             static AggroAmount Add(GameLiving key, long arg)
@@ -387,7 +387,7 @@ namespace DOL.AI.Brain
                 if (FSM.GetCurrentState() != FSM.GetState(eFSMStateType.AGGRO))
                     FSM.SetCurrentState(eFSMStateType.AGGRO);
 
-                NextThinkTick = GameLoop.GameLoopTime;
+                WakeNow();
             }
 
             return true;

--- a/GameServer/ai/brain/StandardMob/StandardMobState.cs
+++ b/GameServer/ai/brain/StandardMob/StandardMobState.cs
@@ -59,7 +59,7 @@ namespace DOL.AI.Brain
         public override void Enter()
         {
             _brain.Body.StopMoving();
-            _brain.NextThinkTick -= _brain.ThinkInterval; // Don't stay in IDLE for a full think cycle.
+            _brain.WakeNow(); // Don't stay in IDLE for a full think cycle.
             base.Enter();
         }
 
@@ -78,7 +78,7 @@ namespace DOL.AI.Brain
                 _brain.FSM.SetCurrentState(eFSMStateType.ROAMING);
 
             if (_brain.FSM.GetCurrentState() != this)
-                _brain.NextThinkTick -= _brain.ThinkInterval; // Don't stay in IDLE for a full think cycle.
+                _brain.WakeNow(); // Don't stay in IDLE for a full think cycle.
             else
                 base.Think();
         }


### PR DESCRIPTION
## Summary

- Move NPC brains onto the sharded schedulable service-object path so inactive brains can sleep until their next think tick instead of being scanned every game-loop tick.
- Add schedule tokens and wake helpers so stale schedule requests cannot re-sleep brains after a wake/reschedule.
- Update brain wake call sites for crowd-control expiry, idle transitions, and forced aggro-state wakes.

## Not included

- `/npcbrains` admin controls from daoc-blackthorn/blackthorn#515.
- The proximity-aggro behavior changes from daoc-blackthorn/blackthorn#515.
- Blackthorn-only region override support.

## Validation

- `dotnet build GameServer\GameServer.csproj`
- `dotnet build GameServer\GameServer.csproj --no-restore`

Both builds passed with existing repository warnings.