### PR TITLE
`invalidnames`: Relax ban on 'Sapph'

### DIFF
--- a/GameServer/config/invalidnames.txt
+++ b/GameServer/config/invalidnames.txt
@@ -313,7 +313,7 @@ rump
 saddam
 sadism
 sadist
-sapph
+sapphic
 satan
 scheis
 schlong


### PR DESCRIPTION
I spent some (way too much) time figuring out why `Sapph` might be part of the invalid names list, and all I found is that it could be a target ban on sapphic, as the list contains a number of other LGBT+ terms.
Disregarding that can of worms, I couldn't find any other languages where it might be problematic, and sapphic itself is already fairly milquetoast.

I'm assuming the original author imported a list of terms from some 3rd party, and axed kick-ass names like `Sapphire` along with it.

FWIW Blackthorn already has poor souls running around with misspelled names to get around this. Set them free.

<img width="181" height="170" alt="image" src="https://github.com/user-attachments/assets/be5cc80c-254e-44c4-9479-04d75890d6e9" />