### PR TITLE
Add toggleable GM powers command

### DIFF
--- a/GameServer/commands/gmcommands/powers.cs
+++ b/GameServer/commands/gmcommands/powers.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Globalization;
+
+namespace DOL.GS.Commands
+{
+    [CmdAttribute(
+        "&powers",
+        ePrivLevel.GM,
+        "Toggle temporary GM powers.",
+        "/powers",
+        "/powers <god | attackable | damageboost> [on | off]",
+        "/powers damageboost [multiplier]",
+        "/powers <status | reset | help>")]
+    public class PowersCommandHandler : AbstractCommandHandler, ICommandHandler
+    {
+        private const double DefaultDamageBoost = 10.0;
+        private const double MinimumDamageBoost = 1.0;
+        private const double MaximumDamageBoost = 100.0;
+
+        public void OnCommand(GameClient client, string[] args)
+        {
+            if (client?.Player == null)
+                return;
+
+            if (IsSpammingCommand(client.Player, "Powers"))
+                return;
+
+            if (args.Length == 1 || args[1].Equals("status", StringComparison.OrdinalIgnoreCase))
+            {
+                DisplayStatus(client);
+                return;
+            }
+
+            switch (args[1].ToLowerInvariant())
+            {
+                case "god":
+                    ToggleGodMode(client, args);
+                    break;
+                case "attackable":
+                    ToggleAttackable(client, args);
+                    break;
+                case "damageboost":
+                case "damage":
+                    ToggleDamageBoost(client, args);
+                    break;
+                case "reset":
+                case "alloff":
+                    GMPowers.DisableAll(client.Player);
+                    DisplayMessage(client, "[Powers] All powers are OFF.");
+                    break;
+                case "help":
+                    DisplayHelp(client);
+                    break;
+                default:
+                    DisplayMessage(client, $"[Powers] Unknown power '{args[1]}'.");
+                    DisplayHelp(client);
+                    break;
+            }
+        }
+
+        private void ToggleGodMode(GameClient client, string[] args)
+        {
+            GMPowers powers = client.Player.GMPowers;
+
+            if (!TryGetToggleState(client, args, powers.GodModeEnabled, out bool enabled))
+                return;
+
+            powers = GMPowers.GetOrCreate(client.Player);
+            powers.GodModeEnabled = enabled;
+            GMPowers.RemoveIfInactive(client.Player);
+            string detail = enabled
+                ? "Incoming damage is still reported, but your health will not change."
+                : "Incoming damage will reduce your health normally.";
+            DisplayPowerState(client, "God mode", enabled, detail);
+        }
+
+        private void ToggleAttackable(GameClient client, string[] args)
+        {
+            GMPowers powers = client.Player.GMPowers;
+
+            if (!TryGetToggleState(client, args, powers.AttackableEnabled, out bool enabled))
+                return;
+
+            powers = GMPowers.GetOrCreate(client.Player);
+            powers.AttackableEnabled = enabled;
+            GMPowers.RemoveIfInactive(client.Player);
+            string detail = enabled
+                ? "Mobs and enemy players may attack you."
+                : "Normal staff attack protection is restored.";
+            DisplayPowerState(client, "Attackable", enabled, detail);
+        }
+
+        private void ToggleDamageBoost(GameClient client, string[] args)
+        {
+            GamePlayer player = client.Player;
+            GMPowers powers = player.GMPowers;
+
+            if (args.Length == 2)
+            {
+                if (powers.DamageBoostEnabled)
+                {
+                    powers.DisableDamageBoost();
+                    GMPowers.RemoveIfInactive(player);
+                    DisplayPowerState(client, "Damage boost", false, "Outgoing damage multiplier restored to 1.0.");
+                }
+                else
+                    EnableDamageBoost(client, DefaultDamageBoost);
+
+                return;
+            }
+
+            if (args.Length > 3)
+            {
+                DisplayMessage(client, "[Powers] Usage: /powers damageboost [on | off | multiplier]");
+                return;
+            }
+
+            string value = args[2];
+
+            if (value.Equals("on", StringComparison.OrdinalIgnoreCase))
+            {
+                EnableDamageBoost(client, powers.DamageBoostEnabled ? powers.DamageMultiplier : DefaultDamageBoost);
+                return;
+            }
+
+            if (value.Equals("off", StringComparison.OrdinalIgnoreCase))
+            {
+                powers.DisableDamageBoost();
+                GMPowers.RemoveIfInactive(player);
+                DisplayPowerState(client, "Damage boost", false, "Outgoing damage multiplier restored to 1.0.");
+                return;
+            }
+
+            if (!double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out double multiplier) ||
+                !double.IsFinite(multiplier) ||
+                multiplier < MinimumDamageBoost ||
+                multiplier > MaximumDamageBoost)
+            {
+                DisplayMessage(client, $"[Powers] Damage multiplier must be a number from {MinimumDamageBoost:0.0} to {MaximumDamageBoost:0.0}.");
+                return;
+            }
+
+            EnableDamageBoost(client, multiplier);
+        }
+
+        private void EnableDamageBoost(GameClient client, double multiplier)
+        {
+            GMPowers.GetOrCreate(client.Player).EnableDamageBoost(multiplier);
+            DisplayPowerState(client, "Damage boost", true, $"Outgoing damage multiplier is {multiplier:0.0}.");
+        }
+
+        private bool TryGetToggleState(GameClient client, string[] args, bool currentState, out bool enabled)
+        {
+            enabled = !currentState;
+
+            if (args.Length == 2)
+                return true;
+
+            if (args.Length > 3)
+            {
+                DisplayMessage(client, $"[Powers] Usage: /powers {args[1].ToLowerInvariant()} [on | off]");
+                return false;
+            }
+
+            if (args[2].Equals("on", StringComparison.OrdinalIgnoreCase))
+            {
+                enabled = true;
+                return true;
+            }
+
+            if (args[2].Equals("off", StringComparison.OrdinalIgnoreCase))
+            {
+                enabled = false;
+                return true;
+            }
+
+            DisplayMessage(client, $"[Powers] Expected 'on' or 'off', not '{args[2]}'.");
+            return false;
+        }
+
+        private void DisplayStatus(GameClient client)
+        {
+            GMPowers powers = client.Player.GMPowers;
+            DisplayMessage(client, "[Powers] Currently enabled:");
+
+            bool anyEnabled = false;
+
+            if (powers.GodModeEnabled)
+            {
+                DisplayMessage(client, "  - God mode (damage is reported but ignored)");
+                anyEnabled = true;
+            }
+
+            if (powers.DamageBoostEnabled)
+            {
+                DisplayMessage(client, $"  - Damage boost ({powers.DamageMultiplier:0.0}x outgoing damage)");
+                anyEnabled = true;
+            }
+
+            if (powers.AttackableEnabled)
+            {
+                DisplayMessage(client, "  - Attackable (mobs and enemy players can attack you)");
+                anyEnabled = true;
+            }
+
+            if (!anyEnabled)
+                DisplayMessage(client, "  None");
+
+            DisplayMessage(client, "Use /powers help for commands.");
+        }
+
+        private void DisplayHelp(GameClient client)
+        {
+            DisplayMessage(client, "[Powers] Available commands:");
+            DisplayMessage(client, "  /powers god [on|off] - take no damage while retaining damage messages");
+            DisplayMessage(client, "  /powers damageboost [on|off|multiplier] - multiply outgoing damage (default 10.0)");
+            DisplayMessage(client, "  /powers attackable [on|off] - allow mobs and enemy players to attack you");
+            DisplayMessage(client, "  /powers - show enabled powers");
+            DisplayMessage(client, "  /powers reset - turn every power off");
+        }
+
+        private void DisplayPowerState(GameClient client, string name, bool enabled, string detail)
+        {
+            DisplayMessage(client, $"[Powers] {name} {(enabled ? "ON" : "OFF")}. {detail}");
+        }
+    }
+}

--- a/GameServer/gameobjects/GMPowers.cs
+++ b/GameServer/gameobjects/GMPowers.cs
@@ -1,0 +1,112 @@
+namespace DOL.GS
+{
+    /// <summary>
+    /// Session-only powers enabled for a GM player.
+    /// </summary>
+    public abstract class GMPowers
+    {
+        /// <summary>
+        /// Shared null object used by players who have no powers enabled.
+        /// </summary>
+        public static GMPowers None => GMPowersFacade.Instance;
+
+        public abstract bool GodModeEnabled { get; set; }
+        public abstract bool AttackableEnabled { get; set; }
+        public abstract bool DamageBoostEnabled { get; set; }
+        public abstract double DamageMultiplier { get; set; }
+
+        internal void EnableDamageBoost(double multiplier)
+        {
+            DamageBoostEnabled = true;
+            DamageMultiplier = multiplier;
+        }
+
+        internal void DisableDamageBoost()
+        {
+            DamageBoostEnabled = false;
+            DamageMultiplier = 1.0;
+        }
+
+        internal static GMPowers GetOrCreate(GamePlayer player)
+        {
+            GMPowers powers = player.GMPowers;
+
+            if (ReferenceEquals(powers, None))
+            {
+                powers = new PlayerGMPowers();
+                player.GMPowers = powers;
+            }
+
+            return powers;
+        }
+
+        internal static void RemoveIfInactive(GamePlayer player)
+        {
+            if (!player.GMPowers.AnyEnabled)
+                player.GMPowers = None;
+        }
+
+        internal static void DisableAll(GamePlayer player)
+        {
+            GMPowers powers = player.GMPowers;
+            powers.GodModeEnabled = false;
+            powers.AttackableEnabled = false;
+            powers.DisableDamageBoost();
+            player.GMPowers = None;
+        }
+
+        private bool AnyEnabled => GodModeEnabled || AttackableEnabled || DamageBoostEnabled;
+    }
+
+    /// <summary>
+    /// Null-object facade returned when a player has no GM powers enabled.
+    /// </summary>
+    internal sealed class GMPowersFacade : GMPowers
+    {
+        internal static GMPowersFacade Instance { get; } = new();
+
+        private GMPowersFacade()
+        {
+        }
+
+        public override bool GodModeEnabled { get => false; set { } }
+        public override bool AttackableEnabled { get => false; set { } }
+        public override bool DamageBoostEnabled { get => false; set { } }
+        public override double DamageMultiplier { get => 1.0; set { } }
+    }
+
+    /// <summary>
+    /// Mutable power state belonging to one player.
+    /// </summary>
+    internal sealed class PlayerGMPowers : GMPowers
+    {
+        private volatile bool _godModeEnabled;
+        private volatile bool _attackableEnabled;
+        private volatile bool _damageBoostEnabled;
+        private double _damageMultiplier = 1.0;
+
+        public override bool GodModeEnabled
+        {
+            get => _godModeEnabled;
+            set => _godModeEnabled = value;
+        }
+
+        public override bool AttackableEnabled
+        {
+            get => _attackableEnabled;
+            set => _attackableEnabled = value;
+        }
+
+        public override bool DamageBoostEnabled
+        {
+            get => _damageBoostEnabled;
+            set => _damageBoostEnabled = value;
+        }
+
+        public override double DamageMultiplier
+        {
+            get => _damageMultiplier;
+            set => _damageMultiplier = value;
+        }
+    }
+}

--- a/GameServer/gameobjects/GameLiving.cs
+++ b/GameServer/gameobjects/GameLiving.cs
@@ -1333,6 +1333,13 @@ namespace DOL.GS
 		/// <param name="criticalAmount">the amount of critical damage</param>
 		public override void TakeDamage(GameObject source, eDamageType damageType, int damageAmount, int criticalAmount)
 		{
+			if (source is GamePlayer playerSource)
+			{
+				double damageMultiplier = playerSource.GMPowers.DamageMultiplier;
+				damageAmount = ApplyDamageMultiplier(damageAmount, damageMultiplier);
+				criticalAmount = ApplyDamageMultiplier(criticalAmount, damageMultiplier);
+			}
+
 			base.TakeDamage(source, damageType, damageAmount, criticalAmount);
 
 			double damageDealt = damageAmount + criticalAmount;
@@ -1415,6 +1422,14 @@ namespace DOL.GS
 					_dieLock.Exit();
 				}
 			}
+		}
+
+		private static int ApplyDamageMultiplier(int damage, double multiplier)
+		{
+			if (damage <= 0 || multiplier == 1.0)
+				return damage;
+
+			return (int) Math.Min(int.MaxValue, damage * multiplier);
 		}
 
 		private readonly Lock _dieLock = new();

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -254,10 +254,28 @@ namespace DOL.GS
             }
         }
 
+        private GMPowers m_gmPowers;
+
+        /// <summary>
+        /// Gets this player's enabled GM powers, or a shared null object when none are enabled.
+        /// </summary>
+        public GMPowers GMPowers
+        {
+            get { return m_gmPowers ?? DOL.GS.GMPowers.None; }
+            internal set { m_gmPowers = ReferenceEquals(value, DOL.GS.GMPowers.None) ? null : value; }
+        }
+
         /// <summary>
         /// Whether or not the player can be attacked.
         /// </summary>
-        public override bool IsAttackable { get { return (Client.Account.PrivLevel <= (uint)ePrivLevel.Player && base.IsAttackable); }}
+        public override bool IsAttackable
+        {
+            get
+            {
+                bool privilegeAllowsAttacks = Client.Account.PrivLevel <= (uint)ePrivLevel.Player || GMPowers.AttackableEnabled;
+                return privilegeAllowsAttacks && base.IsAttackable;
+            }
+        }
 
         /// <summary>
         /// Can this player use cross realm items
@@ -5289,7 +5307,14 @@ namespace DOL.GS
             if (Duel != null && !IsDuelPartner(source as GameLiving))
                 Duel.Stop();
 
-            base.TakeDamage(source, damageType, damageAmount, criticalAmount);
+            if (GMPowers.GodModeEnabled)
+            {
+                // Combat messages are sent by OnAttackedByEnemy before this method is called.
+                // Still publish the damage event for scripts and effects, but do not change health.
+                Notify(GameObjectEvent.TakeDamage, this, new TakeDamageEventArgs(source, damageType, damageAmount, criticalAmount));
+            }
+            else
+                base.TakeDamage(source, damageType, damageAmount, criticalAmount);
 
             if (HasAbility(Abilities.DefensiveCombatPowerRegeneration))
                 Mana += (int)((damageAmount + criticalAmount) * 0.25);

--- a/GameServer/serverrules/AbstractServerRules.cs
+++ b/GameServer/serverrules/AbstractServerRules.cs
@@ -391,8 +391,8 @@ namespace DOL.GS.ServerRules
                 }
             }
 
-            // GMs can't be attacked
-            if (playerDefender != null && playerDefender.Client.Account.PrivLevel > 1)
+            // GMs can't be attacked unless they explicitly enable the attackable power.
+            if (playerDefender != null && playerDefender.Client.Account.PrivLevel > 1 && !playerDefender.GMPowers.AttackableEnabled)
                 return false;
 
             //flame - Commenting out Safe Area check as it was causing lots of lock contention in the GetAreasOfSpot() code. We currently dont have safe-areas so this doesnt affect anything


### PR DESCRIPTION
## Summary

- add a GM-only `/powers` command with toggles for god mode, outgoing damage boost, and attackability
- preserve incoming damage messages while god mode prevents health loss
- multiply outgoing normal and critical damage by 10.0 by default, with optional custom multipliers
- apply the outgoing multiplier centrally in `GameLiving.TakeDamage` without changing player `Effectiveness`
- allow hostile mobs and enemy players through the existing GM attack protections when attackable mode is enabled
- add status, explicit on/off controls, help, and reset commands
- group session-only state behind the abstract `GMPowers` contract exposed through `player.GMPowers`
- use separate `PlayerGMPowers` and `GMPowersFacade` implementations so the shared null object has only false/default getters and no-op setters

## Why

Staff need a convenient, session-scoped way to test combat interactions without manually changing account state or multiple unrelated settings. `GamePlayer` gains only one nullable backing field; its `GMPowers` facade safely returns the stateless null-object implementation until a power is enabled. Damage boost uses dedicated power state rather than `Effectiveness`, so resurrection illness, weapon skill, concentration, buffs, and other effectiveness-based systems remain untouched.

## Impact

The powers are available only to GM-level accounts and are not persisted across sessions. A real per-player state object is created only when needed, and the backing field returns to null when no powers remain. Existing GM protection remains unchanged unless `/powers attackable` is explicitly enabled.

## Validation

- based on the latest `OpenDAoC/master`
- `dotnet restore GameServer/GameServer.csproj`
- `dotnet build GameServer/GameServer.csproj --no-restore --nologo -v:minimal`
- build succeeded with 0 errors; existing project warnings remain