### PR TITLE
Query pre-cached objects in SelectObjects

### DIFF
--- a/CoreDatabase/DataTableHandler.cs
+++ b/CoreDatabase/DataTableHandler.cs
@@ -25,6 +25,7 @@ namespace DOL.Database
 		/// Pre Cache Directory Handler
 		/// </summary>
 		private readonly ConcurrentDictionary<object, DataObject> _precache;
+		private readonly Dictionary<string, ElementBinding> _fieldBindingsByColumn;
 		/// <summary>
 		/// Uses Precaching
 		/// </summary>
@@ -113,6 +114,7 @@ namespace DOL.Database
 
 			// Cache final derived collections once ElementBindings is settled.
 			FieldElementBindings = ElementBindings.Where(static bind => bind.Relation == null).ToArray();
+			_fieldBindingsByColumn = FieldElementBindings.ToDictionary(bind => bind.ColumnName, StringComparer.OrdinalIgnoreCase);
 			UpdateElementBindings = FieldElementBindings.Where(static bind => bind.PrimaryKey == null && bind.ReadOnly == null).ToArray();
 			LastUpdatedBinding = UpdateElementBindings.FirstOrDefault(static bind => bind.ColumnName == nameof(DataObject.LastTimeRowUpdated));
 
@@ -183,6 +185,13 @@ namespace DOL.Database
 		}
 		
 		#region PreCache Handling
+		internal ElementBinding GetFieldBinding(string columnName)
+		{
+			return _fieldBindingsByColumn.TryGetValue(columnName, out ElementBinding binding)
+				? binding
+				: throw new DatabaseException($"Column {columnName} is not mapped on table {TableName}.");
+		}
+
 		/// <summary>
 		/// Set Pre-Cached Object
 		/// </summary>
@@ -238,6 +247,14 @@ namespace DOL.Database
 		public IEnumerable<DataObject> SearchPreCachedObjects(Func<DataObject, bool> whereClause)
 		{
 			return _precache.Where(kv => whereClause(kv.Value)).Select(kv => kv.Value);
+		}
+
+		/// <summary>
+		/// Query the pre-cache using the same structured query used by SelectObjects.
+		/// </summary>
+		public IEnumerable<DataObject> SelectPreCachedObjects(WhereClause whereClause)
+		{
+			return whereClause.ApplyToPreCache(this, _precache.Values);
 		}
 		#endregion
 	}

--- a/CoreDatabase/ObjectDatabase.cs
+++ b/CoreDatabase/ObjectDatabase.cs
@@ -771,6 +771,7 @@ namespace DOL.Database
 			where TObject : DataObject
 		{
 			if (whereClauseBatch == null) throw new ArgumentNullException("Parameter whereClauseBatch may not be null.");
+			WhereClause[] whereClauses = whereClauseBatch.ToArray();
 
 			var tableHandler = GetTableOrViewHandler(typeof(TObject));
 			if (tableHandler == null)
@@ -781,7 +782,9 @@ namespace DOL.Database
 				throw new DatabaseException(string.Format("Table {0} is not registered for Database Connection...", typeof(TObject).FullName));
 			}
 
-			var objs = MultipleSelectObjectsImpl(tableHandler, whereClauseBatch).Select(res => res.OfType<TObject>().ToList()).ToList();
+			var objs = tableHandler.UsesPreCaching
+				? whereClauses.Select(whereClause => tableHandler.SelectPreCachedObjects(whereClause).OfType<TObject>().ToList()).ToList()
+				: MultipleSelectObjectsImpl(tableHandler, whereClauses).Select(res => res.OfType<TObject>().ToList()).ToList();
 
 			FillObjectRelations(objs.SelectMany(obj => obj), false);
 

--- a/CoreDatabase/WhereClause.cs
+++ b/CoreDatabase/WhereClause.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Text;
 
 namespace DOL.Database
@@ -11,6 +13,46 @@ namespace DOL.Database
         private QueryParameter[] _parameters;
 
         internal abstract List<IAtom> IntermediateRepresentation { get; }
+        internal abstract bool MatchesPreCachedObject(DataTableHandler tableHandler, DataObject dataObject);
+
+        internal virtual IEnumerable<DataObject> ApplyToPreCache(DataTableHandler tableHandler, IEnumerable<DataObject> source)
+        {
+            return source.Where(dataObject => MatchesPreCachedObject(tableHandler, dataObject));
+        }
+
+        protected static ElementBinding GetBinding(DataTableHandler tableHandler, string columnName)
+        {
+            return tableHandler.GetFieldBinding(columnName);
+        }
+
+        protected static object ConvertValue(object value, Type targetType)
+        {
+            if (value == null)
+                return null;
+
+            Type effectiveType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+
+            if (effectiveType.IsInstanceOfType(value))
+                return value;
+
+            if (effectiveType.IsEnum)
+                return value is string text ? Enum.Parse(effectiveType, text, true) : Enum.ToObject(effectiveType, value);
+
+            return Convert.ChangeType(value, effectiveType, CultureInfo.InvariantCulture);
+        }
+
+        protected static bool ValuesEqual(object left, object right, Type valueType)
+        {
+            if (left == null || right == null)
+                return false;
+
+            right = ConvertValue(right, valueType);
+
+            if (left is string leftString && right is string rightString)
+                return leftString.Equals(rightString, StringComparison.OrdinalIgnoreCase);
+
+            return left.Equals(right);
+        }
         public static WhereClause Empty => EmptyWhereClause.Instance;
 
         public virtual string ParameterizedText
@@ -115,6 +157,8 @@ namespace DOL.Database
 
         private EmptyWhereClause() { }
 
+        internal override bool MatchesPreCachedObject(DataTableHandler tableHandler, DataObject dataObject) => true;
+
         public override WhereClause And(WhereClause rightExpression)
         {
             return rightExpression;
@@ -141,6 +185,7 @@ namespace DOL.Database
         private readonly string _columnName;
         private readonly string _op;
         private readonly T _val;
+        private Regex _likeRegex;
 
         internal override List<IAtom> IntermediateRepresentation =>
         [
@@ -154,6 +199,44 @@ namespace DOL.Database
             _columnName = columnName;
             _op = op;
             _val = val;
+        }
+
+        internal override bool MatchesPreCachedObject(DataTableHandler tableHandler, DataObject dataObject)
+        {
+            ElementBinding binding = GetBinding(tableHandler, _columnName);
+            object left = binding.GetValue(dataObject);
+            object right = _val;
+
+            if (left == null || right == null)
+                return false;
+
+            right = ConvertValue(right, binding.ValueType);
+
+            if (_op == "=")
+                return ValuesEqual(left, right, binding.ValueType);
+
+            if (_op == "!=")
+                return !ValuesEqual(left, right, binding.ValueType);
+
+            if (_op == "LIKE")
+            {
+                _likeRegex ??= new Regex("^" + Regex.Escape(right.ToString()).Replace("%", ".*").Replace("_", ".") + "$",
+                    RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+                return _likeRegex.IsMatch(left.ToString());
+            }
+
+            if (left is not IComparable comparable)
+                throw new DatabaseException($"Column {_columnName} cannot be compared with operator {_op}.");
+
+            int comparison = comparable.CompareTo(right);
+            return _op switch
+            {
+                ">" => comparison > 0,
+                ">=" => comparison >= 0,
+                "<" => comparison < 0,
+                "<=" => comparison <= 0,
+                _ => throw new DatabaseException($"Unsupported pre-cache query operator {_op}.")
+            };
         }
 
         public override bool Equals(object obj)
@@ -183,6 +266,12 @@ namespace DOL.Database
         {
             _columnName = columnName;
             _op = op;
+        }
+
+        internal override bool MatchesPreCachedObject(DataTableHandler tableHandler, DataObject dataObject)
+        {
+            object value = GetBinding(tableHandler, _columnName).GetValue(dataObject);
+            return _op == "IS NULL" ? value == null : value != null;
         }
 
         public override bool Equals(object obj)
@@ -243,6 +332,14 @@ namespace DOL.Database
             }
         }
 
+        internal override bool MatchesPreCachedObject(DataTableHandler tableHandler, DataObject dataObject)
+        {
+            ElementBinding binding = GetBinding(tableHandler, _columnName);
+            object value = binding.GetValue(dataObject);
+            _valueList ??= _val.ToList();
+            return value != null && _valueList.Any(candidate => ValuesEqual(value, candidate, binding.ValueType));
+        }
+
         public override bool Equals(object obj)
         {
             if (obj is not InExpression<T> other)
@@ -288,6 +385,13 @@ namespace DOL.Database
             _left = left;
             _right = right;
             _chainingOperator = chainingOperator;
+        }
+
+        internal override bool MatchesPreCachedObject(DataTableHandler tableHandler, DataObject dataObject)
+        {
+            return _chainingOperator == "AND"
+                ? _left.MatchesPreCachedObject(tableHandler, dataObject) && _right.MatchesPreCachedObject(tableHandler, dataObject)
+                : _left.MatchesPreCachedObject(tableHandler, dataObject) || _right.MatchesPreCachedObject(tableHandler, dataObject);
         }
 
         public override bool Equals(object obj)
@@ -340,6 +444,22 @@ namespace DOL.Database
             _limit = limit;
         }
 
+        internal override bool MatchesPreCachedObject(DataTableHandler tableHandler, DataObject dataObject)
+        {
+            return _left.MatchesPreCachedObject(tableHandler, dataObject);
+        }
+
+        internal override IEnumerable<DataObject> ApplyToPreCache(DataTableHandler tableHandler, IEnumerable<DataObject> source)
+        {
+            ElementBinding binding = GetBinding(tableHandler, _column.Name);
+            IEnumerable<DataObject> filtered = source.Where(dataObject => _left.MatchesPreCachedObject(tableHandler, dataObject));
+            IEnumerable<DataObject> ordered = _descending
+                ? filtered.OrderByDescending(binding.GetValue, PreCacheValueComparer.Instance)
+                : filtered.OrderBy(binding.GetValue, PreCacheValueComparer.Instance);
+
+            return _limit > 0 ? ordered.Take(_limit) : ordered;
+        }
+
         public override bool Equals(object obj)
         {
             if (obj is not OrderLimitExpression other)
@@ -354,6 +474,21 @@ namespace DOL.Database
         public override int GetHashCode()
         {
             throw new NotImplementedException();
+        }
+    }
+
+    internal sealed class PreCacheValueComparer : IComparer<object>
+    {
+        public static readonly PreCacheValueComparer Instance = new();
+
+        public int Compare(object left, object right)
+        {
+            if (ReferenceEquals(left, right)) return 0;
+            if (left == null) return -1;
+            if (right == null) return 1;
+            if (left is string leftString && right is string rightString)
+                return StringComparer.OrdinalIgnoreCase.Compare(leftString, rightString);
+            return ((IComparable)left).CompareTo(right);
         }
     }
 

--- a/Tests/UnitTests/UT_PreCacheSelect.cs
+++ b/Tests/UnitTests/UT_PreCacheSelect.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.IO;
+using System.Linq;
+using DOL.Database;
+using DOL.Database.Attributes;
+using DOL.Database.Handlers;
+using NUnit.Framework;
+
+namespace DOL.Tests.UnitTests;
+
+[TestFixture]
+public class UT_PreCacheSelect
+{
+    private string _databaseFile;
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (File.Exists(_databaseFile))
+            File.Delete(_databaseFile);
+    }
+
+    [Test]
+    public void SelectObjects_QueriesPreCacheWithoutDatabaseAccess()
+    {
+        CountingSqliteObjectDatabase database = CreateDatabase();
+        Seed(database);
+        database.ResetConnectionCount();
+
+        List<PreCachedSelectObject> selected = database.SelectObjects<PreCachedSelectObject>(
+            DB.Column(nameof(PreCachedSelectObject.GroupId)).IsEqualTo("GROUP-1")
+                .And(DB.Column(nameof(PreCachedSelectObject.Value)).IsLike("value-%"))
+                .OrderBy(DB.Column(nameof(PreCachedSelectObject.Id)), descending: true, limit: 1));
+        List<PreCachedSelectObject> nonNullValues = database.SelectObjects<PreCachedSelectObject>(
+            DB.Column(nameof(PreCachedSelectObject.Value)).IsNotNull());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(selected.Select(item => item.Id), Is.EqualTo(new[] { "item-b" }));
+            Assert.That(nonNullValues.Select(item => item.Id), Is.EquivalentTo(new[] { "item-a", "item-b" }));
+            Assert.That(database.ConnectionCount, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void MultipleSelectObjects_QueriesPreCacheInBatchOrder()
+    {
+        CountingSqliteObjectDatabase database = CreateDatabase();
+        Seed(database);
+        database.ResetConnectionCount();
+
+        List<List<PreCachedSelectObject>> selected = database.MultipleSelectObjects<PreCachedSelectObject>(
+        [
+            DB.Column(nameof(PreCachedSelectObject.Id)).IsIn(new[] { "item-b" }),
+            DB.Column(nameof(PreCachedSelectObject.GroupId)).IsEqualTo("group-1")
+        ]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(selected[0].Select(item => item.Id), Is.EqualTo(new[] { "item-b" }));
+            Assert.That(selected[1].Select(item => item.Id), Is.EquivalentTo(new[] { "item-a", "item-b" }));
+            Assert.That(database.ConnectionCount, Is.Zero);
+        });
+    }
+
+    private CountingSqliteObjectDatabase CreateDatabase()
+    {
+        _databaseFile = Path.Combine(Path.GetTempPath(), $"dol-precache-select-{Guid.NewGuid():N}.sqlite");
+        CountingSqliteObjectDatabase database = new($"Data Source={_databaseFile};Version=3;Pooling=False");
+        database.RegisterDataObject(typeof(PreCachedSelectObject));
+        return database;
+    }
+
+    private static void Seed(IObjectDatabase database)
+    {
+        Assert.That(database.AddObject(new DataObject[]
+        {
+            new PreCachedSelectObject { Id = "item-a", GroupId = "group-1", Value = "value-a" },
+            new PreCachedSelectObject { Id = "item-b", GroupId = "group-1", Value = "value-b" }
+        }), Is.True);
+    }
+
+    private sealed class CountingSqliteObjectDatabase : SqliteObjectDatabase
+    {
+        public int ConnectionCount { get; private set; }
+
+        public CountingSqliteObjectDatabase(string connectionString) : base(connectionString) { }
+
+        public void ResetConnectionCount() => ConnectionCount = 0;
+
+        protected override void OpenConnection(DbConnection connection)
+        {
+            ConnectionCount++;
+            base.OpenConnection(connection);
+        }
+    }
+}
+
+[DataTable(TableName = "PreCachedSelectObject", PreCache = true)]
+public class PreCachedSelectObject : DataObject
+{
+    [PrimaryKey]
+    public string Id { get; set; }
+
+    [DataElement(AllowDbNull = false, Index = true)]
+    public string GroupId { get; set; }
+
+    [DataElement(AllowDbNull = false)]
+    public string Value { get; set; }
+}


### PR DESCRIPTION
﻿## What changed

- route `SelectObjects` and `MultipleSelectObjects` queries to the in-memory pre-cache for tables with `PreCache = true`
- evaluate structured `WhereClause` expressions against cached objects, including comparisons, `AND`/`OR`, `IN`, `LIKE`, null checks, ordering, and limits
- cache column-to-binding lookups and reuse LIKE matchers to keep cached filtering efficient
- add focused tests proving query results are correct and incur zero database connections

## Why

Previously, `UsesPreCaching` only affected key lookups and select-all calls. Filtered `SelectObjects` calls still queried the database even though the complete table was already held in memory. This makes filtered and batched selects consistently honor the pre-cache and avoids unnecessary database round trips.

## Validation

- `dotnet build Tests/Tests.csproj -c Release -p:RunPostBuildEvent=Never`
- `dotnet test Tests/Tests.csproj -c Release --no-build --filter FullyQualifiedName~UT_PreCacheSelect` (2 passed)
