### PR TITLE
Scripted Mob shared variable cleanup

### DIFF
--- a/GameServer/ai/brain/Special/EncounterKillCounter.cs
+++ b/GameServer/ai/brain/Special/EncounterKillCounter.cs
@@ -1,52 +1,39 @@
 using System;
-using DOL.GS;
+using System.Threading;
 
 namespace DOL.AI.Brain
 {
-    /// <summary>
-    /// Implemented by brains that gate an encounter behind a number of add kills.
-    /// </summary>
     public interface IEncounterGateOwner
     {
         EncounterKillCounter GateCounter { get; }
     }
 
-    /// <summary>
-    /// Tracks how many adds of a given gate have died.
-    /// </summary>
     public sealed class EncounterKillCounter
     {
         private readonly Action<int, int> _onProgress;
+        private int _kills;
 
-        public EncounterKillCounter(string gateId, int requiredKills, Action<int, int> onProgress = null)
+        public EncounterKillCounter(int requiredKills, Action<int, int> onProgress = null)
         {
-            GateId = gateId;
             RequiredKills = requiredKills;
             _onProgress = onProgress;
         }
 
-        public string GateId { get; }
         public int RequiredKills { get; }
-        public int Kills { get; private set; }
+        public int Kills => Volatile.Read(ref _kills);
         public bool IsOpen => Kills >= RequiredKills;
 
         public void Reset()
         {
-            Kills = 0;
+            Interlocked.Exchange(ref _kills, 0);
         }
 
-        public static void NotifyDeath(EncounterGateAdd add)
+        public void IncrementKills()
         {
-            foreach (GameNPC npc in add.GetNPCsInRadius(add.GateNotifyRadius))
-            {
-                if (npc.Brain is IEncounterGateOwner owner && owner.GateCounter is EncounterKillCounter counter && counter.GateId == add.GateId)
-                {
-                    counter.Kills++;
+            int newKills = Interlocked.Increment(ref _kills);
 
-                    if (!counter.IsOpen)
-                        counter._onProgress?.Invoke(counter.Kills, counter.RequiredKills);
-                }
-            }
+            if (newKills < RequiredKills)
+                _onProgress?.Invoke(newKills, RequiredKills);
         }
     }
 }

--- a/GameServer/gameobjects/EncounterGateAdd.cs
+++ b/GameServer/gameobjects/EncounterGateAdd.cs
@@ -2,21 +2,37 @@ using DOL.AI.Brain;
 
 namespace DOL.GS
 {
-    /// <summary>
-    /// An add whose death is reported to every nearby brain owning a matching encounter gate counter.
-    /// </summary>
     public abstract class EncounterGateAdd : GameNPC
     {
-        public virtual string GateId => PackageID;
-        public virtual ushort GateNotifyRadius => 4000;
+        private EncounterKillCounter _counter;
+
         protected virtual bool CountsTowardGate => true;
 
-        public override void Die(GameObject killer)
+        protected virtual bool IsGateOwner(GameNPC npc) => npc.Brain is IEncounterGateOwner;
+
+        public override bool AddToWorld()
+        {
+            if (!base.AddToWorld())
+                return false;
+
+            foreach (GameNPC npc in GetNPCsInRadius(4000))
+            {
+                if (IsGateOwner(npc) && npc.Brain is IEncounterGateOwner owner)
+                {
+                    _counter = owner.GateCounter;
+                    break;
+                }
+            }
+
+            return true;
+        }
+
+        public override void ProcessDeath(GameObject killer)
         {
             if (CountsTowardGate)
-                EncounterKillCounter.NotifyDeath(this);
+                _counter?.IncrementKills();
 
-            base.Die(killer);
+            base.ProcessDeath(killer);
         }
     }
 }

--- a/GameServer/gameobjects/EncounterGateAdd.cs
+++ b/GameServer/gameobjects/EncounterGateAdd.cs
@@ -4,33 +4,35 @@ namespace DOL.GS
 {
     public abstract class EncounterGateAdd : GameNPC
     {
-        private EncounterKillCounter _counter;
+        protected const ushort GATE_OWNER_SEARCH_RADIUS = 4000;
+
+        private GameNPC _gateOwner;
 
         protected virtual bool CountsTowardGate => true;
 
-        protected virtual bool IsGateOwner(GameNPC npc) => npc.Brain is IEncounterGateOwner;
-
-        public override bool AddToWorld()
-        {
-            if (!base.AddToWorld())
-                return false;
-
-            foreach (GameNPC npc in GetNPCsInRadius(4000))
-            {
-                if (IsGateOwner(npc) && npc.Brain is IEncounterGateOwner owner)
-                {
-                    _counter = owner.GateCounter;
-                    break;
-                }
-            }
-
-            return true;
-        }
+        protected abstract bool IsGateOwner(GameNPC npc);
 
         public override void ProcessDeath(GameObject killer)
         {
             if (CountsTowardGate)
-                _counter?.IncrementKills();
+            {
+                if (_gateOwner == null || _gateOwner.ObjectState is not eObjectState.Active || !IsGateOwner(_gateOwner))
+                {
+                    _gateOwner = null;
+
+                    foreach (GameNPC npc in GetNPCsInRadius(GATE_OWNER_SEARCH_RADIUS))
+                    {
+                        if (IsGateOwner(npc) && npc.Brain is IEncounterGateOwner)
+                        {
+                            _gateOwner = npc;
+                            break;
+                        }
+                    }
+                }
+
+                if (_gateOwner?.Brain is IEncounterGateOwner owner)
+                    owner.GateCounter?.IncrementKills();
+            }
 
             base.ProcessDeath(killer);
         }

--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -1927,7 +1927,7 @@ namespace DOL.GS
 			Brain?.Start();
 
 			if (Brain is IEncounterGateOwner gateOwner)
-				gateOwner.GateCounter.Reset();
+				gateOwner.GateCounter?.Reset();
 
 			if (Mana <= 0 && MaxMana > 0)
 				Mana = MaxMana;

--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -1926,6 +1926,9 @@ namespace DOL.GS
 
 			Brain?.Start();
 
+			if (Brain is IEncounterGateOwner gateOwner)
+				gateOwner.GateCounter.Reset();
+
 			if (Mana <= 0 && MaxMana > 0)
 				Mana = MaxMana;
 			else if (Mana > 0 && MaxMana > 0 && Mana < MaxMana)

--- a/GameServer/scripts/mobs/AlbionMobs/Throatripper.cs
+++ b/GameServer/scripts/mobs/AlbionMobs/Throatripper.cs
@@ -32,7 +32,7 @@ namespace DOL.AI.Brain
 			AggroLevel = 80;
 			AggroRange = 400;
 			ThinkInterval = 1000;
-			GateCounter = new("ThroatripperGate", 10, (kills, required) =>
+			GateCounter = new(10, (kills, required) =>
 			{
 				if (kills == required / 2)
 					Message.MessageToArea(Body, "Distant howls answer one another in the dark.", eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow, WorldMgr.VISIBILITY_DISTANCE);
@@ -72,7 +72,7 @@ namespace DOL.GS
 	{
 		public ThroatripperAdd() : base() { }
 
-		public override string GateId => "ThroatripperGate";
+		protected override bool IsGateOwner(GameNPC npc) => npc is Throatripper;
 		protected override bool CountsTowardGate => CurrentRegion.IsNightTime;
 
 		public override bool AddToWorld()

--- a/GameServer/scripts/mobs/MidgardMobs/QueenMajor.cs
+++ b/GameServer/scripts/mobs/MidgardMobs/QueenMajor.cs
@@ -32,7 +32,7 @@ namespace DOL.AI.Brain
 			AggroLevel = 80;
 			AggroRange = 400;
 			ThinkInterval = 1000;
-			GateCounter = new("QueenMajorGate", 20, (kills, required) =>
+			GateCounter = new(20, (kills, required) =>
 			{
 				if (kills == required / 2)
 					Message.MessageToArea(Body, "An angry buzz rises from the nest below.", eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow, WorldMgr.VISIBILITY_DISTANCE);
@@ -66,7 +66,7 @@ namespace DOL.GS
 	{
 		public QueenMajorAdd() : base() { }
 
-		public override string GateId => "QueenMajorGate";
+		protected override bool IsGateOwner(GameNPC npc) => npc is QueenMajor;
 
 		public override bool AddToWorld()
 		{

--- a/GameServer/scripts/mobs/MidgardMobs/Snarls.cs
+++ b/GameServer/scripts/mobs/MidgardMobs/Snarls.cs
@@ -34,7 +34,7 @@ namespace DOL.AI.Brain
 			ThinkInterval = 1000;
 		}
 
-		public EncounterKillCounter GateCounter { get; } = new("SnarlsGate", 3);
+		public EncounterKillCounter GateCounter { get; } = new(3);
 
 		public override void Think()
 		{
@@ -56,7 +56,7 @@ namespace DOL.GS
 	{
 		public SnarlsAdd() : base() { }
 
-		public override string GateId => "SnarlsGate";
+		protected override bool IsGateOwner(GameNPC npc) => npc is Snarls;
 
 		public override bool AddToWorld()
 		{

--- a/GameServer/scripts/mobs/MidgardMobs/Stripe.cs
+++ b/GameServer/scripts/mobs/MidgardMobs/Stripe.cs
@@ -32,7 +32,7 @@ namespace DOL.AI.Brain
 			AggroLevel = 50;
 			AggroRange = 300;
 			ThinkInterval = 1000;
-			GateCounter = new("StripeGate", 20, (kills, required) =>
+			GateCounter = new(20, (kills, required) =>
 			{
 				if (kills == required / 2)
 					Message.MessageToArea(Body, "The grass sways! Something big is circling closer...", eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow, WorldMgr.VISIBILITY_DISTANCE);
@@ -61,7 +61,7 @@ namespace DOL.GS
 	{
 		public StripeAdd() : base() { }
 
-		public override string GateId => "StripeGate";
+		protected override bool IsGateOwner(GameNPC npc) => npc is Stripe;
 
 		public override bool AddToWorld()
 		{

--- a/GameServer/scripts/mobs/MidgardMobs/Zrit-Zrit.cs
+++ b/GameServer/scripts/mobs/MidgardMobs/Zrit-Zrit.cs
@@ -32,7 +32,7 @@ namespace DOL.AI.Brain
 			AggroLevel = 50;
 			AggroRange = 300;
 			ThinkInterval = 1000;
-			GateCounter = new("ZritZritGate", 20, (kills, required) =>
+			GateCounter = new(20, (kills, required) =>
 			{
 				if (kills == required / 2)
 					Message.MessageToArea(Body, "Furious chittering echoes from the cracks in the rock.", eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow, WorldMgr.VISIBILITY_DISTANCE);
@@ -61,7 +61,7 @@ namespace DOL.GS
 	{
 		public ZritZritAdd() : base() { }
 
-		public override string GateId => "ZritZritGate";
+		protected override bool IsGateOwner(GameNPC npc) => npc is ZritZrit;
 
 		public override bool AddToWorld()
 		{

--- a/GameServer/scripts/namedmobs/Albion Named Mobs/Classic Zones/MorganaBechardSilcharde.cs
+++ b/GameServer/scripts/namedmobs/Albion Named Mobs/Classic Zones/MorganaBechardSilcharde.cs
@@ -578,6 +578,18 @@ namespace DOL.GS
 		public MorganaBrain OwnerBrain;
 		public override void ProcessDeath(GameObject killer)
 		{
+			if (OwnerBrain == null || OwnerBrain.Body == null || OwnerBrain.Body.Brain != OwnerBrain || OwnerBrain.Body.ObjectState is not eObjectState.Active)
+			{
+				OwnerBrain = null;
+				foreach (GameNPC npc in WorldMgr.GetNPCsFromRegion(CurrentRegionID))
+				{
+					if (npc.Brain is MorganaBrain brain)
+					{
+						OwnerBrain = brain;
+						break;
+					}
+				}
+			}
 			if (OwnerBrain != null)
 			{
 				if (PackageID == "BechardMinion")

--- a/GameServer/scripts/namedmobs/Albion Named Mobs/Classic Zones/MorganaBechardSilcharde.cs
+++ b/GameServer/scripts/namedmobs/Albion Named Mobs/Classic Zones/MorganaBechardSilcharde.cs
@@ -73,10 +73,12 @@ namespace DOL.AI.Brain
 		private bool Message = false;
 		private bool SpawnDemons = false;
 		private bool PlayerAreaCheck = false;
-		public static bool CanRemoveMorgana = false;
+		public bool CanRemoveMorgana = false;
 		private bool Morganacast = false;
 		public int BechardDemonicMinionsKilled = 0;
 		public int SilchardeDemonicMinionsKilled = 0;
+		public bool BechardKilled = false;
+		public bool SilchardeKilled = false;
 		public override void Think()
 		{
 			if (!PlayerAreaCheck)
@@ -119,7 +121,7 @@ namespace DOL.AI.Brain
                     }
                 }
             }
-			if (!SpawnDemons || (CanRemoveMorgana && SpawnDemons && Bechard.BechardKilled && Silcharde.SilchardeKilled))
+			if (!SpawnDemons || (CanRemoveMorgana && SpawnDemons && BechardKilled && SilchardeKilled))
 			{
 				if (changed == false)
 				{
@@ -167,8 +169,8 @@ namespace DOL.AI.Brain
 			Morganacast = false;
 			SpawnDemons = false;
 			CanRemoveMorgana = false;
-			Bechard.BechardKilled = false;
-			Silcharde.SilchardeKilled = false;
+			BechardKilled = false;
+			SilchardeKilled = false;
 			BechardDemonicMinionsKilled = 0;
 			SilchardeDemonicMinionsKilled = 0;
 			return 0;
@@ -280,44 +282,54 @@ namespace DOL.GS
 		{
 			INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(700000009);
 			LoadTemplate(npcTemplate);
-			BechardKilled = false;
 
 			BechardBrain sbrain = new BechardBrain();
 			SetOwnBrain(sbrain);
 			LoadedFromScript = true;
 			RespawnInterval = -1;
 			base.AddToWorld();
+
+			MorganaBrain owner = ResolveOwnerBrain();
+
+			if (owner != null)
+				owner.BechardKilled = false;
+
 			return true;
 		}
-		public static bool BechardKilled = false;
 		public MorganaBrain OwnerBrain;
+		private MorganaBrain ResolveOwnerBrain()
+		{
+			if (OwnerBrain == null || OwnerBrain.Body == null || OwnerBrain.Body.Brain != OwnerBrain || OwnerBrain.Body.ObjectState is not eObjectState.Active)
+			{
+				OwnerBrain = null;
+				foreach (GameNPC mob in GetNPCsInRadius(5000))
+				{
+					if (mob.Brain is MorganaBrain brain)
+					{
+						OwnerBrain = brain;
+						break;
+					}
+				}
+			}
+			return OwnerBrain;
+		}
 		public override void ProcessDeath(GameObject killer)
 		{
-			BechardKilled = true;
-			SpawnDemonic();
+			MorganaBrain owner = ResolveOwnerBrain();
+
+			if (owner != null)
+				owner.BechardKilled = true;
+
+			SpawnDemonic(owner);
 			base.ProcessDeath(killer);
 		}
-		private void SpawnDemonic()
+		private void SpawnDemonic(MorganaBrain owner)
 		{
 			Point3D spawn = new Point3D(306041, 670103, 3310);
 			Vector3 position = new(spawn.X, spawn.Y, spawn.Z);
 			Zone zone = CurrentZone;
 			bool usePathfinding = zone != null && zone.IsPathfindingEnabled;
 			EDtPolyFlags[] filters = usePathfinding ? PathfindingProvider.Instance.DefaultFilters : null;
-
-			MorganaBrain owner = OwnerBrain;
-
-			if (owner == null)
-			{
-				foreach (GameNPC mob in GetNPCsInRadius(5000))
-				{
-					if (mob.Brain is MorganaBrain brain)
-					{
-						owner = brain;
-						break;
-					}
-				}
-			}
 
 			for (int i = 0; i < Morgana.BechardMinionCount + Util.Random(4, 6); i++)
 			{
@@ -455,45 +467,55 @@ namespace DOL.GS
 		{
 			INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(700000008);
 			LoadTemplate(npcTemplate);
-			SilchardeKilled = false;
 
 			SilchardeBrain sbrain = new SilchardeBrain();
 			SetOwnBrain(sbrain);
 			LoadedFromScript = true;
 			RespawnInterval = -1;
 			base.AddToWorld();
+
+			MorganaBrain owner = ResolveOwnerBrain();
+
+			if (owner != null)
+				owner.SilchardeKilled = false;
+
 			return true;
 		}
 
-		public static bool SilchardeKilled = false;
 		public MorganaBrain OwnerBrain;
+		private MorganaBrain ResolveOwnerBrain()
+		{
+			if (OwnerBrain == null || OwnerBrain.Body == null || OwnerBrain.Body.Brain != OwnerBrain || OwnerBrain.Body.ObjectState is not eObjectState.Active)
+			{
+				OwnerBrain = null;
+				foreach (GameNPC mob in GetNPCsInRadius(5000))
+				{
+					if (mob.Brain is MorganaBrain brain)
+					{
+						OwnerBrain = brain;
+						break;
+					}
+				}
+			}
+			return OwnerBrain;
+		}
 		public override void ProcessDeath(GameObject killer)
 		{
-			SilchardeKilled = true;
-			SpawnDemonic();
+			MorganaBrain owner = ResolveOwnerBrain();
+
+			if (owner != null)
+				owner.SilchardeKilled = true;
+
+			SpawnDemonic(owner);
 			base.ProcessDeath(killer);
 		}
-		private void SpawnDemonic()
+		private void SpawnDemonic(MorganaBrain owner)
 		{
 			Point3D spawn = new Point3D(306041, 670103, 3310);
 			Vector3 position = new(spawn.X, spawn.Y, spawn.Z);
 			Zone zone = CurrentZone;
 			bool usePathfinding = zone != null && zone.IsPathfindingEnabled;
 			EDtPolyFlags[] filters = usePathfinding ? PathfindingProvider.Instance.DefaultFilters : null;
-
-			MorganaBrain owner = OwnerBrain;
-
-			if (owner == null)
-			{
-				foreach (GameNPC mob in GetNPCsInRadius(5000))
-				{
-					if (mob.Brain is MorganaBrain brain)
-					{
-						owner = brain;
-						break;
-					}
-				}
-			}
 
 			for (int i = 0; i < Morgana.SilchardeMinionCount + Util.Random(4, 6); i++)
 			{

--- a/GameServer/scripts/namedmobs/Albion Named Mobs/Classic Zones/MorganaBechardSilcharde.cs
+++ b/GameServer/scripts/namedmobs/Albion Named Mobs/Classic Zones/MorganaBechardSilcharde.cs
@@ -22,12 +22,8 @@ namespace DOL.GS
 			if (log.IsInfoEnabled)
 				log.Info("Morgana Initializing...");
 		}
-		public static int BechardCount = 0;
-		public static int SilchardeCount = 0;
-		public static int BechardMinionCount = 10;
-		public static int SilchardeMinionCount = 10;
-		public static int BechardDemonicMinionsCount = 0;
-		public static int SilchardeDemonicMinionsCount = 0;
+		public const int BechardMinionCount = 10;
+		public const int SilchardeMinionCount = 10;
 		public override bool AddToWorld()
 		{
 			foreach (GameNPC npc in GetNPCsInRadius(5000))
@@ -79,6 +75,8 @@ namespace DOL.AI.Brain
 		private bool PlayerAreaCheck = false;
 		public static bool CanRemoveMorgana = false;
 		private bool Morganacast = false;
+		public int BechardDemonicMinionsKilled = 0;
+		public int SilchardeDemonicMinionsKilled = 0;
 		public override void Think()
 		{
 			if (!PlayerAreaCheck)
@@ -98,9 +96,9 @@ namespace DOL.AI.Brain
 				}
 			}
 			INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(700000001);
-			if(Morgana.BechardMinionCount > 0 && Morgana.BechardDemonicMinionsCount > 0 && Morgana.SilchardeMinionCount > 0 && Morgana.SilchardeDemonicMinionsCount > 0)
+			if(Morgana.BechardMinionCount > 0 && BechardDemonicMinionsKilled > 0 && Morgana.SilchardeMinionCount > 0 && SilchardeDemonicMinionsKilled > 0)
             {
-				if(Morgana.BechardDemonicMinionsCount >= 10 && Morgana.SilchardeDemonicMinionsCount >= 10)
+				if(BechardDemonicMinionsKilled >= 10 && SilchardeDemonicMinionsKilled >= 10)
                 {
 					if(!Morganacast)
                     {
@@ -171,49 +169,41 @@ namespace DOL.AI.Brain
 			CanRemoveMorgana = false;
 			Bechard.BechardKilled = false;
 			Silcharde.SilchardeKilled = false;
-			Morgana.SilchardeCount = 0;
-			Silcharde.SilchardeKilled = false;
-			Morgana.BechardCount = 0;
-			Bechard.BechardKilled = false;
-			Morgana.BechardDemonicMinionsCount = 0;
-			Morgana.SilchardeDemonicMinionsCount = 0;
+			BechardDemonicMinionsKilled = 0;
+			SilchardeDemonicMinionsKilled = 0;
 			return 0;
 		}
 		private void SpawnBechard()
 		{
-			if (Morgana.BechardCount == 0)
+			foreach (GameNPC mob in Body.GetNPCsInRadius(5000))
 			{
-				foreach (GameNPC mob in Body.GetNPCsInRadius(5000))
-				{
-					if (mob.Brain is BechardBrain)
-						return;
-				}
-				Bechard npc = new Bechard();
-				npc.X = 306044;
-				npc.Y = 670253;
-				npc.Z = 3028;
-				npc.Heading = 3232;
-				npc.CurrentRegion = Body.CurrentRegion;
-				npc.AddToWorld();
+				if (mob.Brain is BechardBrain)
+					return;
 			}
+			Bechard npc = new Bechard();
+			npc.X = 306044;
+			npc.Y = 670253;
+			npc.Z = 3028;
+			npc.Heading = 3232;
+			npc.CurrentRegion = Body.CurrentRegion;
+			npc.OwnerBrain = this;
+			npc.AddToWorld();
 		}
 		private void SpawnSilcharde()
 		{
-			if (Morgana.SilchardeCount == 0)
+			foreach (GameNPC mob in Body.GetNPCsInRadius(5000))
 			{
-				foreach (GameNPC mob in Body.GetNPCsInRadius(5000))
-				{
-					if (mob.Brain is SilchardeBrain)
-						return;
-				}
-				Silcharde npc = new Silcharde();
-				npc.X = 306132;
-				npc.Y = 669983;
-				npc.Z = 3040;
-				npc.Heading = 3148;
-				npc.CurrentRegion = Body.CurrentRegion;
-				npc.AddToWorld();
+				if (mob.Brain is SilchardeBrain)
+					return;
 			}
+			Silcharde npc = new Silcharde();
+			npc.X = 306132;
+			npc.Y = 669983;
+			npc.Z = 3040;
+			npc.Heading = 3148;
+			npc.CurrentRegion = Body.CurrentRegion;
+			npc.OwnerBrain = this;
+			npc.AddToWorld();
 		}
 	}
 }
@@ -290,7 +280,6 @@ namespace DOL.GS
 		{
 			INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(700000009);
 			LoadTemplate(npcTemplate);
-			++Morgana.BechardCount;
 			BechardKilled = false;
 
 			BechardBrain sbrain = new BechardBrain();
@@ -301,9 +290,9 @@ namespace DOL.GS
 			return true;
 		}
 		public static bool BechardKilled = false;
+		public MorganaBrain OwnerBrain;
 		public override void ProcessDeath(GameObject killer)
 		{
-			--Morgana.BechardCount;
 			BechardKilled = true;
 			SpawnDemonic();
 			base.ProcessDeath(killer);
@@ -315,6 +304,20 @@ namespace DOL.GS
 			Zone zone = CurrentZone;
 			bool usePathfinding = zone != null && zone.IsPathfindingEnabled;
 			EDtPolyFlags[] filters = usePathfinding ? PathfindingProvider.Instance.DefaultFilters : null;
+
+			MorganaBrain owner = OwnerBrain;
+
+			if (owner == null)
+			{
+				foreach (GameNPC mob in GetNPCsInRadius(5000))
+				{
+					if (mob.Brain is MorganaBrain brain)
+					{
+						owner = brain;
+						break;
+					}
+				}
+			}
 
 			for (int i = 0; i < Morgana.BechardMinionCount + Util.Random(4, 6); i++)
 			{
@@ -330,6 +333,7 @@ namespace DOL.GS
 				npc.Heading = 3148;
 				npc.CurrentRegion = CurrentRegion;
 				npc.PackageID = "BechardMinion";
+				npc.OwnerBrain = owner;
 				npc.AddToWorld();
 			}
 		}
@@ -451,7 +455,6 @@ namespace DOL.GS
 		{
 			INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(700000008);
 			LoadTemplate(npcTemplate);
-			++Morgana.SilchardeCount;
 			SilchardeKilled = false;
 
 			SilchardeBrain sbrain = new SilchardeBrain();
@@ -463,10 +466,10 @@ namespace DOL.GS
 		}
 
 		public static bool SilchardeKilled = false;
+		public MorganaBrain OwnerBrain;
 		public override void ProcessDeath(GameObject killer)
 		{
 			SilchardeKilled = true;
-			--Morgana.SilchardeCount;
 			SpawnDemonic();
 			base.ProcessDeath(killer);
 		}
@@ -477,6 +480,20 @@ namespace DOL.GS
 			Zone zone = CurrentZone;
 			bool usePathfinding = zone != null && zone.IsPathfindingEnabled;
 			EDtPolyFlags[] filters = usePathfinding ? PathfindingProvider.Instance.DefaultFilters : null;
+
+			MorganaBrain owner = OwnerBrain;
+
+			if (owner == null)
+			{
+				foreach (GameNPC mob in GetNPCsInRadius(5000))
+				{
+					if (mob.Brain is MorganaBrain brain)
+					{
+						owner = brain;
+						break;
+					}
+				}
+			}
 
 			for (int i = 0; i < Morgana.SilchardeMinionCount + Util.Random(4, 6); i++)
 			{
@@ -492,6 +509,7 @@ namespace DOL.GS
 				npc.Heading = 3148;
 				npc.CurrentRegion = CurrentRegion;
 				npc.PackageID = "SilchardeMinion";
+				npc.OwnerBrain = owner;
 				npc.AddToWorld();
 			}
 		}
@@ -557,12 +575,16 @@ namespace DOL.GS
 			base.AddToWorld();
 			return true;
 		}
+		public MorganaBrain OwnerBrain;
 		public override void ProcessDeath(GameObject killer)
 		{
-			if (PackageID == "BechardMinion")
-				++Morgana.BechardDemonicMinionsCount;
-			if (PackageID == "SilchardeMinion")
-				++Morgana.SilchardeDemonicMinionsCount;
+			if (OwnerBrain != null)
+			{
+				if (PackageID == "BechardMinion")
+					++OwnerBrain.BechardDemonicMinionsKilled;
+				if (PackageID == "SilchardeMinion")
+					++OwnerBrain.SilchardeDemonicMinionsKilled;
+			}
 			base.ProcessDeath(killer);
 		}
 	}

--- a/GameServer/scripts/namedmobs/Albion Named Mobs/Classic Zones/SisterBlythe.cs
+++ b/GameServer/scripts/namedmobs/Albion Named Mobs/Classic Zones/SisterBlythe.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using DOL.AI.Brain;
 using DOL.Database;
 using DOL.Events;
@@ -107,6 +108,7 @@ namespace DOL.GS
         private void SpawnExecutioners()
 		{
 			Point3D spawn = new Point3D(322192, 671493, 2764);
+			Executioners.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not eObjectState.Active);
 			for (int i = 0; i < 4; i++)
 			{
 				FallenExecutioner npc = new FallenExecutioner();
@@ -116,8 +118,10 @@ namespace DOL.GS
 				npc.Heading = Heading;
 				npc.CurrentRegion = CurrentRegion;
 				npc.AddToWorld();
+				Executioners.Add(npc);
 			}
 		}
+		public readonly List<GameNPC> Executioners = new List<GameNPC>();
 	}
 }
 namespace DOL.AI.Brain
@@ -138,7 +142,6 @@ namespace DOL.AI.Brain
 				player.Out.SendMessage(message, eChatType.CT_Say, eChatLoc.CL_ChatWindow);
 			}
 		}
-		public static int FallenExecutionerCount = 0;
 		private bool Message1 = false;
 		private bool Message2 = false;
 		public override void Think()
@@ -154,17 +157,6 @@ namespace DOL.AI.Brain
 			if(HasAggro && Body.TargetObject != null)
             {
 				GameLiving target = Body.TargetObject as GameLiving;
-				if (!Message1)
-                {
-					switch(Util.Random(1,2))
-                    {
-						case 1: BroadcastMessage("Sister Blythe shouts in a language you cannot understand!"); break;
-						case 2: BroadcastMessage(String.Format("{0} says, \"Come my pets! Let us show these fools what comes of failure!\"", Body.Name)); break;
-					}
-					if(FallenExecutionerCount > 0)
-						BroadcastMessage("The fallen executioner says, \"By your command!\"");
-					Message1 = true;
-                }
 				foreach (GameNPC npc in Body.GetNPCsInRadius(2500))
 				{
 					if (npc != null && npc.IsAlive && npc.Brain is FallenExecutionerBrain brain)
@@ -173,7 +165,19 @@ namespace DOL.AI.Brain
 							brain.AddToAggroList(target, 10);
 					}
 				}
-				if(FallenExecutionerCount < 4)
+				int executionerCount = AliveExecutionerCount();
+				if (!Message1)
+                {
+					switch(Util.Random(1,2))
+                    {
+						case 1: BroadcastMessage("Sister Blythe shouts in a language you cannot understand!"); break;
+						case 2: BroadcastMessage(String.Format("{0} says, \"Come my pets! Let us show these fools what comes of failure!\"", Body.Name)); break;
+					}
+					if(executionerCount > 0)
+						BroadcastMessage("The fallen executioner says, \"By your command!\"");
+					Message1 = true;
+                }
+				if(executionerCount < 4)
                 {
 					if (!Message2)
 					{
@@ -207,12 +211,30 @@ namespace DOL.AI.Brain
 			}
 			return 0;
         }
+		private int AliveExecutionerCount()
+		{
+			if (Body is not SisterBlythe blythe)
+				return 0;
+
+			int count = 0;
+			foreach (GameNPC npc in blythe.Executioners)
+			{
+				if (npc != null && npc.IsAlive && npc.ObjectState is GameObject.eObjectState.Active)
+					++count;
+			}
+			return count;
+		}
 		private void SpawnExecutioners()
 		{
+			if (Body is not SisterBlythe blythe)
+				return;
+
+			blythe.Executioners.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not GameObject.eObjectState.Active);
+			int executionerCount = blythe.Executioners.Count;
 			Point3D spawn = new Point3D(322192, 671493, 2764);
 			for (int i = 0; i < 4; i++)
 			{
-				if (FallenExecutionerCount < 4)
+				if (executionerCount < 4)
 				{
 					FallenExecutioner npc = new FallenExecutioner();
 					npc.X = spawn.X + Util.Random(-150, 150);
@@ -221,6 +243,8 @@ namespace DOL.AI.Brain
 					npc.Heading = Body.Heading;
 					npc.CurrentRegion = Body.CurrentRegion;
 					npc.AddToWorld();
+					blythe.Executioners.Add(npc);
+					++executionerCount;
 				}
 			}
 		}
@@ -237,7 +261,6 @@ namespace DOL.GS
 		{
 			INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(60160685);
 			LoadTemplate(npcTemplate);
-			++SisterBlytheBrain.FallenExecutionerCount;
 
 			FallenExecutionerBrain sbrain = new FallenExecutionerBrain();
 			SetOwnBrain(sbrain);
@@ -246,12 +269,6 @@ namespace DOL.GS
 			base.AddToWorld();
 			return true;
 		}
-		
-        public override void ProcessDeath(GameObject killer)
-        {
-			--SisterBlytheBrain.FallenExecutionerCount;
-            base.ProcessDeath(killer);
-        }
     }
 }
 namespace DOL.AI.Brain

--- a/GameServer/scripts/namedmobs/Albion Named Mobs/Shrouded Isles/Colialt.cs
+++ b/GameServer/scripts/namedmobs/Albion Named Mobs/Shrouded Isles/Colialt.cs
@@ -94,7 +94,7 @@ namespace DOL.GS
         }
 		public override void DealDamage(AttackData ad)
 		{
-			if (ad != null && ad.AttackType == AttackData.eAttackType.Spell && ad.Damage > 0 && ColialtBrain.ColialtPhase)
+			if (ad != null && ad.AttackType == AttackData.eAttackType.Spell && ad.Damage > 0 && Brain is ColialtBrain brain && brain.ColialtPhase)
 			{
 				Health += ad.Damage;
 			}
@@ -102,7 +102,7 @@ namespace DOL.GS
 		}
 		public override void StartAttack(GameObject target)
         {
-			if (ColialtBrain.ColialtPhase)
+			if (Brain is ColialtBrain brain && brain.ColialtPhase)
 				return;
 			else
 				base.StartAttack(target);
@@ -120,7 +120,7 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool ColialtPhase = false;
+		public bool ColialtPhase = false;
 		private bool CanFollow = false;
 		public override void Think()
 		{

--- a/GameServer/scripts/namedmobs/Albion Named Mobs/Shrouded Isles/ValnirMordeth.cs
+++ b/GameServer/scripts/namedmobs/Albion Named Mobs/Shrouded Isles/ValnirMordeth.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using DOL.AI.Brain;
 using DOL.Database;
 using DOL.Events;
@@ -9,6 +10,7 @@ namespace DOL.GS
 	public class ValnirMordeth : GameEpicBoss
 	{
 		public ValnirMordeth() : base() { }
+		public readonly List<GameNPC> EssenceGhouls = new List<GameNPC>();
 
 		[ScriptLoadedEvent]
 		public static void ScriptLoaded(DOLEvent e, object sender, EventArgs args)
@@ -80,6 +82,7 @@ namespace DOL.GS
         private bool canSpawnAdds = false;
 		private void SpawnAdds()
         {
+			EssenceGhouls.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not eObjectState.Active);
 			for (int i = 0; i < Util.Random(2, 3); i++)
 			{
 				ValnirMordethAdd add = new ValnirMordethAdd();
@@ -90,6 +93,7 @@ namespace DOL.GS
 				add.CurrentRegion = CurrentRegion;
 				add.PackageID = "MordethBaf";
 				add.AddToWorld();
+				EssenceGhouls.Add(add);
 			}
 		}
 		public override void OnAttackEnemy(AttackData ad)
@@ -207,10 +211,24 @@ namespace DOL.AI.Brain
 			}
 			base.Think();
 		}
+		private int AliveEssenceGhoulCount()
+		{
+			if (Body is not ValnirMordeth mordeth)
+				return 0;
+
+			int count = 0;
+			foreach (GameNPC npc in mordeth.EssenceGhouls)
+			{
+				if (npc != null && npc.IsAlive && npc.ObjectState is GameObject.eObjectState.Active)
+					++count;
+			}
+			return count;
+		}
 		private int SpawnAdds(ECSGameTimer timer)
 		{
-			if (Body.IsAlive && HasAggro && ValnirMordethAdd.EssenceGhoulCount == 0)
+			if (Body.IsAlive && HasAggro && AliveEssenceGhoulCount() == 0 && Body is ValnirMordeth mordeth)
 			{
+				mordeth.EssenceGhouls.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not GameObject.eObjectState.Active);
 				ValnirMordethAdd add = new ValnirMordethAdd();
 				add.X = Body.X + Util.Random(-100, 100);
 				add.Y = Body.Y + Util.Random(-100, 100);
@@ -219,14 +237,16 @@ namespace DOL.AI.Brain
 				add.CurrentRegion = Body.CurrentRegion;
 				add.PackageID = "MordethAdds";
 				add.AddToWorld();
+				mordeth.EssenceGhouls.Add(add);
 			}
 			CanSpawnMoreGhouls = false;
 			return 0;
 		}
 		private void SpawnAddsAfterCombat()
         {
-			if (!HasAggro && ValnirMordethAdd.EssenceGhoulCount == 0)
+			if (!HasAggro && AliveEssenceGhoulCount() == 0 && Body is ValnirMordeth mordeth)
 			{
+				mordeth.EssenceGhouls.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not GameObject.eObjectState.Active);
 				for (int i = 0; i < Util.Random(2, 3); i++)
 				{
 					ValnirMordethAdd add = new ValnirMordethAdd();
@@ -237,6 +257,7 @@ namespace DOL.AI.Brain
 					add.CurrentRegion = Body.CurrentRegion;
 					add.PackageID = "MordethBaf";
 					add.AddToWorld();
+					mordeth.EssenceGhouls.Add(add);
 				}
 			}
 		}
@@ -351,7 +372,6 @@ namespace DOL.GS
         public override short Intelligence { get => base.Intelligence; set => base.Intelligence = 200; }
         public override short Quickness { get => base.Quickness; set => base.Quickness = 80; }
         public override short Strength { get => base.Strength; set => base.Strength = 120; }
-		public static int EssenceGhoulCount = 0;
         public override bool AddToWorld()
 		{
 			Model = 921;
@@ -360,7 +380,6 @@ namespace DOL.GS
 			Size = (byte)Util.Random(55, 65);
 			MaxSpeedBase = 225;
 			RespawnInterval = -1;
-			++EssenceGhoulCount;
 
 			Faction = FactionMgr.GetFactionByID(64);
 
@@ -372,11 +391,6 @@ namespace DOL.GS
 		}
         public override long ExperienceValue => 0;
         public override bool CanDropLoot => false;
-        public override void ProcessDeath(GameObject killer)
-        {
-			--EssenceGhoulCount;
-            base.ProcessDeath(killer);
-        }
         public override void DealDamage(AttackData ad)
 		{
 			if (ad != null && ad.AttackType == AttackData.eAttackType.Spell && ad.Damage > 0)

--- a/GameServer/scripts/namedmobs/AvalonCity/CrystalCave/Xanxicar.cs
+++ b/GameServer/scripts/namedmobs/AvalonCity/CrystalCave/Xanxicar.cs
@@ -166,24 +166,24 @@ namespace DOL.AI.Brain
 			ThinkInterval = 1500;
 		}
         #region Check Flags/Port,DD list/broadcast
-        public static GamePlayer randomtarget = null;
-		public static GamePlayer RandomTarget
+        public GamePlayer randomtarget = null;
+		public GamePlayer RandomTarget
 		{
 			get { return randomtarget; }
 			set { randomtarget = value; }
 		}
-		public static GamePlayer randomtarget2 = null;
-		public static GamePlayer RandomTarget2
+		public GamePlayer randomtarget2 = null;
+		public GamePlayer RandomTarget2
 		{
 			get { return randomtarget2; }
 			set { randomtarget2 = value; }
 		}
-		public static bool IsTargetPicked = false;
-		public static bool IsTargetPicked2 = false;
-		public static bool Bomb1 = false;
-		public static bool Bomb2 = false;
-		public static bool Bomb3 = false;
-		public static bool Bomb4 = false;
+		public bool IsTargetPicked = false;
+		public bool IsTargetPicked2 = false;
+		public bool Bomb1 = false;
+		public bool Bomb2 = false;
+		public bool Bomb3 = false;
+		public bool Bomb4 = false;
 		private bool RemoveAdds = false;
         System.Collections.Generic.List<GamePlayer> Port_Enemys = new System.Collections.Generic.List<GamePlayer>();
 		System.Collections.Generic.List<GamePlayer> DD_Enemys = new System.Collections.Generic.List<GamePlayer>();
@@ -374,8 +374,8 @@ namespace DOL.AI.Brain
         #endregion
 
         #region adds
-        public static bool SpawnAddsOnce = false;
-		public static bool CheckForSingleAdd = false;
+        public bool SpawnAddsOnce = false;
+		public bool CheckForSingleAdd = false;
 		private readonly List<GameNPC> _champions = new List<GameNPC>();
 		private int AliveChampionCount
 		{

--- a/GameServer/scripts/namedmobs/AvalonCity/CrystalCave/Xanxicar.cs
+++ b/GameServer/scripts/namedmobs/AvalonCity/CrystalCave/Xanxicar.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using DOL.AI.Brain;
 using DOL.Database;
 using DOL.Events;
@@ -307,7 +308,7 @@ namespace DOL.AI.Brain
 				Bomb4 = false;
 				SpawnAddsOnce = false;
 				CheckForSingleAdd = false;
-				XanxicarianChampion.XanxicarianChampionCount = 0;
+				_champions.Clear();
 				if (!RemoveAdds)
 				{
 					foreach (GameNPC npc in WorldMgr.GetNPCsFromRegion(Body.CurrentRegionID))
@@ -356,12 +357,12 @@ namespace DOL.AI.Brain
 				}
 				if(Body.HealthPercent<=50)
                 {
-					if(SpawnAddsOnce==false && XanxicarianChampion.XanxicarianChampionCount == 0)
+					if(SpawnAddsOnce==false && AliveChampionCount == 0)
                     {
 						SpawnAdds();
 						SpawnAddsOnce = true;
                     }
-					if(SpawnAddsOnce && CheckForSingleAdd==false && XanxicarianChampion.XanxicarianChampionCount == 0)
+					if(SpawnAddsOnce && CheckForSingleAdd==false && AliveChampionCount == 0)
                     {
 						new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(SpawnMoreAdds), Util.Random(15000, 25000));//spawn 1 add every 25-35s
 						CheckForSingleAdd = true;
@@ -375,6 +376,15 @@ namespace DOL.AI.Brain
         #region adds
         public static bool SpawnAddsOnce = false;
 		public static bool CheckForSingleAdd = false;
+		private readonly List<GameNPC> _champions = new List<GameNPC>();
+		private int AliveChampionCount
+		{
+			get
+			{
+				_champions.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not GameObject.eObjectState.Active);
+				return _champions.Count;
+			}
+		}
 		public void SpawnAdds()
         {
 			for (int i = 0; i < 5; i++)
@@ -387,11 +397,12 @@ namespace DOL.AI.Brain
 				Add.CurrentRegion = Body.CurrentRegion;
 				Add.Heading = Body.Heading;
 				Add.AddToWorld();
+				_champions.Add(Add);
 			}
 		}
 		public int SpawnMoreAdds(ECSGameTimer timer)
         {
-			if (XanxicarianChampion.XanxicarianChampionCount == 0 && HasAggro)
+			if (AliveChampionCount == 0 && HasAggro)
 			{
 				XanxicarianChampion Add = new XanxicarianChampion();
 				Add.X = Body.X + Util.Random(-150, 150);
@@ -401,6 +412,7 @@ namespace DOL.AI.Brain
 				Add.CurrentRegion = Body.CurrentRegion;
 				Add.Heading = Body.Heading;
 				Add.AddToWorld();
+				_champions.Add(Add);
 				CheckForSingleAdd = false;
 			}
 			return 0;
@@ -500,17 +512,10 @@ namespace DOL.GS
 			get { return 8000; }
 		}
 
-		public static int XanxicarianChampionCount = 0;
-		public override void ProcessDeath(GameObject killer)
-		{
-			--XanxicarianChampionCount;
-			base.ProcessDeath(killer);
-		}
 		public override bool AddToWorld()
 		{
 			INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(91);
 			LoadTemplate(npcTemplate);
-			++XanxicarianChampionCount;
 			Faction = FactionMgr.GetFactionByID(10);
 			RespawnInterval = -1;
 			XanxicarianChampionBrain sbrain = new XanxicarianChampionBrain();

--- a/GameServer/scripts/namedmobs/AvalonCity/DraargusMighty.cs
+++ b/GameServer/scripts/namedmobs/AvalonCity/DraargusMighty.cs
@@ -40,9 +40,11 @@ namespace DOL.GS
 			get { return 30000; }
 		}
 
+		private DraugynSphere _sphere;
+		private bool IsSphereActive => _sphere != null && _sphere.IsAlive && _sphere.ObjectState is eObjectState.Active;
 		public override void StartAttack(GameObject target)
 		{
-			if (DraugynSphere.SphereCount > 0)
+			if (IsSphereActive)
 				return;
 			else
 				base.StartAttack(target);
@@ -52,7 +54,7 @@ namespace DOL.GS
 		{
 			if (IsAlive && keyName == GS.Abilities.CCImmunity)
 				return true;
-			if (DraugynSphere.SphereCount > 0 && IsAlive && keyName == GS.Abilities.DamageImmunity)
+			if (IsSphereActive && IsAlive && keyName == GS.Abilities.DamageImmunity)
 				return true;
 			return base.HasAbility(keyName);
 		}
@@ -74,7 +76,7 @@ namespace DOL.GS
 		}
 		public void CreateSphere()
         {
-			if (DraugynSphere.SphereCount == 0)
+			if (!IsSphereActive)
 			{
 				DraugynSphere Add = new DraugynSphere();
 				Add.X = 26766;
@@ -83,6 +85,7 @@ namespace DOL.GS
 				Add.CurrentRegion = CurrentRegion;
 				Add.Heading = 966;
 				Add.AddToWorld();
+				_sphere = Add;
 			}
 		}
 	}
@@ -188,23 +191,13 @@ namespace DOL.GS
 		{
 			get { return 10000; }
 		}
-		public static int SphereCount = 0;
-		public static bool IsSphereDead = false;
-        public override void ProcessDeath(GameObject killer)
-        {
-			--SphereCount;
-			IsSphereDead = true;
-            base.ProcessDeath(killer);
-        }
         public override bool AddToWorld()
 		{
 			INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(60160133);
 			LoadTemplate(npcTemplate);
-			IsSphereDead = false;
 
 			Faction = FactionMgr.GetFactionByID(9);
 			MaxSpeedBase = 0;
-			++SphereCount;
 			RespawnInterval = -1;
 
 			DraugynSphereBrain sbrain = new DraugynSphereBrain();

--- a/GameServer/scripts/namedmobs/AvalonCity/DuraekEmpowered.cs
+++ b/GameServer/scripts/namedmobs/AvalonCity/DuraekEmpowered.cs
@@ -140,7 +140,7 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsPulled = false;
+		public bool IsPulled = false;
 		public override void Think()
 		{
 			if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/AvalonCity/SyssroTheRuthless.cs
+++ b/GameServer/scripts/namedmobs/AvalonCity/SyssroTheRuthless.cs
@@ -134,14 +134,14 @@ namespace DOL.AI.Brain
 			AggroRange = 400;
 			ThinkInterval = 1500;
 		}
-		public static GamePlayer randomtarget = null;
-		public static GamePlayer RandomTarget
+		public GamePlayer randomtarget = null;
+		public GamePlayer RandomTarget
 		{
 			get { return randomtarget; }
 			set { randomtarget = value; }
 		}
-		public static bool IsTargetPicked = false;
-		public static bool IsPulled = false;
+		public bool IsTargetPicked = false;
+		public bool IsPulled = false;
 		List<GamePlayer> Port_Enemys = new List<GamePlayer>();
 		public int ThrowPlayer(ECSGameTimer timer)
 		{

--- a/GameServer/scripts/namedmobs/AvalonCity/SyssroTheRuthless.cs
+++ b/GameServer/scripts/namedmobs/AvalonCity/SyssroTheRuthless.cs
@@ -69,12 +69,7 @@ namespace DOL.GS
 			LoadTemplate(npcTemplate);
 			RespawnInterval = ServerProperties.Properties.SET_EPIC_GAME_ENCOUNTER_RESPAWNINTERVAL * 60000;//1min is 60000 miliseconds
 			Faction = FactionMgr.GetFactionByID(11);
-			CreateMonsters = false;
-			if(CreateMonsters==false)
-            {
-				CreatePitMonsters();
-				CreateMonsters = true;
-            }
+			CreatePitMonsters();
 			SyssroRuthlessBrain sbrain = new SyssroRuthlessBrain();
 			SetOwnBrain(sbrain);
 			LoadedFromScript = false;//load from database
@@ -82,134 +77,50 @@ namespace DOL.GS
 			base.AddToWorld();
 			return true;
 		}
-		public static bool CreateMonsters = false;
+		private readonly List<PitMonster> _pitMonsters = new List<PitMonster>();
+
+		private static readonly (int X, int Y, int Z, ushort Heading)[] _pitMonsterSpawns =
+		[
+			(41375, 40134, 7726, 2600),
+			(41484, 40198, 7725, 1818),
+			(41695, 40142, 7730, 1287),
+			(41916, 40469, 7724, 347),
+			(41995, 40874, 7726, 2754),
+			(41780, 41185, 7727, 48),
+			(41488, 41402, 7736, 1438),
+			(41261, 41246, 7728, 3480),
+			(41001, 40966, 7727, 2868),
+			(40978, 40538, 7727, 3357),
+			(41335, 40736, 7707, 2775),
+			(41712, 40832, 7712, 1342),
+			(41564, 40489, 7711, 107),
+			(41481, 41083, 7719, 1829),
+			(41490, 40758, 7701, 1979)
+		];
+
 		public void CreatePitMonsters()
         {
-			if (PitMonster.PitMonsterCount == 0)
+			foreach (PitMonster monster in _pitMonsters)
 			{
-                #region Pit Monster location
-                PitMonster Add = new PitMonster();
-				Add.X = 41375;
-				Add.Y = 40134;
-				Add.Z = 7726;
-				Add.CurrentRegion = CurrentRegion;
-				Add.Heading = 2600;
-				Add.AddToWorld();
+				if (monster != null && monster.IsAlive && monster.ObjectState is eObjectState.Active)
+					return;
+			}
 
-				PitMonster Add2 = new PitMonster();
-				Add2.X = 41484;
-				Add2.Y = 40198;
-				Add2.Z = 7725;
-				Add2.CurrentRegion = CurrentRegion;
-				Add2.Heading = 1818;
-				Add2.AddToWorld();
+			_pitMonsters.Clear();
 
-				PitMonster Add3 = new PitMonster();
-				Add3.X = 41695;
-				Add3.Y = 40142;
-				Add3.Z = 7730;
-				Add3.CurrentRegion = CurrentRegion;
-				Add3.Heading = 1287;
-				Add3.AddToWorld();
-
-				PitMonster Add4 = new PitMonster();
-				Add4.X = 41916;
-				Add4.Y = 40469;
-				Add4.Z = 7724;
-				Add4.CurrentRegion = CurrentRegion;
-				Add4.Heading = 347;
-				Add4.AddToWorld();
-
-				PitMonster Add5 = new PitMonster();
-				Add5.X = 41995;
-				Add5.Y = 40874;
-				Add5.Z = 7726;
-				Add5.CurrentRegion = CurrentRegion;
-				Add5.Heading = 2754;
-				Add5.AddToWorld();
-
-				PitMonster Add6 = new PitMonster();
-				Add6.X = 41780;
-				Add6.Y = 41185;
-				Add6.Z = 7727;
-				Add6.CurrentRegion = CurrentRegion;
-				Add6.Heading = 48;
-				Add6.AddToWorld();
-
-				PitMonster Add7 = new PitMonster();
-				Add7.X = 41488;
-				Add7.Y = 41402;
-				Add7.Z = 7736;
-				Add7.CurrentRegion = CurrentRegion;
-				Add7.Heading = 1438;
-				Add7.AddToWorld();
-
-				PitMonster Add8 = new PitMonster();
-				Add8.X = 41261;
-				Add8.Y = 41246;
-				Add8.Z = 7728;
-				Add8.CurrentRegion = CurrentRegion;
-				Add8.Heading = 3480;
-				Add8.AddToWorld();
-
-				PitMonster Add9 = new PitMonster();
-				Add9.X = 41001;
-				Add9.Y = 40966;
-				Add9.Z = 7727;
-				Add9.CurrentRegion = CurrentRegion;
-				Add9.Heading = 2868;
-				Add9.AddToWorld();
-
-				PitMonster Add10 = new PitMonster();
-				Add10.X = 40978;
-				Add10.Y = 40538;
-				Add10.Z = 7727;
-				Add10.CurrentRegion = CurrentRegion;
-				Add10.Heading = 3357;
-				Add10.AddToWorld();
-
-				PitMonster Add11 = new PitMonster();
-				Add11.X = 41335;
-				Add11.Y = 40736;
-				Add11.Z = 7707;
-				Add11.CurrentRegion = CurrentRegion;
-				Add11.Heading = 2775;
-				Add11.AddToWorld();
-
-				PitMonster Add12 = new PitMonster();
-				Add12.X = 41712;
-				Add12.Y = 40832;
-				Add12.Z = 7712;
-				Add12.CurrentRegion = CurrentRegion;
-				Add12.Heading = 1342;
-				Add12.AddToWorld();
-
-				PitMonster Add13 = new PitMonster();
-				Add13.X = 41564;
-				Add13.Y = 40489;
-				Add13.Z = 7711;
-				Add13.CurrentRegion = CurrentRegion;
-				Add13.Heading = 107;
-				Add13.AddToWorld();
-
-				PitMonster Add14 = new PitMonster();
-				Add14.X = 41481;
-				Add14.Y = 41083;
-				Add14.Z = 7719;
-				Add14.CurrentRegion = CurrentRegion;
-				Add14.Heading = 1829;
-				Add14.AddToWorld();
-
-				PitMonster Add15 = new PitMonster();
-				Add15.X = 41490;
-				Add15.Y = 40758;
-				Add15.Z = 7701;
-				Add15.CurrentRegion = CurrentRegion;
-				Add15.Heading = 1979;
-				Add15.AddToWorld();
-				#endregion
+			foreach ((int x, int y, int z, ushort heading) in _pitMonsterSpawns)
+			{
+				PitMonster add = new PitMonster();
+				add.X = x;
+				add.Y = y;
+				add.Z = z;
+				add.CurrentRegion = CurrentRegion;
+				add.Heading = heading;
+				add.AddToWorld();
+				_pitMonsters.Add(add);
 			}
         }
+
 	}
 }
 namespace DOL.AI.Brain
@@ -358,12 +269,6 @@ namespace DOL.GS
 			}
 			base.OnAttackEnemy(ad);
 		}
-		public static int PitMonsterCount = 0;
-        public override void ProcessDeath(GameObject killer)
-        {
-			--PitMonsterCount;
-            base.ProcessDeath(killer);
-        }
         public override bool AddToWorld()
 		{
 			Model = 823;
@@ -375,7 +280,6 @@ namespace DOL.GS
 			Constitution = 100;
 			Quickness = 130;
 			MaxSpeedBase = 0;
-			++PitMonsterCount;
 			Faction = FactionMgr.GetFactionByID(11);
 			RespawnInterval = -1;
 			PitMonsterBrain sbrain = new PitMonsterBrain();

--- a/GameServer/scripts/namedmobs/AvalonCity/VeraeriusBrave.cs
+++ b/GameServer/scripts/namedmobs/AvalonCity/VeraeriusBrave.cs
@@ -100,7 +100,7 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsPulled = false;
+		public bool IsPulled = false;
 		public override void Think()
 		{
 			if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/AvalonCity/WenoiakEnlightened.cs
+++ b/GameServer/scripts/namedmobs/AvalonCity/WenoiakEnlightened.cs
@@ -75,7 +75,7 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsPulled = false;
+		public bool IsPulled = false;
 		public override void Think()
 		{
 			if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/CaerSidi/ApocalypseAnd4Horsemans .cs
+++ b/GameServer/scripts/namedmobs/CaerSidi/ApocalypseAnd4Horsemans .cs
@@ -1526,6 +1526,15 @@ namespace DOL.AI.Brain
                             }
                         }
                     }
+                    if (Body is Morbus morbusToClear)
+                    {
+                        foreach (GameNPC npc in morbusToClear.Swarm)
+                        {
+                            if (npc != null && npc.ObjectState is GameObject.eObjectState.Active)
+                                npc.RemoveFromWorld();
+                        }
+                        morbusToClear.Swarm.Clear();
+                    }
                     RemoveAdds = true;
                 }
             }

--- a/GameServer/scripts/namedmobs/CaerSidi/ApocalypseAnd4Horsemans .cs
+++ b/GameServer/scripts/namedmobs/CaerSidi/ApocalypseAnd4Horsemans .cs
@@ -1304,7 +1304,7 @@ namespace DOL.GS
         {
             if (source is GamePlayer || source is GameSummonedPet)
             {
-                if (Morbus_Swarm_count > 0)
+                if (AliveSwarmCount > 0)
                 {
                     if (damageType == eDamageType.Body || damageType == eDamageType.Cold || damageType == eDamageType.Energy || damageType == eDamageType.Heat
                         || damageType == eDamageType.Matter || damageType == eDamageType.Spirit || damageType == eDamageType.Crush || damageType == eDamageType.Thrust
@@ -1381,7 +1381,22 @@ namespace DOL.GS
             return 0;
         }
         public static bool spawn_fate3 = false;
-        public static int Morbus_Swarm_count = 0;
+        public readonly List<GameNPC> Swarm = new List<GameNPC>();
+        public int AliveSwarmCount
+        {
+            get
+            {
+                int count = 0;
+
+                foreach (GameNPC npc in Swarm)
+                {
+                    if (npc != null && npc.IsAlive && npc.ObjectState is eObjectState.Active)
+                        count++;
+                }
+
+                return count;
+            }
+        }
         public void SpawnFateBearer()
         {
             INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(60160741);
@@ -1507,10 +1522,7 @@ namespace DOL.AI.Brain
                             if (npc.IsAlive)
                             {
                                 if (npc.PackageID == "MorbusBaf" && npc.Brain is MorbusSwarmBrain)
-                                {
                                     npc.RemoveFromWorld();
-                                    Morbus.Morbus_Swarm_count = 0;
-                                }
                             }
                         }
                     }
@@ -1537,7 +1549,7 @@ namespace DOL.AI.Brain
             if (Body.InCombat || HasAggro || Body.attackComponent.AttackState == true)
             {
                 StartedMorbus = true;
-                if(Morbus.Morbus_Swarm_count > 0)
+                if(Body is Morbus morbus && morbus.AliveSwarmCount > 0)
                 {
                     Body.Model = 771;
                     Body.Size = 50;
@@ -1570,7 +1582,7 @@ namespace DOL.AI.Brain
                         }
                     }
                 }
-                if(Morbus.Morbus_Swarm_count == 0)
+                if(Body is Morbus morbus2 && morbus2.AliveSwarmCount == 0)
                 {
                     if (spawn_swarm == false)
                     {
@@ -1596,6 +1608,9 @@ namespace DOL.AI.Brain
         {
             if (Body.IsAlive)
             {
+                if (Body is Morbus morbusToPrune)
+                    morbusToPrune.Swarm.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not GameObject.eObjectState.Active);
+
                 for (int i = 0; i < Util.Random(6,10); i++)
                 {
                     MorbusSwarm Add = new MorbusSwarm();
@@ -1607,7 +1622,8 @@ namespace DOL.AI.Brain
                     Add.RespawnInterval = -1;
                     Add.PackageID = "MorbusBaf";
                     Add.AddToWorld();
-                    ++Morbus.Morbus_Swarm_count;
+                    if (Body is Morbus morbus)
+                        morbus.Swarm.Add(Add);
                 }
             }
             spawn_swarm=false;
@@ -1637,12 +1653,6 @@ namespace DOL.GS
         {
             get { return 15000; }
         }
-        public override void ProcessDeath(GameObject killer)
-        {
-            --Morbus.Morbus_Swarm_count;
-            base.ProcessDeath(killer);
-        }
-
         public override void SetStats(DbMob dbMob = null)
         {
             if (PackageID == "MorbusBaf")
@@ -2132,7 +2142,6 @@ namespace DOL.GS
             ApocalypseBrain.ApocAggro = false;
             ApocalypseBrain.pop_harbringers = false;
             ApocalypseBrain.StartedApoc = false;
-            HarbringerOfFate.HarbringersCount = 0;
             ApocUP = true;
 
 
@@ -2146,7 +2155,7 @@ namespace DOL.GS
             return true;
         }
 
-        public static int KilledEnemys = 0;
+        public int KilledEnemys = 0;
         public override void EnemyKilled(GameLiving enemy)
         {
             if(enemy is GamePlayer)
@@ -2185,6 +2194,7 @@ namespace DOL.AI.Brain
         public static bool pop_harbringers = false;
         public static bool StartedApoc = false;
         private bool RemoveAdds = false;
+        private int _harbringersCount = 0;
 
         public override void Think()
         {
@@ -2202,8 +2212,9 @@ namespace DOL.AI.Brain
                 ApocAggro = false;
                 pop_harbringers = false;
                 StartedApoc = false;
-                Apocalypse.KilledEnemys = 0;
-                HarbringerOfFate.HarbringersCount = 0;
+                if (Body is Apocalypse apoc)
+                    apoc.KilledEnemys = 0;
+                _harbringersCount = 0;
 
                 if (!RemoveAdds)
                 {
@@ -2261,7 +2272,7 @@ namespace DOL.AI.Brain
                     SpawnRainOfFire();
                     spawn_rain_of_fire = true;
                 }
-                if (HarbringerOfFate.HarbringersCount == 0)
+                if (_harbringersCount == 0)
                 {
                     if (spawn_harbringers == false)
                     {
@@ -2347,7 +2358,7 @@ namespace DOL.AI.Brain
         public static bool spawn_harbringers = false;
         public int SpawnHarbringers(ECSGameTimer timer)
         {
-            if (Apocalypse.KilledEnemys == 4)//he doint it only once, spawning 2 harbringers is killed 4 players
+            if (Body is Apocalypse apoc && apoc.KilledEnemys == 4)//he doint it only once, spawning 2 harbringers is killed 4 players
             {
                 foreach (GamePlayer player in Body.GetPlayersInRadius(2500))
                 {
@@ -2367,7 +2378,7 @@ namespace DOL.AI.Brain
                     Add.RespawnInterval = -1;
                     Add.PackageID = "ApocBaf";
                     Add.AddToWorld();
-                    ++HarbringerOfFate.HarbringersCount;
+                    ++_harbringersCount;
                 }
             }
             if(Body.HealthPercent <= 50 && pop_harbringers==false)/// spawning another 2 harbringers if boss is at 50%
@@ -2392,7 +2403,7 @@ namespace DOL.AI.Brain
                     Add.RespawnInterval = -1;
                     Add.PackageID = "ApocBaf";
                     Add.AddToWorld();
-                    ++HarbringerOfFate.HarbringersCount;
+                    ++_harbringersCount;
                 }
                 pop_harbringers = true;
             }
@@ -2404,6 +2415,7 @@ namespace DOL.AI.Brain
         public void SpawnRainOfFire()
         {
             RainOfFire Add = new RainOfFire();
+            Add.Apoc = Body as Apocalypse;
             Add.X = Body.X;
             Add.Y = Body.Y;
             Add.Z = Body.Z + 940;
@@ -2479,7 +2491,6 @@ namespace DOL.GS
                 return;
             base.SetStats(dbMob);
         }
-        public static int HarbringersCount = 0;
         public override short Quickness { get => base.Quickness; set => base.Quickness = 50; }
         public override short Strength { get => base.Strength; set => base.Strength = 200; }
         public override bool AddToWorld()
@@ -2555,6 +2566,8 @@ namespace DOL.GS
     {
         public RainOfFire() : base() { }
 
+        public Apocalypse Apoc;
+
         public override int GetResist(eDamageType damageType)
         {
             switch (damageType)
@@ -2567,9 +2580,9 @@ namespace DOL.GS
         }
         public override void EnemyKilled(GameLiving enemy)
         {
-            if (enemy is GamePlayer)
+            if (enemy is GamePlayer && Apoc != null && Apoc.IsAlive)
             {
-                ++Apocalypse.KilledEnemys;
+                ++Apoc.KilledEnemys;
             }
             base.EnemyKilled(enemy);
         }

--- a/GameServer/scripts/namedmobs/CaerSidi/ApocalypseAnd4Horsemans .cs
+++ b/GameServer/scripts/namedmobs/CaerSidi/ApocalypseAnd4Horsemans .cs
@@ -14,9 +14,26 @@ namespace DOL.GS
     public class ApocInitializator : GameNPC
     {
         public ApocInitializator() : base() { }
-        public static bool spawn_apoc = false;
-        public static bool start_respawn_check = false;
-        public static bool StartEncounter = false;
+        public bool start_respawn_check = false;
+        public bool FamesIsUp = true;
+        public bool BellumUP = true;
+        public bool MorbusUP = true;
+        public bool FunusUp = true;
+        public bool ApocUP = true;
+        public bool StartedFames = false;
+        public bool StartedBellum = false;
+        public bool StartedMorbus = false;
+        public bool StartedFunus = false;
+        public bool StartedApoc = false;
+        public static ApocInitializator GetInitializator(ushort regionID)
+        {
+            foreach (GameNPC npc in WorldMgr.GetNPCsFromRegion(regionID))
+            {
+                if (npc is ApocInitializator initializator)
+                    return initializator;
+            }
+            return null;
+        }
 
         #region Timer cycling and repeatable dostuff
         public void StartTimer()
@@ -91,7 +108,6 @@ namespace DOL.GS
             new ECSGameTimer(this, new ECSGameTimer.ECSTimerCallback(Message_timer8), 5000);//60s before starting
             return 0;
         }
-        public static bool FamesWaitForText = false;
         public int Message_timer8(ECSGameTimer timer)
         {
             BroadcastMessage(String.Format("Fames asks, 'You, "+RandomTarget.Name+", do you come to challenge fate? Come to me with your answer so that I may see the answer" +
@@ -105,6 +121,7 @@ namespace DOL.GS
         public int SpawnHorsemanFames(ECSGameTimer timer)
         {
             Fames Add = new Fames();
+            Add.Initializator = this;
             Add.X = X;
             Add.Y = Y;
             Add.Z = Z;
@@ -112,11 +129,10 @@ namespace DOL.GS
             Add.Flags = eFlags.PEACE;
             Add.Heading = 4072;
             Add.AddToWorld();
-            FamesWaitForText = true;
             new ECSGameTimer(this, new ECSGameTimer.ECSTimerCallback(OtherPlayersCanInteract), 60000);
             return 0;
         }
-        public static bool OthersCanInteract = false;
+        public bool OthersCanInteract = false;
         private int OtherPlayersCanInteract(ECSGameTimer timer)
         {          
             OthersCanInteract = true;
@@ -126,15 +142,14 @@ namespace DOL.GS
         #endregion
 
         #region Pick Random Player, PlayerEnter
-        private bool CheckNullPlayer = false;
-        public static GamePlayer randomtarget=null;
-        public static GamePlayer RandomTarget
+        public GamePlayer randomtarget=null;
+        public GamePlayer RandomTarget
         {
             get { return randomtarget; }
             set { randomtarget = value; }
         }
         List<GamePlayer> PlayersInRoom = new List<GamePlayer>();
-        public static bool PickedTarget = false;
+        public bool PickedTarget = false;
         public void PlayerEnter()
         {
             foreach (GamePlayer player in GetPlayersInRadius(1500))
@@ -165,7 +180,7 @@ namespace DOL.GS
         {
             if (IsAlive)
             {
-                if (!Fames.FamesIsUp && !Bellum.BellumUP && !Morbus.MorbusUP && !Funus.FunusUp && !Apocalypse.ApocUP && !start_respawn_check)
+                if (!FamesIsUp && !BellumUP && !MorbusUP && !FunusUp && !ApocUP && !start_respawn_check)
                 {
                     RandomTarget = null;//reset picked player
                     PlayersInRoom.Clear();
@@ -239,7 +254,7 @@ namespace DOL.GS
 
             if(this.CurrentRegionID == 60)//caer sidi
             {
-                if(FamesBrain.StartedFames==true || BellumBrain.StartedBellum==true || MorbusBrain.StartedMorbus==true || FunusBrain.StartedFunus==true || ApocalypseBrain.StartedApoc==true)
+                if(StartedFames==true || StartedBellum==true || StartedMorbus==true || StartedFunus==true || StartedApoc==true)
                 {
                     foreach (GamePlayer player in GetPlayersInRadius(1500))
                     {
@@ -292,13 +307,18 @@ namespace DOL.GS
     public class Fames : GameEpicBoss
     {
         public Fames() : base() { }
+        private ApocInitializator _initializator;
+        public ApocInitializator Initializator
+        {
+            get => _initializator ??= ApocInitializator.GetInitializator(CurrentRegionID);
+            set => _initializator = value;
+        }
         public int StartFamesTimer(ECSGameTimer timer)
         {
             Flags = 0;
             return 0;
         }
-        public static bool CanInteract = false;
-        public static bool FamesIsUp = true;
+        public bool CanInteract = false;
         public override int GetResist(eDamageType damageType)
         {
             switch (damageType)
@@ -312,7 +332,7 @@ namespace DOL.GS
         public override bool Interact(GamePlayer player)
         {
             if (!base.Interact(player)) return false;
-            GamePlayer player2 = ApocInitializator.RandomTarget;
+            GamePlayer player2 = Initializator?.RandomTarget;
             if (CanInteract == false)
             {
                 if (player == player2)
@@ -324,7 +344,7 @@ namespace DOL.GS
                         "Say [yes] and prepare yourselves.", eChatType.CT_Say, eChatLoc.CL_PopupWindow);
                 }
             }
-            if (ApocInitializator.OthersCanInteract == true)
+            if (Initializator != null && Initializator.OthersCanInteract == true)
             {
                 if (player != null)
                 {
@@ -344,7 +364,7 @@ namespace DOL.GS
             GamePlayer t = (GamePlayer)source;
             if (CanInteract == false)
             {            
-                if (t == ApocInitializator.RandomTarget || ApocInitializator.OthersCanInteract == true)
+                if (Initializator != null && (t == Initializator.RandomTarget || Initializator.OthersCanInteract == true))
                 {
                     TurnTo(t.X, t.Y);
                     switch (str.ToLower())
@@ -415,13 +435,17 @@ namespace DOL.GS
                 new ECSGameTimer(this, new ECSGameTimer.ECSTimerCallback(SpawnHorsemanBellum), 60000);//60s before starting
                 prepareBellum = true;
             }
-            FamesIsUp = false;
-            FamesBrain.StartedFames = false;
+            if (Initializator != null)
+            {
+                Initializator.FamesIsUp = false;
+                Initializator.StartedFames = false;
+            }
             base.ProcessDeath(killer);
         }
         public int SpawnHorsemanBellum(ECSGameTimer timer)
         {
             Bellum Add = new Bellum();
+            Add.Initializator = Initializator;
             Add.X = 29468;
             Add.Y = 25235;
             Add.Z = 19490;
@@ -448,11 +472,13 @@ namespace DOL.GS
             Faction = FactionMgr.GetFactionByID(64);
             BodyType = 11;
             Realm = eRealm.None;
-            FamesBrain.spawn_fate = false;
             CanInteract = false;
-            FamesBrain.StartedFames = false;
-            FamesIsUp = true;
             prepareBellum = false;
+            if (Initializator != null)
+            {
+                Initializator.StartedFames = false;
+                Initializator.FamesIsUp = true;
+            }
 
             FamesBrain adds = new FamesBrain();
             SetOwnBrain(adds);
@@ -473,9 +499,9 @@ namespace DOL.AI.Brain
             AggroRange = 600;
             ThinkInterval = 2000;
         }
-        public static bool BafMobs = false;
-        public static bool spawn_fate = false;
-        public static bool StartedFames = false;
+        public bool BafMobs = false;
+        public bool spawn_fate = false;
+        private ApocInitializator Initializator => (Body as Fames)?.Initializator;
         public override void Think()
         {
             if (!CheckProximityAggro())
@@ -484,7 +510,8 @@ namespace DOL.AI.Brain
                 FSM.SetCurrentState(eFSMStateType.RETURN_TO_SPAWN);
                 Body.Health = Body.MaxHealth;
                 BafMobs = false;
-                StartedFames = false;
+                if (Initializator != null)
+                    Initializator.StartedFames = false;
             }
             if (Body.IsOutOfTetherRange)
             {
@@ -497,7 +524,8 @@ namespace DOL.AI.Brain
             }
             if (Body.InCombat || HasAggro || Body.attackComponent.AttackState == true)//bring mobs from rooms if mobs got set PackageID="FamesBaf"
             {
-                StartedFames = true;
+                if (Initializator != null)
+                    Initializator.StartedFames = true;
                 if (spawn_fate == false)
                 {
                     SpawnFateBearer();
@@ -546,6 +574,12 @@ namespace DOL.GS
     public class Bellum : GameEpicBoss
     {
         public Bellum() : base() { }
+        private ApocInitializator _initializator;
+        public ApocInitializator Initializator
+        {
+            get => _initializator ??= ApocInitializator.GetInitializator(CurrentRegionID);
+            set => _initializator = value;
+        }
         public override bool HasAbility(string keyName)
         {
             if (IsAlive && keyName == GS.Abilities.CCImmunity)
@@ -568,7 +602,6 @@ namespace DOL.GS
         {
             get { return 100000; }
         }
-        public static bool BellumUP = true;
         public void BroadcastMessage(String message)
         {
             foreach (GamePlayer player in this.GetPlayersInRadius(WorldMgr.VISIBILITY_DISTANCE))
@@ -600,14 +633,18 @@ namespace DOL.GS
                 }
             }
             
-            BellumBrain.StartedBellum = false;
-            BellumUP = false;
+            if (Initializator != null)
+            {
+                Initializator.StartedBellum = false;
+                Initializator.BellumUP = false;
+            }
             spawn_fate2 = false;
             base.ProcessDeath(killer);
         }
         public int SpawnHorsemanMorbus(ECSGameTimer timer)
         {
             Morbus Add = new Morbus();
+            Add.Initializator = Initializator;
             Add.X = 29467;
             Add.Y = 25235;
             Add.Z = 19490;
@@ -616,7 +653,7 @@ namespace DOL.GS
             Add.AddToWorld();
             return 0;
         }
-        public static bool spawn_fate2 = false;
+        public bool spawn_fate2 = false;
         public void SpawnFateBearer()
         {
             INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(60160741);
@@ -650,10 +687,12 @@ namespace DOL.GS
             Faction = FactionMgr.GetFactionByID(64);
             BodyType = 11;
             Realm = eRealm.None;
-            BellumBrain.StartedBellum = false;
-            BellumBrain.SpawnWeapons = false;
-            BellumUP = true;
             prepareMorbus = false;
+            if (Initializator != null)
+            {
+                Initializator.StartedBellum = false;
+                Initializator.BellumUP = true;
+            }
 
             AbilityBonus[eProperty.Resist_Body] = -10;
             AbilityBonus[eProperty.Resist_Heat] = -10;
@@ -689,8 +728,8 @@ namespace DOL.AI.Brain
             AggroRange = 1200;
             ThinkInterval = 2000;
         }
-        public static bool StartedBellum= false;
-        public static bool SpawnWeapons = false;
+        public bool SpawnWeapons = false;
+        private ApocInitializator Initializator => (Body as Bellum)?.Initializator;
         private bool RemoveAdds = false;
         public override void Think()
         {
@@ -699,7 +738,8 @@ namespace DOL.AI.Brain
                 //set state to RETURN TO SPAWN
                 FSM.SetCurrentState(eFSMStateType.RETURN_TO_SPAWN);
                 Body.Health = Body.MaxHealth;
-                StartedBellum = false;
+                if (Initializator != null)
+                    Initializator.StartedBellum = false;
                 SpawnWeapons = false;
                 if (!RemoveAdds)
                 {
@@ -721,7 +761,8 @@ namespace DOL.AI.Brain
             }
             if (HasAggro && Body.TargetObject != null)//bring mobs from rooms if mobs got set PackageID="FamesBaf"
             {
-                StartedBellum = true;
+                if (Initializator != null)
+                    Initializator.StartedBellum = true;
                 RemoveAdds = false;
                 if(SpawnWeapons==false)
                 {
@@ -788,6 +829,7 @@ namespace DOL.GS
     public class WarIncarnateCrush : GameNPC
     {
         public WarIncarnateCrush() : base() { }
+        public bool spawn_copies = false;
 
         public override double GetArmorAF(eArmorSlot slot)
         {
@@ -852,7 +894,6 @@ namespace DOL.GS
             Realm = eRealm.None;
             WarIncarnateCrushBrain adds = new WarIncarnateCrushBrain();
             LoadedFromScript = true;
-            WarIncarnateCrushBrain.spawn_copies = false;
             SetOwnBrain(adds);
             base.AddToWorld();
             return true;
@@ -919,21 +960,21 @@ namespace DOL.AI.Brain
                 smb.AggroLevel = 100;
                 smb.AggroRange = 1000;
                 Add.AddBrain(smb);
+                Add.spawn_copies = true;
                 Add.AddToWorld();
                 WarIncarnateCrushBrain brain = (WarIncarnateCrushBrain)Add.Brain;
                 brain.AddToAggroList(ptarget, 1);
                 Add.StartAttack(ptarget);
             }
         }
-        public static bool spawn_copies = false;
         public override void Think()
         {
             if (Body.IsAlive)
             {
-                if(spawn_copies==false)
+                if(Body is WarIncarnateCrush weapon && weapon.spawn_copies==false)
                 {
                     SpawnCrushWeapons();
-                    spawn_copies = true;
+                    weapon.spawn_copies = true;
                 }
             }
             base.Think();
@@ -948,6 +989,7 @@ namespace DOL.GS
     public class WarIncarnateSlash : GameNPC
     {
         public WarIncarnateSlash() : base() { }
+        public bool spawn_copies2 = false;
         public override double GetArmorAF(eArmorSlot slot)
         {
             return 200;
@@ -1020,7 +1062,6 @@ namespace DOL.GS
             Realm = eRealm.None;
             WarIncarnateSlashBrain adds = new WarIncarnateSlashBrain();
             LoadedFromScript = true;
-            WarIncarnateSlashBrain.spawn_copies2 = false;
             SetOwnBrain(adds);
             base.AddToWorld();
             return true;
@@ -1096,21 +1137,21 @@ namespace DOL.AI.Brain
                 smb.AggroLevel = 100;
                 smb.AggroRange = 1000;
                 Add.AddBrain(smb);
+                Add.spawn_copies2 = true;
                 Add.AddToWorld();
                 WarIncarnateSlashBrain brain = (WarIncarnateSlashBrain)Add.Brain;
                 brain.AddToAggroList(ptarget, 1);
                 Add.StartAttack(ptarget);
             }
         }
-        public static bool spawn_copies2 = false;
         public override void Think()
         {
             if (Body.IsAlive)
             {
-                if (spawn_copies2 == false)
+                if (Body is WarIncarnateSlash weapon && weapon.spawn_copies2 == false)
                 {
                     SpawnSlashWeapons();
-                    spawn_copies2 = true;
+                    weapon.spawn_copies2 = true;
                 }
             }
             base.Think();
@@ -1125,6 +1166,7 @@ namespace DOL.GS
     public class WarIncarnateThrust : GameNPC
     {
         public WarIncarnateThrust() : base() { }
+        public bool spawn_copies3 = false;
         public override double GetArmorAF(eArmorSlot slot)
         {
             return 200;
@@ -1188,7 +1230,6 @@ namespace DOL.GS
             Realm = eRealm.None;
             WarIncarnateThrustBrain adds = new WarIncarnateThrustBrain();
             LoadedFromScript = true;
-            WarIncarnateThrustBrain.spawn_copies3 = false;
             SetOwnBrain(adds);
             base.AddToWorld();
             return true;
@@ -1256,21 +1297,21 @@ namespace DOL.AI.Brain
                 smb.AggroLevel = 100;
                 smb.AggroRange = 1000;
                 Add.AddBrain(smb);
+                Add.spawn_copies3 = true;
                 Add.AddToWorld();
                 WarIncarnateThrustBrain brain = (WarIncarnateThrustBrain)Add.Brain;
                 brain.AddToAggroList(ptarget, 1);
                 Add.StartAttack(ptarget);
             }
         }
-        public static bool spawn_copies3 = false;
         public override void Think()
         {
             if (Body.IsAlive)
             {
-                if (spawn_copies3 == false)
+                if (Body is WarIncarnateThrust weapon && weapon.spawn_copies3 == false)
                 {
                     SpawnThrustWeapons();
-                    spawn_copies3 = true;
+                    weapon.spawn_copies3 = true;
                 }
             }
             base.Think();
@@ -1286,6 +1327,12 @@ namespace DOL.GS
     public class Morbus : GameEpicBoss
     {
         public Morbus() : base() { }
+        private ApocInitializator _initializator;
+        public ApocInitializator Initializator
+        {
+            get => _initializator ??= ApocInitializator.GetInitializator(CurrentRegionID);
+            set => _initializator = value;
+        }
         public override bool HasAbility(string keyName)
         {
             if (IsAlive && keyName == GS.Abilities.CCImmunity)
@@ -1295,7 +1342,7 @@ namespace DOL.GS
         }
         public override void ReturnToSpawnPoint(short speed)
         {
-            if (MorbusBrain.IsBug)
+            if (Brain is MorbusBrain morbusBrain && morbusBrain.IsBug)
                 return;
 
             base.ReturnToSpawnPoint(speed);
@@ -1343,7 +1390,6 @@ namespace DOL.GS
         {
             get { return 100000; }
         }
-        public static bool MorbusUP = true;
         private bool prepareFunus = false;
         public void BroadcastMessage(String message)
         {
@@ -1364,14 +1410,18 @@ namespace DOL.GS
                 new ECSGameTimer(this, new ECSGameTimer.ECSTimerCallback(SpawnHorsemanFunus), 60000);//60s before starting
                 prepareFunus = true;
             }
-            MorbusBrain.StartedMorbus = false;
+            if (Initializator != null)
+            {
+                Initializator.StartedMorbus = false;
+                Initializator.MorbusUP = false;
+            }
             spawn_fate3 = false;
-            MorbusUP = false;
             base.ProcessDeath(killer);
         }
         public int SpawnHorsemanFunus(ECSGameTimer timer)
         {
             Funus Add = new Funus();//inside controller
+            Add.Initializator = Initializator;
             Add.X = 29467;
             Add.Y = 25235;
             Add.Z = 19490;
@@ -1380,7 +1430,7 @@ namespace DOL.GS
             Add.AddToWorld();
             return 0;
         }
-        public static bool spawn_fate3 = false;
+        public bool spawn_fate3 = false;
         public readonly List<GameNPC> Swarm = new List<GameNPC>();
         public int AliveSwarmCount
         {
@@ -1429,13 +1479,12 @@ namespace DOL.GS
             Faction = FactionMgr.GetFactionByID(64);
             BodyType = 11;
             Realm = eRealm.None;
-            MorbusBrain.StartedMorbus = false;
-            MorbusBrain.BafMobs3 = false;
-            MorbusBrain.spawn_swarm = false;
-            MorbusBrain.message_warning1 = false;
-            MorbusBrain.IsBug = false;
-            MorbusUP = true;
             prepareFunus = false;
+            if (Initializator != null)
+            {
+                Initializator.StartedMorbus = false;
+                Initializator.MorbusUP = true;
+            }
 
             AbilityBonus[eProperty.Resist_Body] = 26;
             AbilityBonus[eProperty.Resist_Heat] = 26;
@@ -1472,11 +1521,11 @@ namespace DOL.AI.Brain
             AggroRange = 1200;
             ThinkInterval = 2000;
         }
-        public static bool BafMobs3 = false;
-        public static bool spawn_swarm = false;
-        public static bool message_warning1 = false;
-        public static bool IsBug = false;
-        public static bool StartedMorbus = false;
+        public bool BafMobs3 = false;
+        public bool spawn_swarm = false;
+        public bool message_warning1 = false;
+        public bool IsBug = false;
+        private ApocInitializator Initializator => (Body as Morbus)?.Initializator;
         private bool RemoveAdds = false;
         public override void AttackMostWanted()
         {
@@ -1510,7 +1559,8 @@ namespace DOL.AI.Brain
                 //set state to RETURN TO SPAWN
                 FSM.SetCurrentState(eFSMStateType.RETURN_TO_SPAWN);
                 Body.Health = Body.MaxHealth;
-                StartedMorbus = false;
+                if (Initializator != null)
+                    Initializator.StartedMorbus = false;
                 BafMobs3 = false;
                 message_warning1 = false;
                 if (!RemoveAdds)
@@ -1557,7 +1607,8 @@ namespace DOL.AI.Brain
 
             if (Body.InCombat || HasAggro || Body.attackComponent.AttackState == true)
             {
-                StartedMorbus = true;
+                if (Initializator != null)
+                    Initializator.StartedMorbus = true;
                 if(Body is Morbus morbus && morbus.AliveSwarmCount > 0)
                 {
                     Body.Model = 771;
@@ -1830,6 +1881,12 @@ namespace DOL.GS
     public class Funus : GameEpicBoss
     {
         public Funus() : base() { }
+        private ApocInitializator _initializator;
+        public ApocInitializator Initializator
+        {
+            get => _initializator ??= ApocInitializator.GetInitializator(CurrentRegionID);
+            set => _initializator = value;
+        }
         //Funus only take all dmg from clerics melee/magic/dmgadd
         //and some restricted dmg from other classes:
         //-from mercenary by bow
@@ -1896,7 +1953,6 @@ namespace DOL.GS
         {
             get { return 50000; }
         }
-        public static bool FunusUp = true;
         private bool prepareApoc = false;
         public override void ProcessDeath(GameObject killer)//on kill generate orbs
         {
@@ -1907,13 +1963,17 @@ namespace DOL.GS
                 prepareApoc = true;
             }
             spawn_fate4 = false;
-            FunusBrain.StartedFunus = false;
-            FunusUp = false;
+            if (Initializator != null)
+            {
+                Initializator.StartedFunus = false;
+                Initializator.FunusUp = false;
+            }
             base.ProcessDeath(killer);
         }
         public int SpawnApoc(ECSGameTimer timer)
         {
             Apocalypse Add = new Apocalypse();
+            Add.Initializator = Initializator;
             Add.X = 29467;
             Add.Y = 25235;
             Add.Z = 19490;
@@ -1938,7 +1998,7 @@ namespace DOL.GS
             Add.AddToWorld();
         }
 
-        public static bool spawn_fate4 = false;
+        public bool spawn_fate4 = false;
         public override bool AddToWorld()
         {
             Model = 911;
@@ -1956,10 +2016,12 @@ namespace DOL.GS
             Faction = FactionMgr.GetFactionByID(64);
             BodyType = 11;
             Realm = eRealm.None;
-            FunusBrain.StartedFunus = false;
-            FunusBrain.BafMobs4 = false;
-            FunusUp = true;
             prepareApoc = false;
+            if (Initializator != null)
+            {
+                Initializator.StartedFunus = false;
+                Initializator.FunusUp = true;
+            }
 
             AbilityBonus[eProperty.Resist_Body] = -25;
             AbilityBonus[eProperty.Resist_Heat] = -25;
@@ -1995,8 +2057,8 @@ namespace DOL.AI.Brain
             AggroRange = 1200;
             ThinkInterval = 2000;
         }
-        public static bool BafMobs4 = false;
-        public static bool StartedFunus = false;
+        public bool BafMobs4 = false;
+        private ApocInitializator Initializator => (Body as Funus)?.Initializator;
         public override void Think()
         {
             if (!CheckProximityAggro())
@@ -2004,7 +2066,8 @@ namespace DOL.AI.Brain
                 //set state to RETURN TO SPAWN
                 FSM.SetCurrentState(eFSMStateType.RETURN_TO_SPAWN);
                 Body.Health = Body.MaxHealth;
-                StartedFunus = false;
+                if (Initializator != null)
+                    Initializator.StartedFunus = false;
                 BafMobs4 = false;
             }
             if (Body.IsOutOfTetherRange)
@@ -2018,7 +2081,8 @@ namespace DOL.AI.Brain
             }
             if (Body.TargetObject != null && HasAggro)//bring mobs from rooms if mobs got set PackageID="FamesBaf"
             {
-                StartedFunus = true;
+                if (Initializator != null)
+                    Initializator.StartedFunus = true;
                 if (BafMobs4 == false)
                 {
                     foreach (GameNPC npc in WorldMgr.GetNPCsFromRegion(Body.CurrentRegionID))
@@ -2047,6 +2111,12 @@ namespace DOL.GS
     public class Apocalypse : GameEpicBoss
     {
         public Apocalypse() : base() { }
+        private ApocInitializator _initializator;
+        public ApocInitializator Initializator
+        {
+            get => _initializator ??= ApocInitializator.GetInitializator(CurrentRegionID);
+            set => _initializator = value;
+        }
         public void BroadcastMessage(String message)
         {
             foreach (GamePlayer player in GetPlayersInRadius(WorldMgr.VISIBILITY_DISTANCE))
@@ -2086,7 +2156,6 @@ namespace DOL.GS
         {
             get { return 300000; }
         }
-        public static bool ApocUP = true;
         public override void ProcessDeath(GameObject killer)//on kill generate orbs
         {
             foreach (GameNPC npc in GetNPCsInRadius(4000))
@@ -2104,9 +2173,12 @@ namespace DOL.GS
 
             AwardEpicEncounterKillPoint();
 
-            ApocalypseBrain.StartedApoc = false;
-            ApocInitializator.start_respawn_check = false;
-            ApocUP = false;
+            if (Initializator != null)
+            {
+                Initializator.StartedApoc = false;
+                Initializator.start_respawn_check = false;
+                Initializator.ApocUP = false;
+            }
             base.ProcessDeath(killer);
         }      
         
@@ -2142,16 +2214,11 @@ namespace DOL.GS
             LoadTemplate(npcTemplate);
             Faction = FactionMgr.GetFactionByID(64);
 
-            ApocalypseBrain.spawn_harbringers = false;
-            ApocalypseBrain.spawn_rain_of_fire = false;
-            ApocalypseBrain.apoc_fly_phase = false;
-            ApocalypseBrain.IsInFlyPhase = false;
-            ApocalypseBrain.fly_phase1 = false;
-            ApocalypseBrain.fly_phase2 = false;
-            ApocalypseBrain.ApocAggro = false;
-            ApocalypseBrain.pop_harbringers = false;
-            ApocalypseBrain.StartedApoc = false;
-            ApocUP = true;
+            if (Initializator != null)
+            {
+                Initializator.StartedApoc = false;
+                Initializator.ApocUP = true;
+            }
 
 
             foreach (GamePlayer player in ClientService.Instance.GetPlayersOfRegion(CurrentRegion))
@@ -2175,7 +2242,7 @@ namespace DOL.GS
         }
         public override void StartAttack(GameObject target)
         {
-            if (ApocalypseBrain.IsInFlyPhase)
+            if (Brain is ApocalypseBrain apocBrain && apocBrain.IsInFlyPhase)
                 return;
             else
                 base.StartAttack(target);
@@ -2194,14 +2261,14 @@ namespace DOL.AI.Brain
             AggroRange = 1300;
             ThinkInterval = 2000;
         }
-        public static bool spawn_rain_of_fire = false;
-        public static bool apoc_fly_phase = false;
-        public static bool IsInFlyPhase = false;
-        public static bool fly_phase1 = false;
-        public static bool fly_phase2 = false;
-        public static bool ApocAggro = false;
-        public static bool pop_harbringers = false;
-        public static bool StartedApoc = false;
+        public bool spawn_rain_of_fire = false;
+        public bool apoc_fly_phase = false;
+        public bool IsInFlyPhase = false;
+        public bool fly_phase1 = false;
+        public bool fly_phase2 = false;
+        public bool ApocAggro = false;
+        public bool pop_harbringers = false;
+        private ApocInitializator Initializator => (Body as Apocalypse)?.Initializator;
         private bool RemoveAdds = false;
         private int _harbringersCount = 0;
 
@@ -2211,22 +2278,22 @@ namespace DOL.AI.Brain
             if (Body.InCombatInLast(60 * 1000) == false && this.Body.InCombatInLast(65 * 1000))
             {
                 Body.Health = Body.MaxHealth;
-                spawn_rain_of_fire = false;
-                spawn_harbringers = false;
-
                 apoc_fly_phase = false;
                 IsInFlyPhase = false;
                 fly_phase1 = false;
                 fly_phase2 = false;
                 ApocAggro = false;
                 pop_harbringers = false;
-                StartedApoc = false;
+                if (Initializator != null)
+                    Initializator.StartedApoc = false;
                 if (Body is Apocalypse apoc)
                     apoc.KilledEnemys = 0;
-                _harbringersCount = 0;
 
                 if (!RemoveAdds)
                 {
+                    spawn_rain_of_fire = false;
+                    spawn_harbringers = false;
+                    _harbringersCount = 0;
                     foreach (GameNPC npc in Body.GetNPCsInRadius(4000))
                     {
                         if (npc != null)
@@ -2246,7 +2313,8 @@ namespace DOL.AI.Brain
             #region Boss combat
             if (Body.IsAlive)//bring mobs from rooms if mobs got set PackageID="ApocBaf"
             {
-                StartedApoc = true;
+                if (Initializator != null)
+                    Initializator.StartedApoc = true;
                 if (HasAggro && Body.TargetObject != null)
                     RemoveAdds = false;
 
@@ -2364,7 +2432,7 @@ namespace DOL.AI.Brain
         #endregion
 
         #region Spawn Harbringers
-        public static bool spawn_harbringers = false;
+        public bool spawn_harbringers = false;
         public int SpawnHarbringers(ECSGameTimer timer)
         {
             if (Body is Apocalypse apoc && apoc.KilledEnemys == 4)//he doint it only once, spawning 2 harbringers is killed 4 players
@@ -2670,8 +2738,8 @@ namespace DOL.AI.Brain
             get { return dd_Target; }
             set { dd_Target = value; }
         }
-        public static bool cast_dd = false;
-        public static bool reset_cast = false;
+        public bool cast_dd = false;
+        public bool reset_cast = false;
         public void PickTarget()
         {
             foreach (GamePlayer player in Body.GetPlayersInRadius(2500))

--- a/GameServer/scripts/namedmobs/CaerSidi/BaneOfHope.cs
+++ b/GameServer/scripts/namedmobs/CaerSidi/BaneOfHope.cs
@@ -65,8 +65,8 @@ namespace DOL.AI.Brain
             AggroLevel = 100;
             AggroRange = 500;
         }
-        public static GameLiving TeleportTarget = null;
-        public static bool CanPoison = false;
+        public GameLiving TeleportTarget = null;
+        public bool CanPoison = false;
         public override void OnAttackedByEnemy(AttackData ad)
         {
             if(ad != null && ad.Attacker != null && Body.TargetObject != ad.Attacker && CanPoison==false)

--- a/GameServer/scripts/namedmobs/CaerSidi/LichLordIlron.cs
+++ b/GameServer/scripts/namedmobs/CaerSidi/LichLordIlron.cs
@@ -61,7 +61,7 @@ namespace DOL.GS.Scripts
             sBrain.AggroLevel = 100;
             sBrain.AggroRange = 500;
 
-            LichLordIlronBrain.spawnimages = true;
+            sBrain.spawnimages = true;
             LoadedFromScript = false;//load from database
             SaveIntoDatabase();
             base.AddToWorld();
@@ -94,7 +94,7 @@ namespace DOL.AI.Brain
     {
         private static readonly Logging.Logger log = Logging.LoggerManager.Create(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        public static bool spawnimages = true;
+        public bool spawnimages = true;
 
         public override void Think()
         {

--- a/GameServer/scripts/namedmobs/CaerSidi/LordSanguis.cs
+++ b/GameServer/scripts/namedmobs/CaerSidi/LordSanguis.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Numerics;
 using DOL.AI.Brain;
 using DOL.Events;
@@ -187,6 +188,15 @@ namespace DOL.AI.Brain
             AggroRange = 500;
         }
         private bool RemoveAdds = false;
+        private readonly List<GameNPC> _mages = new List<GameNPC>();
+        private int AliveMageCount
+        {
+            get
+            {
+                _mages.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not GameObject.eObjectState.Active);
+                return _mages.Count;
+            }
+        }
         public override void Think()
         {
             if (!CheckProximityAggro())
@@ -194,7 +204,7 @@ namespace DOL.AI.Brain
                 //set state to RETURN TO SPAWN
                 FSM.SetCurrentState(eFSMStateType.RETURN_TO_SPAWN);
                 Body.Health = Body.MaxHealth;
-                BloodMage.MageCount = 0;
+                _mages.Clear();
                 if (!RemoveAdds)
                 {
                     foreach (GameNPC mages in Body.GetNPCsInRadius(5000))
@@ -213,7 +223,7 @@ namespace DOL.AI.Brain
                 RemoveAdds = false;
                 if (Util.Chance(10))
                 {
-                    if (BloodMage.MageCount < 2)
+                    if (AliveMageCount < 2)
                         SpawnMages();
                 }
             }
@@ -228,6 +238,7 @@ namespace DOL.AI.Brain
             Add.CurrentRegion = Body.CurrentRegion;
             Add.Heading = Body.Heading;
             Add.AddToWorld();
+            _mages.Add(Add);
         }
     }
 }
@@ -391,13 +402,6 @@ namespace DOL.GS
             get { return 8000; }
         }
 
-        public override void ProcessDeath(GameObject killer)
-        {
-            --MageCount;
-            base.ProcessDeath(killer);
-        }
-
-        public static int MageCount = 0;
         public override short Quickness { get => base.Quickness; set => base.Quickness = 80; }
         public override short Strength { get => base.Strength; set => base.Strength = 150; }   
         public override bool AddToWorld()
@@ -429,7 +433,6 @@ namespace DOL.GS
             Faction = FactionMgr.GetFactionByID(64);
             BodyType = 6;
             Realm = eRealm.None;
-            ++MageCount;
 
             BloodMageBrain adds = new BloodMageBrain();
             SetOwnBrain(adds);
@@ -447,10 +450,7 @@ namespace DOL.GS
             if (InCombat || Brain is StandardMobBrain { HasAggro: true })
                 return DESPAWN_RETRY_INTERVAL;
 
-            // RemoveFromWorld skips ProcessDeath, so the counter must be decremented here.
-            if (RemoveFromWorld())
-                --MageCount;
-
+            RemoveFromWorld();
             return 0;
         }
     }

--- a/GameServer/scripts/namedmobs/CaerSidi/LordSanguis.cs
+++ b/GameServer/scripts/namedmobs/CaerSidi/LordSanguis.cs
@@ -94,7 +94,7 @@ namespace DOL.GS
             base.ProcessDeath(killer);
         }
 
-        public static bool Spawn_Lich_Lord = false;
+        public bool Spawn_Lich_Lord = false;
 
         public int SpawnLich(ECSGameTimer timer)
         {
@@ -302,7 +302,6 @@ namespace DOL.GS
             Name = "Lich Lord Sanguis";
             ParryChance = 35;
             RespawnInterval = -1;
-            LichLordSanguisBrain.set_flag = false;
 
             TetherRange = 2000;
             Size = 100;
@@ -312,7 +311,6 @@ namespace DOL.GS
             Faction = FactionMgr.GetFactionByID(64);
             BodyType = 8;
             Realm = eRealm.None;
-            LichLordSanguisBrain.set_flag = false;
             LichLordSanguisBrain adds = new LichLordSanguisBrain();
             SetOwnBrain(adds);
             base.AddToWorld();
@@ -345,7 +343,7 @@ namespace DOL.AI.Brain
                 player.Out.SendMessage(message, eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow);
             }
         }
-        public static bool set_flag = false;
+        public bool set_flag = false;
         public override void Think()
         {
             if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/CaerSidi/Silencer.cs
+++ b/GameServer/scripts/namedmobs/CaerSidi/Silencer.cs
@@ -92,10 +92,10 @@ namespace DOL.GS
             }
         }
 
-        public static bool get_resist = false; //set resists
-        public static bool resist_timer = false;
-        public static bool resist_timer_end = false;
-        public static bool spam1 = false;
+        public bool get_resist = false; //set resists
+        public bool resist_timer = false;
+        public bool resist_timer_end = false;
+        public bool spam1 = false;
 
         public int ResistTime(ECSGameTimer timer)
         {
@@ -131,6 +131,7 @@ namespace DOL.GS
             INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(60166029);
             LoadTemplate(npcTemplate);
             LoadTemplate(npcTemplate);
+            attackers.Clear();
             attackers_count = 0;
             get_resist = false;
             resist_timer = false;

--- a/GameServer/scripts/namedmobs/CaerSidi/Silencer.cs
+++ b/GameServer/scripts/namedmobs/CaerSidi/Silencer.cs
@@ -46,8 +46,8 @@ namespace DOL.GS
             return 0.20;
         }
 
-        public static List<GamePlayer> attackers = new List<GamePlayer>();
-        public static int attackers_count = 0;
+        public List<GamePlayer> attackers = new List<GamePlayer>();
+        public int attackers_count = 0;
         public override void TakeDamage(GameObject source, eDamageType damageType, int damageAmount, int criticalAmount)
         {
             if (source is GamePlayer || source is GameSummonedPet)
@@ -170,14 +170,16 @@ namespace DOL.AI.Brain
                 //set state to RETURN TO SPAWN
                 FSM.SetCurrentState(eFSMStateType.RETURN_TO_SPAWN);
                 Body.Health = Body.MaxHealth;
-                Silencer.attackers_count = 0;
-                //Silencer silencer = new Silencer();
-                if (!ClearAttackers)
+                if (Body is Silencer silencer)
                 {
-                    if (Silencer.attackers.Count > 0)
+                    silencer.attackers_count = 0;
+                    if (!ClearAttackers)
                     {
-                        Silencer.attackers.Clear();
-                        ClearAttackers = true;
+                        if (silencer.attackers.Count > 0)
+                        {
+                            silencer.attackers.Clear();
+                            ClearAttackers = true;
+                        }
                     }
                 }
             }

--- a/GameServer/scripts/namedmobs/CaerSidi/SoulReckoner.cs
+++ b/GameServer/scripts/namedmobs/CaerSidi/SoulReckoner.cs
@@ -119,6 +119,12 @@ namespace DOL.GS
             }
         }
 
+        public void RegisterSoul(GameNPC soul)
+        {
+            _souls.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not eObjectState.Active);
+            _souls.Add(soul);
+        }
+
         public override void ProcessDeath(GameObject killer) //on kill generate orbs
         {
             foreach (GameNPC npc in GetNPCsInRadius(8000))
@@ -294,6 +300,9 @@ namespace DOL.AI.Brain
                     Add.CurrentRegion = Body.CurrentRegion;
                     Add.Heading = Body.Heading;
                     Add.AddToWorld();
+
+                    if (Body is SoulReckoner reckoner)
+                        reckoner.RegisterSoul(Add);
                 }
             }
             new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(ResetRespawnSouls), Util.Random(60000, 70000));

--- a/GameServer/scripts/namedmobs/CaerSidi/SoulReckoner.cs
+++ b/GameServer/scripts/namedmobs/CaerSidi/SoulReckoner.cs
@@ -85,7 +85,7 @@ namespace DOL.GS
             return true;
         }
 
-        public static bool spawn_souls = false;
+        public bool spawn_souls = false;
         private readonly List<GameNPC> _souls = new List<GameNPC>();
         private int AliveSoulCount
         {
@@ -151,7 +151,7 @@ namespace DOL.GS
         {
             if (source is GamePlayer || source is GameSummonedPet)
             {
-                if (AliveSoulCount > 0 || SoulReckonerBrain.InRoom == false) //take no damage
+                if (AliveSoulCount > 0 || Brain is not SoulReckonerBrain { InRoom: true }) //take no damage
                 {
                     GamePlayer truc;
                     if (source is GamePlayer)
@@ -206,7 +206,7 @@ namespace DOL.AI.Brain
             CanBaf = false;
         }
 
-        public static bool InRoom = false;
+        public bool InRoom = false;
 
         public void AwayFromRoom()
         {
@@ -242,7 +242,7 @@ namespace DOL.AI.Brain
                 }
             }
         }
-        public static bool BafMobs = false;
+        public bool BafMobs = false;
 
         public override void Think()
         {
@@ -286,7 +286,7 @@ namespace DOL.AI.Brain
             base.Think();
         }
         #region Spawn Soul
-        public static bool Spawn_Souls = false;
+        public bool Spawn_Souls = false;
         private int SpawnSouls(ECSGameTimer timer)
         {
             if (Body.IsAlive && HasAggro)

--- a/GameServer/scripts/namedmobs/CaerSidi/SoulReckoner.cs
+++ b/GameServer/scripts/namedmobs/CaerSidi/SoulReckoner.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using DOL.AI.Brain;
 using DOL.Database;
 using DOL.GS;
@@ -59,7 +60,7 @@ namespace DOL.GS
 
             MeleeDamageType = eDamageType.Spirit;
             RespawnInterval = ServerProperties.Properties.SET_SI_EPIC_ENCOUNTER_RESPAWNINTERVAL * 60000; //1min is 60000 miliseconds
-            ReckonedSoul.SoulCount = 0;
+            _souls.Clear();
             SoulReckonerBrain adds = new SoulReckonerBrain();
             SetOwnBrain(adds);
             if (CurrentRegionID == 60)
@@ -85,9 +86,26 @@ namespace DOL.GS
         }
 
         public static bool spawn_souls = false;
+        private readonly List<GameNPC> _souls = new List<GameNPC>();
+        private int AliveSoulCount
+        {
+            get
+            {
+                int count = 0;
+
+                foreach (GameNPC npc in _souls)
+                {
+                    if (npc != null && npc.IsAlive && npc.ObjectState is eObjectState.Active)
+                        count++;
+                }
+
+                return count;
+            }
+        }
 
         public void SpawnSouls()
         {
+            _souls.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not eObjectState.Active);
             for (int i = 0; i < Util.Random(4, 6); i++) // Spawn 4-6 souls
             {
                 ReckonedSoul Add = new ReckonedSoul();
@@ -97,6 +115,7 @@ namespace DOL.GS
                 Add.CurrentRegion = CurrentRegion;
                 Add.Heading = Heading;
                 Add.AddToWorld();
+                _souls.Add(Add);
             }
         }
 
@@ -126,7 +145,7 @@ namespace DOL.GS
         {
             if (source is GamePlayer || source is GameSummonedPet)
             {
-                if (ReckonedSoul.SoulCount > 0 || SoulReckonerBrain.InRoom == false) //take no damage
+                if (AliveSoulCount > 0 || SoulReckonerBrain.InRoom == false) //take no damage
                 {
                     GamePlayer truc;
                     if (source is GamePlayer)
@@ -348,15 +367,9 @@ namespace DOL.GS
             get { return 20000; }
         }
 
-        public override void ProcessDeath(GameObject killer)
-        {
-            --SoulCount;
-            base.ProcessDeath(killer);
-        }
         public override bool CanDropLoot => false;
         public override short Quickness { get => base.Quickness; set => base.Quickness = 80; }
         public override short Strength { get => base.Strength; set => base.Strength = 150; }
-        public static int SoulCount = 0;
 
         public override bool AddToWorld()
         {
@@ -376,7 +389,6 @@ namespace DOL.GS
             Faction = FactionMgr.GetFactionByID(64);
             BodyType = 6;
             Realm = eRealm.None;
-            ++SoulCount;
 
             ReckonedSoulBrain adds = new ReckonedSoulBrain();
             SetOwnBrain(adds);

--- a/GameServer/scripts/namedmobs/DarknessFalls/Legion.cs
+++ b/GameServer/scripts/namedmobs/DarknessFalls/Legion.cs
@@ -82,9 +82,6 @@ namespace DOL.GS.Scripts
             Empathy = npcTemplate.Empathy;
             Piety = npcTemplate.Piety;
             Intelligence = npcTemplate.Intelligence;
-            LegionBrain.CanThrow = false;
-            LegionBrain.RemoveAdds = false;
-            LegionBrain.IsCreatingSouls = false;
 
             // demon
             BodyType = 2;
@@ -305,59 +302,17 @@ namespace DOL.AI.Brain
             AggroLevel = 100;
             AggroRange = 850;
         }
-        public static bool RemoveAdds = false;
-        public static bool IsCreatingSouls = false;
-        public static bool CanThrow = false;
-        public static bool CanPbaoe = false;
-        #region Health check bools
-        public static bool adds1 = false;
-        public static bool adds2 = false;
-        public static bool adds3 = false;
-        public static bool adds4 = false;
-        public static bool adds5 = false;
-        public static bool adds6 = false;
-        public static bool adds7 = false;
-        public static bool adds8 = false;
-        public static bool adds9 = false;
-        public static bool adds10 = false;
-        public static bool adds11 = false;
-        public static bool adds12 = false;
-        public static bool adds13 = false;
-        public static bool adds14 = false;
-        public static bool adds15 = false;
-        public static bool adds16 = false;
-        public static bool adds17 = false;
-        public static bool adds18 = false;
-        public static bool adds19 = false;
-        #endregion
+        private bool RemoveAdds = false;
+        private bool CanThrow = false;
+        private bool CanPbaoe = false;
+        private readonly bool[] addsSpawned = new bool[19];
 
         public override void Think()
         {
             if(!CheckProximityAggro())
             {
-                IsCreatingSouls = false;
                 CanThrow = false;
-                #region Health check bools
-                adds1 = false;
-                adds2 = false;
-                adds3 = false;
-                adds4 = false;
-                adds5 = false;
-                adds6 = false;
-                adds7 = false;
-                adds8 = false;
-                adds9 = false;
-                adds10 = false;
-                adds11 = false;
-                adds12 = false;
-                adds13 = false;
-                adds14 = false;
-                adds15 = false;
-                adds16 = false;
-                adds17 = false;
-                adds18 = false;
-                adds19 = false;
-                #endregion
+                Array.Clear(addsSpawned, 0, addsSpawned.Length);
 
                 if (randomlyPickedPlayers.Count > 0)//clear randomly picked players
                     randomlyPickedPlayers.Clear();
@@ -400,100 +355,15 @@ namespace DOL.AI.Brain
                     CanPbaoe = true;
                 }
                 #region Legion health checks
-                if (Body.HealthPercent <= 95 && Body.HealthPercent > 90 && !adds1)
+                int healthPercent = Body.HealthPercent;
+                for (int i = 0; i < addsSpawned.Length; i++)
                 {
-                    SpawnAdds();
-                    adds1 = true;
-                }
-                if (Body.HealthPercent <= 90 && Body.HealthPercent > 85 && !adds2)
-                {
-                    SpawnAdds();
-                    adds2 = true;
-                }
-                if (Body.HealthPercent <= 85 && Body.HealthPercent > 80 && !adds3)
-                {
-                    SpawnAdds();
-                    adds3 = true;
-                }
-                if (Body.HealthPercent <= 80 && Body.HealthPercent > 75 && !adds4)
-                {
-                    SpawnAdds();
-                    adds4 = true;
-                }
-                if (Body.HealthPercent <= 75 && Body.HealthPercent > 70 && !adds5)
-                {
-                    SpawnAdds();
-                    adds5 = true;
-                }
-                if (Body.HealthPercent <= 70 && Body.HealthPercent > 65 && !adds6)
-                {
-                    SpawnAdds();
-                    adds6 = true;
-                }
-                if (Body.HealthPercent <= 65 && Body.HealthPercent > 60 && !adds7)
-                {
-                    SpawnAdds();
-                    adds7 = true;
-                }
-                if (Body.HealthPercent <= 60 && Body.HealthPercent > 55 && !adds8)
-                {
-                    SpawnAdds();
-                    adds8 = true;
-                }
-                if (Body.HealthPercent <= 55 && Body.HealthPercent > 50 && !adds9)
-                {
-                    SpawnAdds();
-                    adds9 = true;
-                }
-                if (Body.HealthPercent <= 50 && Body.HealthPercent > 45 && !adds10)
-                {
-                    SpawnAdds();
-                    adds10 = true;
-                }
-                if (Body.HealthPercent <= 45 && Body.HealthPercent > 40 && !adds11)
-                {
-                    SpawnAdds();
-                    adds11 = true;
-                }
-                if (Body.HealthPercent <= 40 && Body.HealthPercent > 35 && !adds12)
-                {
-                    SpawnAdds();
-                    adds12 = true;
-                }
-                if (Body.HealthPercent <= 35 && Body.HealthPercent > 30 && !adds13)
-                {
-                    SpawnAdds();
-                    adds13 = true;
-                }
-                if (Body.HealthPercent <= 30 && Body.HealthPercent > 25 && !adds14)
-                {
-                    SpawnAdds();
-                    adds14 = true;
-                }
-                if (Body.HealthPercent <= 25 && Body.HealthPercent > 20 && !adds15)
-                {
-                    SpawnAdds();
-                    adds15 = true;
-                }
-                if (Body.HealthPercent <= 20 && Body.HealthPercent > 15 && !adds16)
-                {
-                    SpawnAdds();
-                    adds16 = true;
-                }
-                if (Body.HealthPercent <= 15 && Body.HealthPercent > 10 && !adds17)
-                {
-                    SpawnAdds();
-                    adds17 = true;
-                }
-                if (Body.HealthPercent <= 10 && Body.HealthPercent > 5 && !adds18)
-                {
-                    SpawnAdds();
-                    adds18 = true;
-                }
-                if (Body.HealthPercent <= 5 && Body.HealthPercent > 0 && !adds19)
-                {
-                    SpawnAdds();
-                    adds19 = true;
+                    int upperBound = 95 - i * 5;
+                    if (healthPercent <= upperBound && healthPercent > upperBound - 5 && !addsSpawned[i])
+                    {
+                        SpawnAdds();
+                        addsSpawned[i] = true;
+                    }
                 }
                 #endregion
                 if (!CanThrow)

--- a/GameServer/scripts/namedmobs/DarknessFalls/Legion.cs
+++ b/GameServer/scripts/namedmobs/DarknessFalls/Legion.cs
@@ -403,134 +403,96 @@ namespace DOL.AI.Brain
                 if (Body.HealthPercent <= 95 && Body.HealthPercent > 90 && !adds1)
                 {
                     SpawnAdds();
-                    spawnAmount = 0;
-                    PlayerCountInLegionLair = 0;
                     adds1 = true;
                 }
                 if (Body.HealthPercent <= 90 && Body.HealthPercent > 85 && !adds2)
                 {
                     SpawnAdds();
-                    spawnAmount = 0;
-                    PlayerCountInLegionLair = 0;
                     adds2 = true;
                 }
                 if (Body.HealthPercent <= 85 && Body.HealthPercent > 80 && !adds3)
                 {
                     SpawnAdds();
-                    spawnAmount = 0;
-                    PlayerCountInLegionLair = 0;
                     adds3 = true;
                 }
                 if (Body.HealthPercent <= 80 && Body.HealthPercent > 75 && !adds4)
                 {
                     SpawnAdds();
-                    spawnAmount = 0;
-                    PlayerCountInLegionLair = 0;
                     adds4 = true;
                 }
                 if (Body.HealthPercent <= 75 && Body.HealthPercent > 70 && !adds5)
                 {
                     SpawnAdds();
-                    spawnAmount = 0;
-                    PlayerCountInLegionLair = 0;
                     adds5 = true;
                 }
                 if (Body.HealthPercent <= 70 && Body.HealthPercent > 65 && !adds6)
                 {
                     SpawnAdds();
-                    spawnAmount = 0;
-                    PlayerCountInLegionLair = 0;
                     adds6 = true;
                 }
                 if (Body.HealthPercent <= 65 && Body.HealthPercent > 60 && !adds7)
                 {
                     SpawnAdds();
-                    spawnAmount = 0;
-                    PlayerCountInLegionLair = 0;
                     adds7 = true;
                 }
                 if (Body.HealthPercent <= 60 && Body.HealthPercent > 55 && !adds8)
                 {
                     SpawnAdds();
-                    spawnAmount = 0;
-                    PlayerCountInLegionLair = 0;
                     adds8 = true;
                 }
                 if (Body.HealthPercent <= 55 && Body.HealthPercent > 50 && !adds9)
                 {
                     SpawnAdds();
-                    spawnAmount = 0;
-                    PlayerCountInLegionLair = 0;
                     adds9 = true;
                 }
                 if (Body.HealthPercent <= 50 && Body.HealthPercent > 45 && !adds10)
                 {
                     SpawnAdds();
-                    spawnAmount = 0;
-                    PlayerCountInLegionLair = 0;
                     adds10 = true;
                 }
                 if (Body.HealthPercent <= 45 && Body.HealthPercent > 40 && !adds11)
                 {
                     SpawnAdds();
-                    spawnAmount = 0;
-                    PlayerCountInLegionLair = 0;
                     adds11 = true;
                 }
                 if (Body.HealthPercent <= 40 && Body.HealthPercent > 35 && !adds12)
                 {
                     SpawnAdds();
-                    spawnAmount = 0;
-                    PlayerCountInLegionLair = 0;
                     adds12 = true;
                 }
                 if (Body.HealthPercent <= 35 && Body.HealthPercent > 30 && !adds13)
                 {
                     SpawnAdds();
-                    spawnAmount = 0;
-                    PlayerCountInLegionLair = 0;
                     adds13 = true;
                 }
                 if (Body.HealthPercent <= 30 && Body.HealthPercent > 25 && !adds14)
                 {
                     SpawnAdds();
-                    spawnAmount = 0;
-                    PlayerCountInLegionLair = 0;
                     adds14 = true;
                 }
                 if (Body.HealthPercent <= 25 && Body.HealthPercent > 20 && !adds15)
                 {
                     SpawnAdds();
-                    spawnAmount = 0;
-                    PlayerCountInLegionLair = 0;
                     adds15 = true;
                 }
                 if (Body.HealthPercent <= 20 && Body.HealthPercent > 15 && !adds16)
                 {
                     SpawnAdds();
-                    spawnAmount = 0;
-                    PlayerCountInLegionLair = 0;
                     adds16 = true;
                 }
                 if (Body.HealthPercent <= 15 && Body.HealthPercent > 10 && !adds17)
                 {
                     SpawnAdds();
-                    spawnAmount = 0;
-                    PlayerCountInLegionLair = 0;
                     adds17 = true;
                 }
                 if (Body.HealthPercent <= 10 && Body.HealthPercent > 5 && !adds18)
                 {
                     SpawnAdds();
-                    spawnAmount = 0;
-                    PlayerCountInLegionLair = 0;
                     adds18 = true;
                 }
                 if (Body.HealthPercent <= 5 && Body.HealthPercent > 0 && !adds19)
                 {
                     SpawnAdds();
-                    spawnAmount = 0;
-                    PlayerCountInLegionLair = 0;
                     adds19 = true;
                 }
                 #endregion
@@ -589,25 +551,25 @@ namespace DOL.AI.Brain
             CanPbaoe = false;
             return 0;
         }
-        public static int PlayerCountInLegionLair = 0;
-        public static int spawnAmount = 0;
         private void SpawnAdds()
         {
+            int playerCountInLegionLair = 0;
+            int spawnAmount = 0;
             if (Body.InCombat && Body.IsAlive && HasAggro)
             {
                 foreach (GamePlayer playerNearby in Body.GetPlayersInRadius(2000))
                 {
                     if (playerNearby != null && playerNearby.Client.Account.PrivLevel == 1)
                     {
-                        PlayerCountInLegionLair++;
+                        playerCountInLegionLair++;
                     }
-                    if (PlayerCountInLegionLair < 4)
+                    if (playerCountInLegionLair < 4)
                         spawnAmount = 1;
-                    if (PlayerCountInLegionLair > 4)
-                        spawnAmount = PlayerCountInLegionLair / 4;
+                    if (playerCountInLegionLair > 4)
+                        spawnAmount = playerCountInLegionLair / 4;
                 }
             }
-            if (PlayerCountInLegionLair > 0 && spawnAmount > 0)
+            if (playerCountInLegionLair > 0 && spawnAmount > 0)
             {
                 //log.Warn("PlayerCountInLegionLair = " + PlayerCountInLegionLair + " and spawnAmount = "+ spawnAmount);
                 for (int i = 0; i < spawnAmount; i++)

--- a/GameServer/scripts/namedmobs/DarknessFalls/PrincessNahemah.cs
+++ b/GameServer/scripts/namedmobs/DarknessFalls/PrincessNahemah.cs
@@ -56,7 +56,7 @@ namespace DOL.GS
             SetOwnBrain(sBrain);
             sBrain.AggroLevel = 100;
             sBrain.AggroRange = 500;
-            PrincessNahemahBrain.spawnMinions = true;
+            sBrain.spawnMinions = true;
 
             // demon
             BodyType = 2;
@@ -87,7 +87,7 @@ namespace DOL.AI.Brain
     {
         private static readonly Logging.Logger log = Logging.LoggerManager.Create(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        public static bool spawnMinions = true;
+        public bool spawnMinions = true;
         private bool RemoveAdds = false;
         public override void Think()
         {

--- a/GameServer/scripts/namedmobs/Dodens/Gudlaugr.cs
+++ b/GameServer/scripts/namedmobs/Dodens/Gudlaugr.cs
@@ -97,7 +97,7 @@ namespace DOL.GS.Scripts
 		{
 			public GudlaugrBrain() : base() { }
 
-			public static bool transmorph = true;
+			public bool transmorph = true;
 			public override void Think()
 			{
 				if (Body.InCombat && Body.IsAlive && HasAggro)

--- a/GameServer/scripts/namedmobs/Dodens/MinstressofRunes.cs
+++ b/GameServer/scripts/namedmobs/Dodens/MinstressofRunes.cs
@@ -143,14 +143,14 @@ namespace DOL.AI.Brain
 		};
 		#endregion
 		#region Nearsight
-		public static GamePlayer randomtarget = null;
-		public static GamePlayer RandomTarget
+		public GamePlayer randomtarget = null;
+		public GamePlayer RandomTarget
 		{
 			get { return randomtarget; }
 			set { randomtarget = value; }
 		}
-		public static bool CanCast = false;
-		public static bool StartCastNS = false;
+		public bool CanCast = false;
+		public bool StartCastNS = false;
 		List<GamePlayer> Enemys_To_NS = new List<GamePlayer>();
 		private int PickRandomTarget(ECSGameTimer timer)
 		{
@@ -172,7 +172,7 @@ namespace DOL.AI.Brain
 				if (CanCast == false)
 				{
 					GamePlayer Target = Enemys_To_NS[Util.Random(0, Enemys_To_NS.Count - 1)];//pick random target from list
-					RandomTarget = Target;//set random target to static RandomTarget
+					RandomTarget = Target;
 					BroadcastMessage(RandomTarget.Name + " can no longer see properly in the vicinity!");
 					new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(ResetDot), 2000);
 					CanCast = true;

--- a/GameServer/scripts/namedmobs/Dodens/SpiritmasterAros.cs
+++ b/GameServer/scripts/namedmobs/Dodens/SpiritmasterAros.cs
@@ -406,7 +406,6 @@ namespace DOL.GS
 		{
 			153,162,137,146,773,784,169,178,185,194
 		};
-		public static int ArosPetCount = 0;
 		public override bool AddToWorld()
 		{
 			Name = "spirit champion";
@@ -427,7 +426,6 @@ namespace DOL.GS
 			Faction = FactionMgr.GetFactionByID(779);
 
 			VisibleActiveWeaponSlots = 16;
-			++ArosPetCount;
 			Size = 50;
 			Level = 62;
 			MaxSpeedBase = 225;
@@ -442,11 +440,6 @@ namespace DOL.GS
 			base.AddToWorld();
 			return true;
 		}
-        public override void ProcessDeath(GameObject killer)
-        {
-			--ArosPetCount;
-            base.ProcessDeath(killer);
-        }
         public override bool CanDropLoot => false;
 		public override long ExperienceValue => 0;
 		private Spell m_SpiritChampion_stun;

--- a/GameServer/scripts/namedmobs/Dodens/SpiritmasterAros.cs
+++ b/GameServer/scripts/namedmobs/Dodens/SpiritmasterAros.cs
@@ -229,10 +229,10 @@ namespace DOL.AI.Brain
 			}
 		}
 		#region Aros Debuff
-		public static bool CanCastDebuff = false;
+		public bool CanCastDebuff = false;
 		List<GamePlayer> Enemys_To_Debuff = new List<GamePlayer>();
-		public static GamePlayer debufftarget = null;
-		public static GamePlayer DebuffTarget
+		public GamePlayer debufftarget = null;
+		public GamePlayer DebuffTarget
 		{
 			get { return debufftarget; }
 			set { debufftarget = value; }
@@ -254,7 +254,7 @@ namespace DOL.AI.Brain
 					if (CanCastDebuff == false && Body.GetSkillDisabledDuration(Aros_Debuff) == 0)
 					{
 						GamePlayer Target = Enemys_To_Debuff[Util.Random(0, Enemys_To_Debuff.Count - 1)];//pick random target from list
-						DebuffTarget = Target;//set random target to static RandomTarget
+						DebuffTarget = Target;
 						new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(ResetDebuff), 5000);
 						CanCastDebuff = true;
 					}

--- a/GameServer/scripts/namedmobs/Evern.cs
+++ b/GameServer/scripts/namedmobs/Evern.cs
@@ -79,7 +79,6 @@ namespace DOL.GS
             INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(60160628);
             LoadTemplate(npcTemplate);
             RespawnInterval = ServerProperties.Properties.SET_SI_EPIC_ENCOUNTER_RESPAWNINTERVAL * 60000; //1min is 60000 miliseconds
-            EvernBrain.spawnfairy = false;
             //Idle = false;
             MaxSpeedBase = 300;
 
@@ -166,7 +165,7 @@ namespace DOL.AI.Brain
             AggroRange = 600;
             ThinkInterval = 1500;
         }
-        public static bool spawnfairy = false;
+        public bool spawnfairy = false;
         private bool RemoveAdds = false;
         public override void Think()
         {

--- a/GameServer/scripts/namedmobs/Fomor/Anurigunda.cs
+++ b/GameServer/scripts/namedmobs/Fomor/Anurigunda.cs
@@ -91,7 +91,7 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsPulled = false;
+		public bool IsPulled = false;
 		private bool RemoveAdds = false;
 		public void BlockEntrance()
         {
@@ -162,8 +162,8 @@ namespace DOL.AI.Brain
 			}
 			base.Think();
 		}
-		public static bool Adds1 = false;
-		public static bool Adds2 = false;
+		public bool Adds1 = false;
+		public bool Adds2 = false;
 		public void SpawnFomorians()
         {
 			if (Body.HealthPercent <= 40 && Adds1 == false)

--- a/GameServer/scripts/namedmobs/Fomor/Krackenschtein.cs
+++ b/GameServer/scripts/namedmobs/Fomor/Krackenschtein.cs
@@ -106,9 +106,9 @@ namespace DOL.AI.Brain
 			ThinkInterval = 1500;
 		}
         #region bolt random enemy
-        public static bool CanCast = false;
-		public static GamePlayer randomtarget = null;
-		public static GamePlayer RandomTarget
+        public bool CanCast = false;
+		public GamePlayer randomtarget = null;
+		public GamePlayer RandomTarget
 		{
 			get { return randomtarget; }
 			set { randomtarget = value; }
@@ -130,7 +130,7 @@ namespace DOL.AI.Brain
 			if (CanCast == false && Enemys_To_DD.Count > 0)
 			{
 				GamePlayer Target = (GamePlayer)Enemys_To_DD[Util.Random(0, Enemys_To_DD.Count - 1)];//pick random target from list
-				RandomTarget = Target;//set random target to static RandomTarget
+				RandomTarget = Target;
 				new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(CastBolt), 1000);
 				CanCast = true;
 			}
@@ -156,9 +156,9 @@ namespace DOL.AI.Brain
 		}
 		#endregion
 		#region Teleport random enemy
-		public static bool CanPort = false;
-		public static GamePlayer teleporttarget = null;
-		public static GamePlayer TeleportTarget
+		public bool CanPort = false;
+		public GamePlayer teleporttarget = null;
+		public GamePlayer TeleportTarget
 		{
 			get { return teleporttarget; }
 			set { teleporttarget = value; }
@@ -180,7 +180,7 @@ namespace DOL.AI.Brain
 			if (CanPort == false)
 			{
 				GamePlayer Target = (GamePlayer)Enemys_To_Port[Util.Random(0, Enemys_To_Port.Count - 1)];//pick random target from list
-				TeleportTarget = Target;//set random target to static RandomTarget
+				TeleportTarget = Target;
 				switch(Util.Random(1,4))
                 {
 					case 1: TeleportTarget.MoveTo(180, 32956, 37669, 16465, 1028); break;

--- a/GameServer/scripts/namedmobs/Fomor/Myrddraxis.cs
+++ b/GameServer/scripts/namedmobs/Fomor/Myrddraxis.cs
@@ -167,12 +167,7 @@ namespace DOL.GS
 
 			Faction = FactionMgr.GetFactionByID(105);
 
-			CanSpawnHeads = false;
-			if(CanSpawnHeads == false)
-            {
-				SpawnHeads();
-				CanSpawnHeads = true;
-            }
+			SpawnHeads();
 
 			MyrddraxisBrain sbrain = new MyrddraxisBrain();
 			SetOwnBrain(sbrain);
@@ -182,8 +177,7 @@ namespace DOL.GS
 			return true;
 		}
         #region Spawn Heads
-        public static bool CanSpawnHeads = false;
-		public void SpawnHeads()
+        public void SpawnHeads()
         {
 			//Second Head
 			MyrddraxisSecondHead Add1 = new MyrddraxisSecondHead();
@@ -307,16 +301,16 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsPulled = false;
-		public static bool CanCast = false;
-		public static bool CanCast2 = false;
-		public static bool CanCastStun1 = false;
-		public static bool CanCastStun2 = false;
-		public static bool CanCastStun3 = false;
-		public static bool CanCastStun4 = false;
-		public static bool CanCastPBAOE1 = false;
-		public static bool CanCastPBAOE2 = false;
-		public static bool CanCastPBAOE3 = false;
+		public bool IsPulled = false;
+		public bool CanCast = false;
+		public bool CanCast2 = false;
+		public bool CanCastStun1 = false;
+		public bool CanCastStun2 = false;
+		public bool CanCastStun3 = false;
+		public bool CanCastStun4 = false;
+		public bool CanCastPBAOE1 = false;
+		public bool CanCastPBAOE2 = false;
+		public bool CanCastPBAOE3 = false;
 		public void BroadcastMessage(String message)
 		{
 			foreach (GamePlayer player in Body.GetPlayersInRadius(WorldMgr.VISIBILITY_DISTANCE))
@@ -325,8 +319,8 @@ namespace DOL.AI.Brain
 			}
 		}
 		#region Hydra DOT
-		public static GamePlayer randomtarget2 = null;
-		public static GamePlayer RandomTarget2
+		public GamePlayer randomtarget2 = null;
+		public GamePlayer RandomTarget2
 		{
 			get { return randomtarget2; }
 			set { randomtarget2 = value; }
@@ -352,7 +346,7 @@ namespace DOL.AI.Brain
 					if (CanCast2 == false)
 					{
 						GamePlayer Target = (GamePlayer)Enemys_To_DOT[Util.Random(0, Enemys_To_DOT.Count - 1)];//pick random target from list
-						RandomTarget2 = Target;//set random target to static RandomTarget
+						RandomTarget2 = Target;
 						new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(CastDOT), 2000);
 						CanCast2 = true;
 					}
@@ -385,8 +379,8 @@ namespace DOL.AI.Brain
 		}
 		#endregion
 		#region Hydra DD
-		public static GamePlayer randomtarget = null;
-		public static GamePlayer RandomTarget
+		public GamePlayer randomtarget = null;
+		public GamePlayer RandomTarget
 		{
 			get { return randomtarget; }
 			set { randomtarget = value; }
@@ -412,7 +406,7 @@ namespace DOL.AI.Brain
 					if (CanCast == false)
 					{
 						GamePlayer Target = (GamePlayer)Enemys_To_DD[Util.Random(0, Enemys_To_DD.Count - 1)];//pick random target from list
-						RandomTarget = Target;//set random target to static RandomTarget
+						RandomTarget = Target;
 						new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(CastDD), 5000);
 						BroadcastMessage(String.Format(Body.Name + " taking a big flame breath at " + RandomTarget.Name + "."));
 						CanCast = true;
@@ -461,8 +455,8 @@ namespace DOL.AI.Brain
 			return 0;
 		}
 		#endregion
-		public static bool StartCastDD = false;
-		public static bool StartCastDOT = false;
+		public bool StartCastDD = false;
+		public bool StartCastDOT = false;
 		private bool RemoveAdds = false;
 		private bool HeadExists(Type headType)
 		{
@@ -924,7 +918,7 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsPulled1 = false;
+		public bool IsPulled1 = false;
 		public override void Think()
 		{
 			if (!CheckProximityAggro())
@@ -1121,7 +1115,7 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsPulled2 = false;
+		public bool IsPulled2 = false;
 		public override void Think()
 		{
 			if (!CheckProximityAggro())
@@ -1318,7 +1312,7 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsPulled3 = false;
+		public bool IsPulled3 = false;
 		public override void Think()
 		{
 			if (!CheckProximityAggro())
@@ -1514,7 +1508,7 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsPulled4 = false;
+		public bool IsPulled4 = false;
 		public override void Think()
 		{
 			if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/Fomor/Myrddraxis.cs
+++ b/GameServer/scripts/namedmobs/Fomor/Myrddraxis.cs
@@ -464,6 +464,15 @@ namespace DOL.AI.Brain
 		public static bool StartCastDD = false;
 		public static bool StartCastDOT = false;
 		private bool RemoveAdds = false;
+		private bool HeadExists(Type headType)
+		{
+			foreach (GameNPC npc in Body.GetNPCsInRadius(2500))
+			{
+				if (npc != null && npc.IsAlive && npc.GetType() == headType)
+					return true;
+			}
+			return false;
+		}
 		public override void Think()
 		{
 			if (!CheckProximityAggro())
@@ -487,11 +496,15 @@ namespace DOL.AI.Brain
 				CanCastPBAOE3 = false;
 				if (!RemoveAdds)
 				{
+					bool secondHeadUp = HeadExists(typeof(MyrddraxisSecondHead));
+					bool thirdHeadUp = HeadExists(typeof(MyrddraxisThirdHead));
+					bool fourthHeadUp = HeadExists(typeof(MyrddraxisFourthHead));
+					bool fifthHeadUp = HeadExists(typeof(MyrddraxisFifthHead));
 					foreach (GameNPC npc in Body.GetNPCsInRadius(2500))
 					{
 						if (npc != null)
 						{
-							if (MyrddraxisSecondHead.SecondHeadCount == 0)
+							if (!secondHeadUp)
 							{
 								MyrddraxisSecondHead Add1 = new MyrddraxisSecondHead();
 								Add1.X = 32384;
@@ -502,8 +515,9 @@ namespace DOL.AI.Brain
 								Add1.Flags = GameNPC.eFlags.FLYING;
 								Add1.RespawnInterval = -1;
 								Add1.AddToWorld();
+								secondHeadUp = true;
 							}
-							if (MyrddraxisThirdHead.ThirdHeadCount == 0)
+							if (!thirdHeadUp)
 							{
 								MyrddraxisThirdHead Add2 = new MyrddraxisThirdHead();
 								Add2.X = 32187;
@@ -514,8 +528,9 @@ namespace DOL.AI.Brain
 								Add2.Flags = GameNPC.eFlags.FLYING;
 								Add2.RespawnInterval = -1;
 								Add2.AddToWorld();
+								thirdHeadUp = true;
 							}
-							if (MyrddraxisFourthHead.FourthHeadCount == 0)
+							if (!fourthHeadUp)
 							{
 								MyrddraxisFourthHead Add3 = new MyrddraxisFourthHead();
 								Add3.X = 32371;
@@ -526,8 +541,9 @@ namespace DOL.AI.Brain
 								Add3.Flags = GameNPC.eFlags.FLYING;
 								Add3.RespawnInterval = -1;
 								Add3.AddToWorld();
+								fourthHeadUp = true;
 							}
-							if (MyrddraxisFifthHead.FifthHeadCount == 0)
+							if (!fifthHeadUp)
 							{
 								MyrddraxisFifthHead Add4 = new MyrddraxisFifthHead();
 								Add4.X = 32576;
@@ -538,6 +554,7 @@ namespace DOL.AI.Brain
 								Add4.Flags = GameNPC.eFlags.FLYING;
 								Add4.RespawnInterval = -1;
 								Add4.AddToWorld();
+								fifthHeadUp = true;
 							}
 						}
 					}
@@ -852,12 +869,6 @@ namespace DOL.GS
 		{
 			get { return 40000; }
 		}
-		public static int SecondHeadCount = 0;
-		public override void ProcessDeath(GameObject killer)
-		{
-			--SecondHeadCount;
-			base.ProcessDeath(killer);
-		}
         public override void DealDamage(AttackData ad)
         {
 			if(ad != null)
@@ -892,7 +903,6 @@ namespace DOL.GS
 
 			RespawnInterval = -1;
 			MaxSpeedBase = 0;
-			++SecondHeadCount;
 			Faction = FactionMgr.GetFactionByID(105);
 
 			MyrddraxisSecondHeadBrain sbrain = new MyrddraxisSecondHeadBrain();
@@ -1055,12 +1065,6 @@ namespace DOL.GS
 		{
 			get { return 40000; }
 		}
-		public static int ThirdHeadCount = 0;
-		public override void ProcessDeath(GameObject killer)
-		{
-			--ThirdHeadCount;
-			base.ProcessDeath(killer);
-		}
 		public override void DealDamage(AttackData ad)
 		{
 			if (ad != null)
@@ -1095,7 +1099,6 @@ namespace DOL.GS
 
 			RespawnInterval = -1;
 			MaxSpeedBase = 0;
-			++ThirdHeadCount;
 
 			Faction = FactionMgr.GetFactionByID(105);
 
@@ -1259,12 +1262,6 @@ namespace DOL.GS
 		{
 			get { return 40000; }
 		}
-		public static int FourthHeadCount = 0;
-		public override void ProcessDeath(GameObject killer)
-		{
-			--FourthHeadCount;
-			base.ProcessDeath(killer);
-		}
 		public override void DealDamage(AttackData ad)
 		{
 			if (ad != null)
@@ -1299,7 +1296,6 @@ namespace DOL.GS
 
 			RespawnInterval = -1;
 			MaxSpeedBase = 0;
-			++FourthHeadCount;
 
 			Faction = FactionMgr.GetFactionByID(105);
 
@@ -1463,12 +1459,6 @@ namespace DOL.GS
 		{
 			get { return 40000; }
 		}
-		public static int FifthHeadCount = 0;
-		public override void ProcessDeath(GameObject killer)
-		{
-			--FifthHeadCount;
-			base.ProcessDeath(killer);
-		}
 		public override void DealDamage(AttackData ad)
 		{
 			if (ad != null)
@@ -1502,7 +1492,6 @@ namespace DOL.GS
 			LoadTemplate(npcTemplate);
 			RespawnInterval = -1;
 			MaxSpeedBase = 0;
-			++FifthHeadCount;
 
 			Faction = FactionMgr.GetFactionByID(105);
 

--- a/GameServer/scripts/namedmobs/Fomor/Nogoribando.cs
+++ b/GameServer/scripts/namedmobs/Fomor/Nogoribando.cs
@@ -75,11 +75,11 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsPulled = false;
-		public static bool IsBig = false;
-		public static bool IsSmall = false;
-		public static bool IsChangingSize = false;
-		public static bool IsInCombat = false;
+		public bool IsPulled = false;
+		public bool IsBig = false;
+		public bool IsSmall = false;
+		public bool IsChangingSize = false;
+		public bool IsInCombat = false;
 		public int ChangeSizeToBig(ECSGameTimer timer)
 		{
 			if (HasAggro && Body.IsAlive)

--- a/GameServer/scripts/namedmobs/Galladoria/Aroon.cs
+++ b/GameServer/scripts/namedmobs/Galladoria/Aroon.cs
@@ -17,15 +17,15 @@ namespace DOL.GS
         {
         }
 
-        public static bool Aroon_slash = false;
-        public static bool Aroon_crush = false;
-        public static bool Aroon_thrust = false;
-        public static bool Aroon_body = false;
-        public static bool Aroon_cold = false;
-        public static bool Aroon_energy = false;
-        public static bool Aroon_heat = false;
-        public static bool Aroon_matter = false;
-        public static bool Aroon_spirit = false;
+        public bool Aroon_slash = false;
+        public bool Aroon_crush = false;
+        public bool Aroon_thrust = false;
+        public bool Aroon_body = false;
+        public bool Aroon_cold = false;
+        public bool Aroon_energy = false;
+        public bool Aroon_heat = false;
+        public bool Aroon_matter = false;
+        public bool Aroon_spirit = false;
 
         #region Aroon resist damage checks
         public override void TakeDamage(GameObject source, eDamageType damageType, int damageAmount, int criticalAmount)
@@ -330,19 +330,8 @@ namespace DOL.GS
             Aroon_matter = false;
             Aroon_spirit = false;
 
-            CorpScaithBrain.switch_target = false;
-            SpioradScaithBrain.switch_target = false;
-            RopadhScaithBrain.switch_target = false;
-            DamhnaScaithBrain.switch_target = false;
-            FuinneamgScaithBrain.switch_target = false;
-            BruScaithBrain.switch_target = false;
-            FuarScaithBrain.switch_target = false;
-            TaesScaithBrain.switch_target = false;
-            ScorScaithBrain.switch_target = false;
-
             AroonBrain sBrain = new AroonBrain();
             SetOwnBrain(sBrain);
-            AroonBrain.spawn_guardians = false;
             return base.AddToWorld();
         }
 
@@ -425,25 +414,18 @@ namespace DOL.AI.Brain
                 //set state to RETURN TO SPAWN
                 FSM.SetCurrentState(eFSMStateType.RETURN_TO_SPAWN);
                 Body.Health = Body.MaxHealth;
-                Aroon.Aroon_slash = false;
-                Aroon.Aroon_thrust = false;
-                Aroon.Aroon_crush = false;
-                Aroon.Aroon_body = false;
-                Aroon.Aroon_cold = false;
-                Aroon.Aroon_energy = false;
-                Aroon.Aroon_heat = false;
-                Aroon.Aroon_matter = false;
-                Aroon.Aroon_spirit = false;
-
-                CorpScaithBrain.switch_target = false;
-                SpioradScaithBrain.switch_target = false;
-                RopadhScaithBrain.switch_target = false;
-                DamhnaScaithBrain.switch_target = false;
-                FuinneamgScaithBrain.switch_target = false;
-                BruScaithBrain.switch_target = false;
-                FuarScaithBrain.switch_target = false;
-                TaesScaithBrain.switch_target = false;
-                ScorScaithBrain.switch_target = false;
+                if (Body is Aroon boss)
+                {
+                    boss.Aroon_slash = false;
+                    boss.Aroon_thrust = false;
+                    boss.Aroon_crush = false;
+                    boss.Aroon_body = false;
+                    boss.Aroon_cold = false;
+                    boss.Aroon_energy = false;
+                    boss.Aroon_heat = false;
+                    boss.Aroon_matter = false;
+                    boss.Aroon_spirit = false;
+                }
 
                 spawn_guardians = false;
                 if (!RemoveAdds)
@@ -479,15 +461,18 @@ namespace DOL.AI.Brain
             base.Think();
         }
 
-        public static bool spawn_guardians = false;
+        public bool spawn_guardians = false;
         public void SpawnGuardians()
         {
+            Aroon owner = Body as Aroon;
+
             CorpScaith Add = new CorpScaith();
             Add.X = Body.X + Util.Random(-100, 150);
             Add.Y = Body.Y + Util.Random(-100, 150);
             Add.Z = Body.Z;
             Add.CurrentRegion = Body.CurrentRegion;
             Add.Heading = Body.Heading;
+            Add.Owner = owner;
             Add.AddToWorld();
 
             SpioradScaith Add2 = new SpioradScaith();
@@ -496,6 +481,7 @@ namespace DOL.AI.Brain
             Add2.Z = Body.Z;
             Add2.CurrentRegion = Body.CurrentRegion;
             Add2.Heading = Body.Heading;
+            Add2.Owner = owner;
             Add2.AddToWorld();
 
             RopadhScaith Add3 = new RopadhScaith();
@@ -504,6 +490,7 @@ namespace DOL.AI.Brain
             Add3.Z = Body.Z;
             Add3.CurrentRegion = Body.CurrentRegion;
             Add3.Heading = Body.Heading;
+            Add3.Owner = owner;
             Add3.AddToWorld();
 
             DamhnaScaith Add4 = new DamhnaScaith();
@@ -512,6 +499,7 @@ namespace DOL.AI.Brain
             Add4.Z = Body.Z;
             Add4.CurrentRegion = Body.CurrentRegion;
             Add4.Heading = Body.Heading;
+            Add4.Owner = owner;
             Add4.AddToWorld();
 
             FuinneamgScaith Add5 = new FuinneamgScaith();
@@ -520,6 +508,7 @@ namespace DOL.AI.Brain
             Add5.Z = Body.Z;
             Add5.CurrentRegion = Body.CurrentRegion;
             Add5.Heading = Body.Heading;
+            Add5.Owner = owner;
             Add5.AddToWorld();
 
             BruScaith Add6 = new BruScaith();
@@ -528,6 +517,7 @@ namespace DOL.AI.Brain
             Add6.Z = Body.Z;
             Add6.CurrentRegion = Body.CurrentRegion;
             Add6.Heading = Body.Heading;
+            Add6.Owner = owner;
             Add6.AddToWorld();
 
             FuarScaith Add7 = new FuarScaith();
@@ -536,6 +526,7 @@ namespace DOL.AI.Brain
             Add7.Z = Body.Z;
             Add7.CurrentRegion = Body.CurrentRegion;
             Add7.Heading = Body.Heading;
+            Add7.Owner = owner;
             Add7.AddToWorld();
 
             TaesScaith Add8 = new TaesScaith();
@@ -544,6 +535,7 @@ namespace DOL.AI.Brain
             Add8.Z = Body.Z;
             Add8.CurrentRegion = Body.CurrentRegion;
             Add8.Heading = Body.Heading;
+            Add8.Owner = owner;
             Add8.AddToWorld();
 
             ScorScaith Add9 = new ScorScaith();
@@ -552,6 +544,7 @@ namespace DOL.AI.Brain
             Add9.Z = Body.Z;
             Add9.CurrentRegion = Body.CurrentRegion;
             Add9.Heading = Body.Heading;
+            Add9.Owner = owner;
             Add9.AddToWorld();
         }
 
@@ -602,6 +595,7 @@ namespace DOL.GS
         public CorpScaith() : base()
         {
         }
+        public Aroon Owner;
         public override int GetResist(eDamageType damageType)
         {
             switch (damageType)
@@ -642,13 +636,13 @@ namespace DOL.GS
 
         public override void ProcessDeath(GameObject killer)
         {
-            Aroon.Aroon_slash = true;
+            if (Owner != null)
+                Owner.Aroon_slash = true;
             base.ProcessDeath(killer);
         }
 
         public override bool AddToWorld()
         {
-            CorpScaithBrain.Message1 = false;
             Model = (ushort) Util.Random(889, 890);
             Name = "Corp Scaith";
             RespawnInterval = -1;
@@ -690,7 +684,7 @@ namespace DOL.AI.Brain
                 player.Out.SendMessage(message, eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow);
             }
         }
-        public static bool switch_target = false;
+        public bool switch_target = false;
         private GamePlayer randomtarget = null;
 
         private GamePlayer RandomTarget
@@ -714,7 +708,7 @@ namespace DOL.AI.Brain
 
             return 0;
         }
-        public static bool Message1 = false;
+        public bool Message1 = false;
         public override void Think()
         {
             if(Message1==false)
@@ -767,6 +761,7 @@ namespace DOL.GS
         public SpioradScaith() : base()
         {
         }
+        public Aroon Owner;
         public override int GetResist(eDamageType damageType)
         {
             switch (damageType)
@@ -808,7 +803,8 @@ namespace DOL.GS
 
         public override void ProcessDeath(GameObject killer)
         {
-            Aroon.Aroon_thrust = true;
+            if (Owner != null)
+                Owner.Aroon_thrust = true;
             base.ProcessDeath(killer);
         }
 
@@ -816,7 +812,7 @@ namespace DOL.GS
         {
             if (source is GamePlayer || source is GameSummonedPet)
             {
-                if (Aroon.Aroon_slash)
+                if (Owner == null || Owner.Aroon_slash)
                 {
                     base.TakeDamage(source, damageType, damageAmount, criticalAmount);
                 }
@@ -839,7 +835,6 @@ namespace DOL.GS
 
         public override bool AddToWorld()
         {
-            SpioradScaithBrain.Message2 = false;
             Model = (ushort) Util.Random(889, 890);
             Name = "Spiorad Scaith";
             RespawnInterval = -1;
@@ -881,7 +876,7 @@ namespace DOL.AI.Brain
                 player.Out.SendMessage(message, eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow);
             }
         }
-        public static bool switch_target = false;
+        public bool switch_target = false;
         private GamePlayer randomtarget = null;
         private GamePlayer RandomTarget
         {
@@ -902,10 +897,11 @@ namespace DOL.AI.Brain
 
             return 0;
         }
-        public static bool Message2 = false;
+        public bool Message2 = false;
         public override void Think()
         {
-            if(Aroon.Aroon_slash && Message2==false)
+            Aroon boss = (Body as SpioradScaith)?.Owner;
+            if(boss != null && boss.Aroon_slash && Message2==false)
             {
                 BroadcastMessage(String.Format(Body.Name + " eyes are glowing, indicating he's being controlled by Aroon."));
                 Message2 = true;
@@ -953,6 +949,7 @@ namespace DOL.GS
         public RopadhScaith() : base()
         {
         }
+        public Aroon Owner;
         public override int GetResist(eDamageType damageType)
         {
             switch (damageType)
@@ -993,7 +990,8 @@ namespace DOL.GS
 
         public override void ProcessDeath(GameObject killer)
         {
-            Aroon.Aroon_crush = true;
+            if (Owner != null)
+                Owner.Aroon_crush = true;
             base.ProcessDeath(killer);
         }
 
@@ -1001,7 +999,7 @@ namespace DOL.GS
         {
             if (source is GamePlayer || source is GameSummonedPet)
             {
-                if (Aroon.Aroon_slash && Aroon.Aroon_thrust)
+                if (Owner == null || (Owner.Aroon_slash && Owner.Aroon_thrust))
                 {
                     base.TakeDamage(source, damageType, damageAmount, criticalAmount);
                 }
@@ -1024,7 +1022,6 @@ namespace DOL.GS
 
         public override bool AddToWorld()
         {
-            RopadhScaithBrain.Message3 = false;
             Model = (ushort) Util.Random(889, 890);
             Name = "Ropadh Scaith";
             RespawnInterval = -1;
@@ -1066,7 +1063,7 @@ namespace DOL.AI.Brain
                 player.Out.SendMessage(message, eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow);
             }
         }
-        public static bool switch_target = false;
+        public bool switch_target = false;
         private GamePlayer randomtarget = null;
 
         private GamePlayer RandomTarget
@@ -1090,10 +1087,11 @@ namespace DOL.AI.Brain
 
             return 0;
         }
-        public static bool Message3 = false;
+        public bool Message3 = false;
         public override void Think()
         {
-            if (Aroon.Aroon_thrust && Message3 == false)
+            Aroon boss = (Body as RopadhScaith)?.Owner;
+            if (boss != null && boss.Aroon_thrust && Message3 == false)
             {
                 BroadcastMessage(String.Format(Body.Name + " eyes are glowing, indicating he's being controlled by Aroon."));
                 Message3 = true;
@@ -1143,6 +1141,7 @@ namespace DOL.GS
         public DamhnaScaith() : base()
         {
         }
+        public Aroon Owner;
         public override int GetResist(eDamageType damageType)
         {
             switch (damageType)
@@ -1183,7 +1182,8 @@ namespace DOL.GS
 
         public override void ProcessDeath(GameObject killer)
         {
-            Aroon.Aroon_body = true;
+            if (Owner != null)
+                Owner.Aroon_body = true;
             base.ProcessDeath(killer);
         }
 
@@ -1191,7 +1191,7 @@ namespace DOL.GS
         {
             if (source is GamePlayer || source is GameSummonedPet)
             {
-                if (Aroon.Aroon_slash && Aroon.Aroon_thrust && Aroon.Aroon_crush)
+                if (Owner == null || (Owner.Aroon_slash && Owner.Aroon_thrust && Owner.Aroon_crush))
                 {
                     base.TakeDamage(source, damageType, damageAmount, criticalAmount);
                 }
@@ -1214,7 +1214,6 @@ namespace DOL.GS
 
         public override bool AddToWorld()
         {
-            DamhnaScaithBrain.Message4 = false;
             Model = (ushort) Util.Random(889, 890);
             Name = "Damhna Scaith";
             RespawnInterval = -1;
@@ -1256,7 +1255,7 @@ namespace DOL.AI.Brain
                 player.Out.SendMessage(message, eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow);
             }
         }
-        public static bool switch_target = false;
+        public bool switch_target = false;
         private GamePlayer randomtarget = null;
 
         private GamePlayer RandomTarget
@@ -1280,10 +1279,11 @@ namespace DOL.AI.Brain
 
             return 0;
         }
-        public static bool Message4 = false;
+        public bool Message4 = false;
         public override void Think()
         {
-            if (Aroon.Aroon_crush && Message4 == false)
+            Aroon boss = (Body as DamhnaScaith)?.Owner;
+            if (boss != null && boss.Aroon_crush && Message4 == false)
             {
                 BroadcastMessage(String.Format(Body.Name + " eyes are glowing, indicating he's being controlled by Aroon."));
                 Message4 = true;
@@ -1333,6 +1333,7 @@ namespace DOL.GS
         public FuinneamgScaith() : base()
         {
         }
+        public Aroon Owner;
         public override int GetResist(eDamageType damageType)
         {
             switch (damageType)
@@ -1373,7 +1374,8 @@ namespace DOL.GS
 
         public override void ProcessDeath(GameObject killer)
         {
-            Aroon.Aroon_cold = true;
+            if (Owner != null)
+                Owner.Aroon_cold = true;
             base.ProcessDeath(killer);
         }
 
@@ -1381,8 +1383,8 @@ namespace DOL.GS
         {
             if (source is GamePlayer || source is GameSummonedPet)
             {
-                if (Aroon.Aroon_slash && Aroon.Aroon_thrust && Aroon.Aroon_crush &&
-                    Aroon.Aroon_body)
+                if (Owner == null || (Owner.Aroon_slash && Owner.Aroon_thrust && Owner.Aroon_crush &&
+                    Owner.Aroon_body))
                 {
                     base.TakeDamage(source, damageType, damageAmount, criticalAmount);
                 }
@@ -1405,7 +1407,6 @@ namespace DOL.GS
 
         public override bool AddToWorld()
         {
-            FuinneamgScaithBrain.Message5 = false;
             Model = (ushort) Util.Random(889, 890);
             Name = "Fuinneamg Scaith";
             Strength = 350;
@@ -1447,7 +1448,7 @@ namespace DOL.AI.Brain
                 player.Out.SendMessage(message, eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow);
             }
         }
-        public static bool switch_target = false;
+        public bool switch_target = false;
         private GamePlayer randomtarget = null;
 
         private GamePlayer RandomTarget
@@ -1472,10 +1473,11 @@ namespace DOL.AI.Brain
             return 0;
         }
 
-        public static bool Message5 = false;
+        public bool Message5 = false;
         public override void Think()
         {
-            if (Aroon.Aroon_body && Message5 == false)
+            Aroon boss = (Body as FuinneamgScaith)?.Owner;
+            if (boss != null && boss.Aroon_body && Message5 == false)
             {
                 BroadcastMessage(String.Format(Body.Name + " eyes are glowing, indicating he's being controlled by Aroon."));
                 Message5 = true;
@@ -1525,6 +1527,7 @@ namespace DOL.GS
         public BruScaith() : base()
         {
         }
+        public Aroon Owner;
         public override int GetResist(eDamageType damageType)
         {
             switch (damageType)
@@ -1565,7 +1568,8 @@ namespace DOL.GS
 
         public override void ProcessDeath(GameObject killer)
         {
-            Aroon.Aroon_energy = true;
+            if (Owner != null)
+                Owner.Aroon_energy = true;
             base.ProcessDeath(killer);
         }
 
@@ -1573,8 +1577,8 @@ namespace DOL.GS
         {
             if (source is GamePlayer || source is GameSummonedPet)
             {
-                if (Aroon.Aroon_slash && Aroon.Aroon_thrust && Aroon.Aroon_crush &&
-                    Aroon.Aroon_body && Aroon.Aroon_cold)
+                if (Owner == null || (Owner.Aroon_slash && Owner.Aroon_thrust && Owner.Aroon_crush &&
+                    Owner.Aroon_body && Owner.Aroon_cold))
                 {
                     base.TakeDamage(source, damageType, damageAmount, criticalAmount);
                 }
@@ -1597,7 +1601,6 @@ namespace DOL.GS
 
         public override bool AddToWorld()
         {
-            BruScaithBrain.Message6 = false;
             Model = (ushort) Util.Random(889, 890);
             Name = "Bru Scaith";
             RespawnInterval = -1;
@@ -1639,7 +1642,7 @@ namespace DOL.AI.Brain
                 player.Out.SendMessage(message, eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow);
             }
         }
-        public static bool switch_target = false;
+        public bool switch_target = false;
         private GamePlayer randomtarget = null;
 
         private GamePlayer RandomTarget
@@ -1664,10 +1667,11 @@ namespace DOL.AI.Brain
             return 0;
         }
 
-        public static bool Message6 = false;
+        public bool Message6 = false;
         public override void Think()
         {
-            if (Aroon.Aroon_cold && Message6 == false)
+            Aroon boss = (Body as BruScaith)?.Owner;
+            if (boss != null && boss.Aroon_cold && Message6 == false)
             {
                 BroadcastMessage(String.Format(Body.Name + " eyes are glowing, indicating he's being controlled by Aroon."));
                 Message6 = true;
@@ -1717,6 +1721,7 @@ namespace DOL.GS
         public FuarScaith() : base()
         {
         }
+        public Aroon Owner;
         public override int GetResist(eDamageType damageType)
         {
             switch (damageType)
@@ -1757,7 +1762,8 @@ namespace DOL.GS
 
         public override void ProcessDeath(GameObject killer)
         {
-            Aroon.Aroon_heat = true;
+            if (Owner != null)
+                Owner.Aroon_heat = true;
             base.ProcessDeath(killer);
         }
 
@@ -1765,8 +1771,8 @@ namespace DOL.GS
         {
             if (source is GamePlayer || source is GameSummonedPet)
             {
-                if (Aroon.Aroon_slash && Aroon.Aroon_thrust && Aroon.Aroon_crush &&
-                    Aroon.Aroon_body && Aroon.Aroon_cold && Aroon.Aroon_energy)
+                if (Owner == null || (Owner.Aroon_slash && Owner.Aroon_thrust && Owner.Aroon_crush &&
+                    Owner.Aroon_body && Owner.Aroon_cold && Owner.Aroon_energy))
                 {
                     base.TakeDamage(source, damageType, damageAmount, criticalAmount);
                 }
@@ -1789,7 +1795,6 @@ namespace DOL.GS
 
         public override bool AddToWorld()
         {
-            FuarScaithBrain.Message7 = false;
             Model = (ushort) Util.Random(889, 890);
             Name = "Fuar Scaith";
             RespawnInterval = -1;
@@ -1831,7 +1836,7 @@ namespace DOL.AI.Brain
                 player.Out.SendMessage(message, eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow);
             }
         }
-        public static bool switch_target = false;
+        public bool switch_target = false;
         private GamePlayer randomtarget = null;
 
         private GamePlayer RandomTarget
@@ -1856,10 +1861,11 @@ namespace DOL.AI.Brain
             return 0;
         }
 
-        public static bool Message7 = false;
+        public bool Message7 = false;
         public override void Think()
         {
-            if (Aroon.Aroon_energy && Message7 == false)
+            Aroon boss = (Body as FuarScaith)?.Owner;
+            if (boss != null && boss.Aroon_energy && Message7 == false)
             {
                 BroadcastMessage(String.Format(Body.Name + " eyes are glowing, indicating he's being controlled by Aroon."));
                 Message7 = true;
@@ -1909,6 +1915,7 @@ namespace DOL.GS
         public TaesScaith() : base()
         {
         }
+        public Aroon Owner;
         public override int GetResist(eDamageType damageType)
         {
             switch (damageType)
@@ -1949,7 +1956,8 @@ namespace DOL.GS
 
         public override void ProcessDeath(GameObject killer)
         {
-            Aroon.Aroon_matter = true;
+            if (Owner != null)
+                Owner.Aroon_matter = true;
             base.ProcessDeath(killer);
         }
 
@@ -1957,9 +1965,9 @@ namespace DOL.GS
         {
             if (source is GamePlayer || source is GameSummonedPet)
             {
-                if (Aroon.Aroon_slash && Aroon.Aroon_thrust && Aroon.Aroon_crush &&
-                    Aroon.Aroon_body && Aroon.Aroon_cold && Aroon.Aroon_energy
-                    && Aroon.Aroon_heat)
+                if (Owner == null || (Owner.Aroon_slash && Owner.Aroon_thrust && Owner.Aroon_crush &&
+                    Owner.Aroon_body && Owner.Aroon_cold && Owner.Aroon_energy
+                    && Owner.Aroon_heat))
                 {
                     base.TakeDamage(source, damageType, damageAmount, criticalAmount);
                 }
@@ -1982,7 +1990,6 @@ namespace DOL.GS
 
         public override bool AddToWorld()
         {
-            TaesScaithBrain.Message8 = false;
             Model = (ushort) Util.Random(889, 890);
             Name = "Taes Scaith";
             RespawnInterval = -1;
@@ -2024,7 +2031,7 @@ namespace DOL.AI.Brain
                 player.Out.SendMessage(message, eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow);
             }
         }
-        public static bool switch_target = false;
+        public bool switch_target = false;
         private GamePlayer randomtarget = null;
 
         private GamePlayer RandomTarget
@@ -2049,10 +2056,11 @@ namespace DOL.AI.Brain
             return 0;
         }
 
-        public static bool Message8 = false;
+        public bool Message8 = false;
         public override void Think()
         {
-            if (Aroon.Aroon_heat && Message8 == false)
+            Aroon boss = (Body as TaesScaith)?.Owner;
+            if (boss != null && boss.Aroon_heat && Message8 == false)
             {
                 BroadcastMessage(String.Format(Body.Name + " eyes are glowing, indicating he's being controlled by Aroon."));
                 Message8 = true;
@@ -2102,6 +2110,7 @@ namespace DOL.GS
         public ScorScaith() : base()
         {
         }
+        public Aroon Owner;
         public override int GetResist(eDamageType damageType)
         {
             switch (damageType)
@@ -2142,7 +2151,8 @@ namespace DOL.GS
 
         public override void ProcessDeath(GameObject killer)
         {
-            Aroon.Aroon_spirit = true;
+            if (Owner != null)
+                Owner.Aroon_spirit = true;
             base.ProcessDeath(killer);
         }
 
@@ -2150,9 +2160,9 @@ namespace DOL.GS
         {
             if (source is GamePlayer || source is GameSummonedPet)
             {
-                if (Aroon.Aroon_slash && Aroon.Aroon_thrust && Aroon.Aroon_crush &&
-                    Aroon.Aroon_body && Aroon.Aroon_cold && Aroon.Aroon_energy
-                    && Aroon.Aroon_heat && Aroon.Aroon_matter)
+                if (Owner == null || (Owner.Aroon_slash && Owner.Aroon_thrust && Owner.Aroon_crush &&
+                    Owner.Aroon_body && Owner.Aroon_cold && Owner.Aroon_energy
+                    && Owner.Aroon_heat && Owner.Aroon_matter))
                 {
                     base.TakeDamage(source, damageType, damageAmount, criticalAmount);
                 }
@@ -2175,7 +2185,6 @@ namespace DOL.GS
 
         public override bool AddToWorld()
         {
-            ScorScaithBrain.Message9 = false;
             Model = (ushort) Util.Random(889, 890);
             Name = "Scor Scaith";
             RespawnInterval = -1;
@@ -2217,7 +2226,7 @@ namespace DOL.AI.Brain
                 player.Out.SendMessage(message, eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow);
             }
         }
-        public static bool switch_target = false;
+        public bool switch_target = false;
         private GamePlayer randomtarget = null;
 
         private GamePlayer RandomTarget
@@ -2242,10 +2251,11 @@ namespace DOL.AI.Brain
             return 0;
         }
 
-        public static bool Message9 = false;
+        public bool Message9 = false;
         public override void Think()
         {
-            if (Aroon.Aroon_heat && Message9 == false)
+            Aroon boss = (Body as ScorScaith)?.Owner;
+            if (boss != null && boss.Aroon_heat && Message9 == false)
             {
                 BroadcastMessage(String.Format(Body.Name + " eyes are glowing, indicating he's being controlled by Aroon."));
                 Message9 = true;

--- a/GameServer/scripts/namedmobs/Galladoria/Conservator.cs
+++ b/GameServer/scripts/namedmobs/Galladoria/Conservator.cs
@@ -63,12 +63,12 @@ namespace DOL.GS
             INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(60159351);
             LoadTemplate(npcTemplate);
 
-            ConservatorBrain.spampoison = false;
-            ConservatorBrain.spamaoe = false;
             RespawnInterval = ServerProperties.Properties.SET_SI_EPIC_ENCOUNTER_RESPAWNINTERVAL * 60000; //1min is 60000 miliseconds
             Faction = FactionMgr.GetFactionByID(96);
 
             ConservatorBrain sBrain = new ConservatorBrain();
+            sBrain.spampoison = false;
+            sBrain.spamaoe = false;
             SetOwnBrain(sBrain);
             LoadedFromScript = false; //load from database
             SaveIntoDatabase();
@@ -195,8 +195,8 @@ namespace DOL.AI.Brain
             }
             return 0;
         }
-        public static bool spampoison = false;
-        public static bool spamaoe = false;
+        public bool spampoison = false;
+        public bool spamaoe = false;
         public override void Think()
         {
             if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/Galladoria/Easmarach.cs
+++ b/GameServer/scripts/namedmobs/Galladoria/Easmarach.cs
@@ -101,10 +101,10 @@ namespace DOL.GS
 
             RespawnInterval = ServerProperties.Properties.SET_SI_EPIC_ENCOUNTER_RESPAWNINTERVAL * 60000; //1min is 60000 miliseconds
             Faction = FactionMgr.GetFactionByID(96);
-            EasmarachBrain.restphase = false;
-            EasmarachBrain.dontattack = false;
 
             EasmarachBrain sBrain = new EasmarachBrain();
+            sBrain.restphase = false;
+            sBrain.dontattack = false;
             SetOwnBrain(sBrain);
             LoadedFromScript = false; //load from database
             SaveIntoDatabase();
@@ -133,8 +133,8 @@ namespace DOL.AI.Brain
                 player.Out.SendMessage(message, eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow);
             }
         }
-        public static bool restphase = false;
-        public static bool dontattack = false;
+        public bool restphase = false;
+        public bool dontattack = false;
         public override void AttackMostWanted()
         {
             if (dontattack==true)

--- a/GameServer/scripts/namedmobs/Galladoria/EyesWatchingYou.cs
+++ b/GameServer/scripts/namedmobs/Galladoria/EyesWatchingYou.cs
@@ -16,9 +16,8 @@ namespace DOL.GS
         public override bool IsVisibleToPlayers => true;//this make dragon think all the time, no matter if player is around or not
         public override bool AddToWorld()
         {
-            EyesWatchingYouInitBrain.RandomTarget = null;
-            EyesWatchingYouInitBrain.Pick_randomly_Target = false;
             EyesWatchingYouInitBrain sbrain = new EyesWatchingYouInitBrain();
+            sbrain.RandomTarget = null;
             SetOwnBrain(sbrain);
             base.AddToWorld();
             return true;
@@ -71,8 +70,7 @@ namespace DOL.AI.Brain
         {
             ThinkInterval = 1000;
         }
-        public static List<GamePlayer> PlayersInGalla = new List<GamePlayer>();
-        public static bool Pick_randomly_Target = false;
+        public List<GamePlayer> PlayersInGalla = new List<GamePlayer>();
         private bool allowTimer = false;
         private int TimerDoStuff(ECSGameTimer timer)
         {
@@ -96,8 +94,8 @@ namespace DOL.AI.Brain
                 }
             }
         }
-        public static GamePlayer randomtarget = null;
-        public static GamePlayer RandomTarget
+        public GamePlayer randomtarget = null;
+        public GamePlayer RandomTarget
         {
             get { return randomtarget; }
             set { randomtarget = value; }
@@ -122,7 +120,6 @@ namespace DOL.AI.Brain
                         mob.AddToWorld();
                     }
                     RandomTarget = null;
-                    Pick_randomly_Target = false;
                     if (PlayersInGalla.Count > 0)
                         PlayersInGalla.Clear();
                 }

--- a/GameServer/scripts/namedmobs/Galladoria/Hurionthex.cs
+++ b/GameServer/scripts/namedmobs/Galladoria/Hurionthex.cs
@@ -66,23 +66,6 @@ namespace DOL.GS
 
         public override bool AddToWorld() //To make sure after it respawn these checks are correctly set
         {
-            HurionthexBrain.IsBaseForm = false;
-            HurionthexBrain.IsSaiyanForm = false;
-            HurionthexBrain.IsTreantForm = false;
-            HurionthexBrain.IsGranidonForm = false;
-
-            HurionthexBrain.BaseFormCheck = false;
-            HurionthexBrain.GranidonFormCheck = false;
-            HurionthexBrain.TreantFormCheck = false;
-            HurionthexBrain.SaiyanFormCheck = false;
-            HurionthexBrain.SwitchForm = false;
-            HurionthexBrain.reset_checks = false;
-
-            HurionthexBrain.StartForms = false;
-            HurionthexBrain.cast_DA = false;
-            HurionthexBrain.cast_disease = false;
-            HurionthexBrain.cast_DS = false;
-
             INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(60162285);
             LoadTemplate(npcTemplate);
 
@@ -165,15 +148,15 @@ namespace DOL.AI.Brain
             AggroRange = 750;
         }
 
-        public static bool IsBaseForm = false;
-        public static bool IsSaiyanForm = false;
-        public static bool IsTreantForm = false;
-        public static bool IsGranidonForm = false;
-        public static bool BaseFormCheck = false;
-        public static bool SaiyanFormCheck = false;
-        public static bool TreantFormCheck = false;
-        public static bool GranidonFormCheck = false;
-        public static bool SwitchForm = false;
+        public bool IsBaseForm = false;
+        public bool IsSaiyanForm = false;
+        public bool IsTreantForm = false;
+        public bool IsGranidonForm = false;
+        public bool BaseFormCheck = false;
+        public bool SaiyanFormCheck = false;
+        public bool TreantFormCheck = false;
+        public bool GranidonFormCheck = false;
+        public bool SwitchForm = false;
 
         public void BroadcastMessage(String message)
         {
@@ -444,7 +427,7 @@ namespace DOL.AI.Brain
             return 0;
         }
 
-        public static bool reset_checks = false;
+        public bool reset_checks = false;
 
         public int ResetChecks(ECSGameTimer timer)
         {
@@ -485,10 +468,10 @@ namespace DOL.AI.Brain
 
         //Todo = Add DA, DS spells
 
-        public static bool StartForms = false;
-        public static bool cast_DA = false;
-        public static bool cast_disease = false;
-        public static bool cast_DS = false;
+        public bool StartForms = false;
+        public bool cast_DA = false;
+        public bool cast_disease = false;
+        public bool cast_DS = false;
 
         public override void Think()
         {

--- a/GameServer/scripts/namedmobs/Galladoria/Olcasar Geomancer.cs
+++ b/GameServer/scripts/namedmobs/Galladoria/Olcasar Geomancer.cs
@@ -195,7 +195,7 @@ namespace DOL.AI.Brain
                 player.Out.SendMessage(message, eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow);
             }
         }
-        public static bool spawnadds = false;
+        public bool spawnadds = false;
         private bool RemoveAdds = false;
         public override void Think()
         {
@@ -254,10 +254,10 @@ namespace DOL.AI.Brain
             base.Think();
         }
         #region Cast root on random target
-        public static bool CanCast2 = false;
-        public static bool StartCastRoot = false;
-        public static GamePlayer randomtarget2 = null;
-        public static GamePlayer RandomTarget2
+        public bool CanCast2 = false;
+        public bool StartCastRoot = false;
+        public GamePlayer randomtarget2 = null;
+        public GamePlayer RandomTarget2
         {
             get { return randomtarget2; }
             set { randomtarget2 = value; }
@@ -285,7 +285,7 @@ namespace DOL.AI.Brain
                     if (CanCast2 == false)
                     {
                         GamePlayer Target = (GamePlayer)Enemys_To_Root[Util.Random(0, Enemys_To_Root.Count - 1)];//pick random target from list
-                        RandomTarget2 = Target;//set random target to static RandomTarget
+                        RandomTarget2 = Target;
                         new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(CastRoot), 2000);
                         CanCast2 = true;
                     }
@@ -345,7 +345,7 @@ namespace DOL.AI.Brain
             return 0;
         }
 
-        public static bool CanCastAoeSnare = false;
+        public bool CanCastAoeSnare = false;
         public int CastAoeSnare(ECSGameTimer timer)
         {
             if (Body.IsAlive && HasAggro)

--- a/GameServer/scripts/namedmobs/Galladoria/Organic-EnergyMechanism.cs
+++ b/GameServer/scripts/namedmobs/Galladoria/Organic-EnergyMechanism.cs
@@ -67,9 +67,9 @@ namespace DOL.GS
             Faction = FactionMgr.GetFactionByID(96);
             SetOwnBrain(sBrain);
 
-            OrganicEnergyMechanismBrain.StartCastDOT = false;
-            OrganicEnergyMechanismBrain.CanCast = false;
-            OrganicEnergyMechanismBrain.RandomTarget = null;
+            sBrain.StartCastDOT = false;
+            sBrain.CanCast = false;
+            sBrain.RandomTarget = null;
 
             bool success = base.AddToWorld();
             if (success)
@@ -116,10 +116,10 @@ namespace DOL.AI.Brain
             }
         }
         #region OEM Dot
-        public static bool CanCast = false;
-        public static bool StartCastDOT = false;
-        public static GamePlayer randomtarget = null;
-        public static GamePlayer RandomTarget
+        public bool CanCast = false;
+        public bool StartCastDOT = false;
+        public GamePlayer randomtarget = null;
+        public GamePlayer RandomTarget
         {
             get { return randomtarget; }
             set { randomtarget = value; }
@@ -147,7 +147,7 @@ namespace DOL.AI.Brain
                     if (CanCast == false)
                     {
                         GamePlayer Target = (GamePlayer)Enemys_To_DOT[Util.Random(0, Enemys_To_DOT.Count - 1)];//pick random target from list
-                        RandomTarget = Target;//set random target to static RandomTarget
+                        RandomTarget = Target;
                         BroadcastMessage(String.Format(Body.Name + "looks sickly... powerfull magic essense will errupt on " + RandomTarget.Name + "!"));
                         new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(CastDOT), 5000);
                         CanCast = true;
@@ -237,7 +237,7 @@ namespace DOL.AI.Brain
             }
             base.Think();
         }
-        public static bool SpawnFeeder = false;
+        public bool SpawnFeeder = false;
         public int SpawnFeeders(ECSGameTimer timer) // We define here adds
         {
             if (Body.IsAlive && HasAggro)

--- a/GameServer/scripts/namedmobs/Galladoria/SpindlerBroodmother.cs
+++ b/GameServer/scripts/namedmobs/Galladoria/SpindlerBroodmother.cs
@@ -175,7 +175,7 @@ namespace DOL.AI.Brain
             AggroLevel = 100;
             AggroRange = 600;
         }
-        public static bool Spawn_Splinders = false;
+        public bool Spawn_Splinders = false;
         private bool RemoveAdds = false;
         public override void Think()
         {
@@ -258,10 +258,10 @@ namespace DOL.AI.Brain
             return 0;
         }
         #region broodmother mezz
-        public static bool CanCast = false;
-        public static bool StartCastMezz = false;
-        public static GamePlayer randomtarget = null;
-        public static GamePlayer RandomTarget
+        public bool CanCast = false;
+        public bool StartCastMezz = false;
+        public GamePlayer randomtarget = null;
+        public GamePlayer RandomTarget
         {
             get { return randomtarget; }
             set { randomtarget = value; }
@@ -289,7 +289,7 @@ namespace DOL.AI.Brain
                     if (CanCast == false)
                     {
                         GamePlayer Target = (GamePlayer)Enemys_To_Mezz[Util.Random(0, Enemys_To_Mezz.Count - 1)];//pick random target from list
-                        RandomTarget = Target;//set random target to static RandomTarget
+                        RandomTarget = Target;
                         new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(CastMezz), 3000);
                         CanCast = true;
                     }
@@ -322,9 +322,9 @@ namespace DOL.AI.Brain
         }
         #endregion
         #region Pick player to port
-        public static bool IsTargetTeleported = false;
-        public static GamePlayer teleporttarget = null;
-        public static GamePlayer TeleportTarget
+        public bool IsTargetTeleported = false;
+        public GamePlayer teleporttarget = null;
+        public GamePlayer TeleportTarget
         {
             get { return teleporttarget; }
             set { teleporttarget = value; }

--- a/GameServer/scripts/namedmobs/Galladoria/UaimhLairmaster.cs
+++ b/GameServer/scripts/namedmobs/Galladoria/UaimhLairmaster.cs
@@ -9,7 +9,7 @@ namespace DOL.GS.Scripts
     public class UaimhLairmaster : GameEpicBoss
     {
         protected String m_FleeingAnnounce;
-        public static bool IsFleeing = true;
+        public bool IsFleeing = true;
 
         public UaimhLairmaster() : base()
         {
@@ -166,7 +166,7 @@ namespace DOL.GS.Scripts
             protected byte MIN_Size = 60;
 
             protected String m_AggroAnnounce;
-            public static bool IsAggroEnemies = true;
+            public bool IsAggroEnemies = true;
 
             private static readonly Logging.Logger log = Logging.LoggerManager.Create(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 

--- a/GameServer/scripts/namedmobs/GlacierGiant.cs
+++ b/GameServer/scripts/namedmobs/GlacierGiant.cs
@@ -48,9 +48,6 @@ namespace DOL.GS
 			INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(60161360);
 			LoadTemplate(npcTemplate);
 			RespawnInterval = ServerProperties.Properties.SET_SI_EPIC_ENCOUNTER_RESPAWNINTERVAL * 60000;//1min is 60000 miliseconds
-			GlacierGiantBrain.Clear_List = false;
-			GlacierGiantBrain.RandomTarget = null;
-
 			GlacierGiantBrain sbrain = new GlacierGiantBrain();
 			SetOwnBrain(sbrain);
 			LoadedFromScript = false;//load from database
@@ -146,8 +143,8 @@ namespace DOL.AI.Brain
 			base.Think();
 		}
 	
-		public static GamePlayer randomtarget = null;
-		public static GamePlayer RandomTarget
+		public GamePlayer randomtarget = null;
+		public GamePlayer RandomTarget
 		{
 			get { return randomtarget; }
 			set { randomtarget = value; }
@@ -203,7 +200,7 @@ namespace DOL.AI.Brain
 				}
 			}
 		}
-		public static bool Clear_List = false;
+		public bool Clear_List = false;
 		public int ListCleanTimer(ECSGameTimer timer)
         {
 			if (Body.IsAlive && Body.InCombat && HasAggro && Teleported_Players.Count > 0)

--- a/GameServer/scripts/namedmobs/Gnat.cs
+++ b/GameServer/scripts/namedmobs/Gnat.cs
@@ -10,8 +10,6 @@ namespace DOL.GS.Scripts
         {
         }
 
-        public static GameNPC SI_Gnat = new GameNPC();
-
         public override bool AddToWorld()
         {
             Model = 917;
@@ -27,7 +25,6 @@ namespace DOL.GS.Scripts
             SetOwnBrain(sBrain);
             sBrain.AggroLevel = 100;
             sBrain.AggroRange = 500;
-            GnatBrain.spawnants = true;
             base.AddToWorld();
             return true;
         }
@@ -44,7 +41,7 @@ namespace DOL.AI.Brain
         {
         }
 
-        public static bool spawnants = true;
+        public bool spawnants = true;
 
         public override void Think()
         {
@@ -110,8 +107,6 @@ namespace DOL.GS
         public GnatAnts() : base()
         {
         }
-
-        public static GameNPC SI_Gnatants = new GameNPC();
 
         public override int MaxHealth
         {

--- a/GameServer/scripts/namedmobs/HallOfTheCorrupt/AidonTheArchwizard.cs
+++ b/GameServer/scripts/namedmobs/HallOfTheCorrupt/AidonTheArchwizard.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using DOL.AI.Brain;
 using DOL.Database;
 using DOL.Events;
@@ -9,6 +10,8 @@ namespace DOL.GS
 {
     public class AidonTheArchwizard : GameEpicBoss
     {
+        public readonly List<GameNPC> Copies = new List<GameNPC>();
+
         public AidonTheArchwizard() : base()
         {
         }
@@ -211,10 +214,6 @@ namespace DOL.AI.Brain
                 spawn_copies = false;
                 CanCast = false;
                 SpawnCopiesAgain = false;
-                AidonCopyFire.CopyCountFire = 0;
-                AidonCopyIce.CopyCountIce = 0;
-                AidonCopyAir.CopyCountAir = 0;
-                AidonCopyEarth.CopyCountEarth = 0;
                 if (!RemoveAdds)
                 {
                     foreach (GameNPC npc in Body.GetNPCsInRadius(2500))
@@ -269,9 +268,29 @@ namespace DOL.AI.Brain
             CanCast = false;
             return 0;
         }
+        private bool CopyExists(Type copyType)
+        {
+            if (Body is not AidonTheArchwizard aidon)
+                return false;
+
+            foreach (GameNPC npc in aidon.Copies)
+            {
+                if (npc != null && npc.IsAlive && npc.ObjectState is GameObject.eObjectState.Active && npc.GetType() == copyType)
+                    return true;
+            }
+            return false;
+        }
+        private void RegisterCopy(GameNPC copy)
+        {
+            if (Body is AidonTheArchwizard aidon)
+            {
+                aidon.Copies.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not GameObject.eObjectState.Active);
+                aidon.Copies.Add(copy);
+            }
+        }
         private int SpawnMoreCopies(ECSGameTimer timer)
         {
-            if (HasAggro && AidonCopyFire.CopyCountFire == 0 && AidonCopyIce.CopyCountIce == 0 && AidonCopyAir.CopyCountAir == 0 && AidonCopyEarth.CopyCountEarth == 0)
+            if (HasAggro && !CopyExists(typeof(AidonCopyFire)) && !CopyExists(typeof(AidonCopyIce)) && !CopyExists(typeof(AidonCopyAir)) && !CopyExists(typeof(AidonCopyEarth)))
             {
                 switch (Util.Random(1, 4))
                 {
@@ -283,6 +302,7 @@ namespace DOL.AI.Brain
                         Add3.CurrentRegionID = 277;
                         Add3.Heading = 3059;
                         Add3.AddToWorld();
+                        RegisterCopy(Add3);
                         break;
                     case 2:
                         AidonCopyFire Add1 = new AidonCopyFire();
@@ -292,6 +312,7 @@ namespace DOL.AI.Brain
                         Add1.CurrentRegionID = 277;
                         Add1.Heading = 1015;
                         Add1.AddToWorld();
+                        RegisterCopy(Add1);
                         break;
                     case 3:
                         AidonCopyEarth Add4 = new AidonCopyEarth();
@@ -301,6 +322,7 @@ namespace DOL.AI.Brain
                         Add4.CurrentRegionID = 277;
                         Add4.Heading = 1019;
                         Add4.AddToWorld();
+                        RegisterCopy(Add4);
                         break;
                     case 4:
                         AidonCopyIce Add2 = new AidonCopyIce();
@@ -310,6 +332,7 @@ namespace DOL.AI.Brain
                         Add2.CurrentRegionID = 277;
                         Add2.Heading = 3008;
                         Add2.AddToWorld();
+                        RegisterCopy(Add2);
                         break;
                 }
             }
@@ -318,7 +341,7 @@ namespace DOL.AI.Brain
         }
         public void SpawnCopies()
         {
-            if (AidonCopyFire.CopyCountFire == 0)
+            if (!CopyExists(typeof(AidonCopyFire)))
             {
                 AidonCopyFire Add1 = new AidonCopyFire();
                 Add1.X = 31649;
@@ -327,8 +350,9 @@ namespace DOL.AI.Brain
                 Add1.CurrentRegionID = 277;
                 Add1.Heading = 1015;
                 Add1.AddToWorld();
+                RegisterCopy(Add1);
             }
-            if (AidonCopyIce.CopyCountIce == 0)
+            if (!CopyExists(typeof(AidonCopyIce)))
             {
                 AidonCopyIce Add2 = new AidonCopyIce();
                 Add2.X = 31083;
@@ -337,8 +361,9 @@ namespace DOL.AI.Brain
                 Add2.CurrentRegionID = 277;
                 Add2.Heading = 3008;
                 Add2.AddToWorld();
+                RegisterCopy(Add2);
             }
-            if (AidonCopyAir.CopyCountAir == 0)
+            if (!CopyExists(typeof(AidonCopyAir)))
             {
                 AidonCopyAir Add3 = new AidonCopyAir();
                 Add3.X = 31080;
@@ -347,8 +372,9 @@ namespace DOL.AI.Brain
                 Add3.CurrentRegionID = 277;
                 Add3.Heading = 3059;
                 Add3.AddToWorld();
+                RegisterCopy(Add3);
             }
-            if (AidonCopyEarth.CopyCountEarth == 0)
+            if (!CopyExists(typeof(AidonCopyEarth)))
             {
                 AidonCopyEarth Add4 = new AidonCopyEarth();
                 Add4.X = 31637;
@@ -357,6 +383,7 @@ namespace DOL.AI.Brain
                 Add4.CurrentRegionID = 277;
                 Add4.Heading = 1019;
                 Add4.AddToWorld();
+                RegisterCopy(Add4);
             }
         }
         public Spell m_AidonBoss_DD;
@@ -441,12 +468,6 @@ namespace DOL.GS
         {
             get { return 5000; }
         }
-        public static int CopyCountFire = 0;
-        public override void ProcessDeath(GameObject killer)
-        {
-            --CopyCountFire;
-            base.ProcessDeath(killer);
-        }
         public override short Dexterity { get => base.Dexterity; set => base.Dexterity = 200; }
         public override short Piety { get => base.Piety; set => base.Piety = 200; }
         public override short Intelligence { get => base.Intelligence; set => base.Intelligence = 200; }
@@ -472,7 +493,6 @@ namespace DOL.GS
             SwitchWeapon(eActiveWeaponSlot.TwoHanded);
             VisibleActiveWeaponSlots = 34;
             MeleeDamageType = eDamageType.Crush;
-            ++CopyCountFire;
 
             Size = 55;
             Level = 75;
@@ -563,12 +583,6 @@ namespace DOL.GS
         {
             get { return 5000; }
         }
-        public static int CopyCountIce = 0;
-        public override void ProcessDeath(GameObject killer)
-        {
-            --CopyCountIce;
-            base.ProcessDeath(killer);
-        }
         public override short Dexterity { get => base.Dexterity; set => base.Dexterity = 200; }
         public override short Piety { get => base.Piety; set => base.Piety = 200; }
         public override short Intelligence { get => base.Intelligence; set => base.Intelligence = 200; }
@@ -594,7 +608,6 @@ namespace DOL.GS
             SwitchWeapon(eActiveWeaponSlot.TwoHanded);
             VisibleActiveWeaponSlots = 34;
             MeleeDamageType = eDamageType.Crush;
-            ++CopyCountIce;
 
             Size = 55;
             Level = 75;
@@ -686,12 +699,6 @@ namespace DOL.GS
         {
             get { return 5000; }
         }
-        public static int CopyCountAir = 0;
-        public override void ProcessDeath(GameObject killer)
-        {
-            --CopyCountAir;
-            base.ProcessDeath(killer);
-        }
         public override short Dexterity { get => base.Dexterity; set => base.Dexterity = 200; }
         public override short Piety { get => base.Piety; set => base.Piety = 200; }
         public override short Intelligence { get => base.Intelligence; set => base.Intelligence = 200; }
@@ -717,7 +724,6 @@ namespace DOL.GS
             SwitchWeapon(eActiveWeaponSlot.TwoHanded);
             VisibleActiveWeaponSlots = 34;
             MeleeDamageType = eDamageType.Crush;
-            ++CopyCountAir;
 
             Size = 55;
             Level = 75;
@@ -807,12 +813,6 @@ namespace DOL.GS
         {
             get { return 5000; }
         }
-        public static int CopyCountEarth = 0;
-        public override void ProcessDeath(GameObject killer)
-        {
-            --CopyCountEarth;
-            base.ProcessDeath(killer);
-        }
         public override short Dexterity { get => base.Dexterity; set => base.Dexterity = 200; }
         public override short Piety { get => base.Piety; set => base.Piety = 200; }
         public override short Intelligence { get => base.Intelligence; set => base.Intelligence = 200; }
@@ -838,7 +838,6 @@ namespace DOL.GS
             SwitchWeapon(eActiveWeaponSlot.TwoHanded);
             VisibleActiveWeaponSlots = 34;
             MeleeDamageType = eDamageType.Crush;
-            ++CopyCountEarth;
 
             Size = 55;
             Level = 75;

--- a/GameServer/scripts/namedmobs/HallOfTheCorrupt/AidonTheArchwizard.cs
+++ b/GameServer/scripts/namedmobs/HallOfTheCorrupt/AidonTheArchwizard.cs
@@ -96,8 +96,6 @@ namespace DOL.GS
             template.AddNPCEquipment(eInventorySlot.TwoHandWeapon, 1166, 0, 94);
             Inventory = template.CloseTemplate();
             SwitchWeapon(eActiveWeaponSlot.TwoHanded);
-            AidonTheArchwizardBrain.IsPulled = false;
-            AidonTheArchwizardBrain.CanCast = false;
 
             VisibleActiveWeaponSlots = 34;
             MeleeDamageType = eDamageType.Crush;
@@ -166,8 +164,7 @@ namespace DOL.AI.Brain
                 player.Out.SendMessage(message, eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow);
             }
         }
-        public static bool IsPulled = false;
-        public static bool spawn_copies = false;
+        public bool spawn_copies = false;
         public override void OnAttackedByEnemy(AttackData ad)
         {
             if (spawn_copies == false)
@@ -200,7 +197,7 @@ namespace DOL.AI.Brain
             }
             base.OnAttackedByEnemy(ad);
         }
-        public static bool CanCast = false;
+        public bool CanCast = false;
         public bool SpawnCopiesAgain = false;
         private bool RemoveAdds = false;
         public override void Think()
@@ -210,7 +207,6 @@ namespace DOL.AI.Brain
                 //set state to RETURN TO SPAWN
                 FSM.SetCurrentState(eFSMStateType.RETURN_TO_SPAWN);
                 Body.Health = Body.MaxHealth;
-                IsPulled = false;
                 spawn_copies = false;
                 CanCast = false;
                 SpawnCopiesAgain = false;

--- a/GameServer/scripts/namedmobs/HallOfTheCorrupt/CaptainAtwell.cs
+++ b/GameServer/scripts/namedmobs/HallOfTheCorrupt/CaptainAtwell.cs
@@ -202,7 +202,6 @@ namespace DOL.AI.Brain
             AggroRange = 500;
             ThinkInterval = 1500;
         }
-        public static bool reset_darra = false;
         public override void Think()
         {
             if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/HallOfTheCorrupt/CaptainBardalph.cs
+++ b/GameServer/scripts/namedmobs/HallOfTheCorrupt/CaptainBardalph.cs
@@ -222,7 +222,6 @@ namespace DOL.AI.Brain
             AggroRange = 500;
             ThinkInterval = 1500;
         }
-        public static bool reset_darra = false;
         public override void Think()
         {
             if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/HallOfTheCorrupt/CaptainHeathyr.cs
+++ b/GameServer/scripts/namedmobs/HallOfTheCorrupt/CaptainHeathyr.cs
@@ -210,7 +210,6 @@ namespace DOL.AI.Brain
             AggroRange = 500;
             ThinkInterval = 1500;
         }
-        public static bool reset_darra = false;
         public override void Think()
         {
             if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/HallOfTheCorrupt/LadyDarra.cs
+++ b/GameServer/scripts/namedmobs/HallOfTheCorrupt/LadyDarra.cs
@@ -131,7 +131,6 @@ namespace DOL.GS
                 Styles.Add(taunt);
             if(!Styles.Contains(after_block))
                 Styles.Add(after_block);
-            LadyDarraBrain.reset_darra = false;
             spawn_palas = false;
             
             VisibleActiveWeaponSlots = 16;
@@ -182,7 +181,7 @@ namespace DOL.GS
             else
                 log.Warn("Lady Darra exist ingame, remove it and restart server if you want to add by script code.");
         }
-        public static bool spawn_palas = false;
+        public bool spawn_palas = false;
         public static int CountPaladins()
         {
             int count = 0;
@@ -249,7 +248,7 @@ namespace DOL.AI.Brain
             AggroRange = 500;
             ThinkInterval = 1500;
         }
-        public static bool reset_darra = false;
+        public bool reset_darra = false;
         public override void Think()
         {
             if (!CheckProximityAggro())
@@ -267,9 +266,9 @@ namespace DOL.AI.Brain
                 Body.Health = Body.MaxHealth;
                 if (reset_darra == false)
                 {
-                    if (LadyDarra.CountPaladins() <= 3)
+                    if (Body is LadyDarra darra && LadyDarra.CountPaladins() <= 3)
                     {
-                        LadyDarra.spawn_palas = false;
+                        darra.spawn_palas = false;
                         foreach (GameNPC pala in Body.GetNPCsInRadius(2000))
                         {
                             if (pala != null)
@@ -280,7 +279,6 @@ namespace DOL.AI.Brain
                                 }
                             }
                         }
-                        LadyDarra darra = new LadyDarra();
                         darra.SpawnPaladins();
                         new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(ResetDarra), 7000);
                         reset_darra = true;

--- a/GameServer/scripts/namedmobs/HallOfTheCorrupt/LadyDarra.cs
+++ b/GameServer/scripts/namedmobs/HallOfTheCorrupt/LadyDarra.cs
@@ -183,9 +183,19 @@ namespace DOL.GS
                 log.Warn("Lady Darra exist ingame, remove it and restart server if you want to add by script code.");
         }
         public static bool spawn_palas = false;
+        public static int CountPaladins()
+        {
+            int count = 0;
+            foreach (GameNPC npc in WorldMgr.GetNPCsFromRegion(277))
+            {
+                if (npc != null && npc.IsAlive && npc.Brain is SpectralPaladinBrain)
+                    ++count;
+            }
+            return count;
+        }
         public void SpawnPaladins()
         {
-            if (SpectralPaladin.paladins_count == 0 && spawn_palas==false)
+            if (CountPaladins() == 0 && spawn_palas==false)
             {
                 SpectralPaladin Add1 = new SpectralPaladin();
                 Add1.X = 30000;
@@ -257,7 +267,7 @@ namespace DOL.AI.Brain
                 Body.Health = Body.MaxHealth;
                 if (reset_darra == false)
                 {
-                    if (SpectralPaladin.paladins_count <= 3)
+                    if (LadyDarra.CountPaladins() <= 3)
                     {
                         LadyDarra.spawn_palas = false;
                         foreach (GameNPC pala in Body.GetNPCsInRadius(2000))
@@ -322,12 +332,6 @@ namespace DOL.GS
         {
             get { return 5000; }
         }
-        public static int paladins_count = 0;
-        public override void ProcessDeath(GameObject killer)
-        {
-            --paladins_count;
-            base.ProcessDeath(killer);
-        }
         public override bool AddToWorld()
         {
             RespawnInterval = -1;
@@ -347,7 +351,6 @@ namespace DOL.GS
             Inventory = template.CloseTemplate();
             SwitchWeapon(eActiveWeaponSlot.Standard);
             VisibleActiveWeaponSlots = 16;
-            ++paladins_count;
 
             Faction = FactionMgr.GetFactionByID(187);
             SpectralPaladinBrain adds = new SpectralPaladinBrain();

--- a/GameServer/scripts/namedmobs/HallOfTheCorrupt/LieutenantMeade.cs
+++ b/GameServer/scripts/namedmobs/HallOfTheCorrupt/LieutenantMeade.cs
@@ -125,7 +125,6 @@ namespace DOL.GS
             {
                 Styles.Add(slam);
             }
-            LieutenantMeadeBrain.CanWalk = false;
             VisibleActiveWeaponSlots = 16;
             MeleeDamageType = eDamageType.Slash;
             LieutenantMeadeBrain sbrain = new LieutenantMeadeBrain();
@@ -183,7 +182,7 @@ namespace DOL.AI.Brain
             AggroRange = 400;
             ThinkInterval = 1500;
         }
-        public static bool CanWalk = false;
+        public bool CanWalk = false;
         public override void Think()
         {
             if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/HallOfTheCorrupt/LordGildas.cs
+++ b/GameServer/scripts/namedmobs/HallOfTheCorrupt/LordGildas.cs
@@ -125,9 +125,6 @@ namespace DOL.GS
             template.AddNPCEquipment(eInventorySlot.TwoHandWeapon, 7, 0, 0);
             Inventory = template.CloseTemplate();
             SwitchWeapon(eActiveWeaponSlot.Standard);
-            LordGildasBrain.Stage2 = false;
-            LordGildasBrain.CanWalk = false;
-            LordGildasBrain.Reset_Gildas = false;
             if (!Styles.Contains(taunt))
                 Styles.Add(taunt);
             if (!Styles.Contains(slam))
@@ -200,9 +197,9 @@ namespace DOL.AI.Brain
             AggroRange = 500;
             ThinkInterval = 500;
         }
-        public static bool CanWalk = false;
-        public static bool Stage2 = false;
-        public static bool Reset_Gildas = false;
+        public bool CanWalk = false;
+        public bool Stage2 = false;
+        public bool Reset_Gildas = false;
         public int ResetGildas(ECSGameTimer timer)
         {
             Reset_Gildas = false;

--- a/GameServer/scripts/namedmobs/HallOfTheCorrupt/SergeantEddison.cs
+++ b/GameServer/scripts/namedmobs/HallOfTheCorrupt/SergeantEddison.cs
@@ -36,7 +36,7 @@ namespace DOL.GS
             IsRanged = false;
             return 0;
         }
-        public static bool IsRanged = false;
+        public bool IsRanged = false;
         public override void OnAttackEnemy(AttackData ad) //on enemy actions
         {
             if (IsRanged == false)
@@ -233,7 +233,8 @@ namespace DOL.AI.Brain
                 //set state to RETURN TO SPAWN
                 FSM.SetCurrentState(eFSMStateType.RETURN_TO_SPAWN);
                 this.Body.Health = this.Body.MaxHealth;
-                SergeantEddison.IsRanged = false;
+                if (Body is SergeantEddison eddison)
+                    eddison.IsRanged = false;
             }
             if (Body.IsOutOfTetherRange)
             {

--- a/GameServer/scripts/namedmobs/HallOfTheCorrupt/SergeantReede.cs
+++ b/GameServer/scripts/namedmobs/HallOfTheCorrupt/SergeantReede.cs
@@ -133,7 +133,6 @@ namespace DOL.GS
             {
                 Styles.Add(SideFollowUp);
             }
-            SergeantReedeBrain.CanWalk = false;
             VisibleActiveWeaponSlots = 16;
             MeleeDamageType = eDamageType.Thrust;
             SergeantReedeBrain sbrain = new SergeantReedeBrain();
@@ -192,7 +191,7 @@ namespace DOL.AI.Brain
             AggroRange = 400;
             ThinkInterval = 1500;
         }
-        public static bool CanWalk = false;
+        public bool CanWalk = false;
         public override void Think()
         {
             if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/Hibernia Named Mobs/Classic Zones/Blight.cs
+++ b/GameServer/scripts/namedmobs/Hibernia Named Mobs/Classic Zones/Blight.cs
@@ -32,7 +32,7 @@ namespace DOL.GS
 		public override int MeleeAttackRange => 350;
 		public override void StartAttack(GameObject target)
 		{
-			if (BlightBrain.canGrowth)
+			if (Brain is BlightBrain brain && brain.canGrowth)
 				return;
 			else
 				base.StartAttack(target);
@@ -41,7 +41,7 @@ namespace DOL.GS
 		{
 			if (IsAlive && keyName == GS.Abilities.CCImmunity)
 				return true;
-			if (BlightBrain.canGrowth && IsAlive && keyName == GS.Abilities.DamageImmunity)
+			if (Brain is BlightBrain brain && brain.canGrowth && IsAlive && keyName == GS.Abilities.DamageImmunity)
 				return true;
 			return base.HasAbility(keyName);
 		}
@@ -78,7 +78,6 @@ namespace DOL.GS
 		}
 		public override bool AddToWorld()
 		{
-			BlightBrain.canGrowth = true;
 			Name = "Blight";
 			Model = 26;
 			Level = 70;
@@ -195,7 +194,7 @@ namespace DOL.AI.Brain
 				player.Out.SendMessage(message, eChatType.CT_Broadcast, eChatLoc.CL_ChatWindow);
 			}
 		}
-		public static bool canGrowth = true;
+		public bool canGrowth = true;
 		bool SpamMessage = false;
 		public override void Think()
 		{
@@ -615,6 +614,11 @@ namespace DOL.AI.Brain
 
 		public void ResetBlightCycle()
 		{
+			foreach (GameNPC npc in Body.GetNPCsInRadius(8000))
+			{
+				if (npc.IsAlive && (npc.Brain is FireBlightBrain || npc.Brain is LateBlightBrain || npc.Brain is FleshBlightBrain))
+					npc.RemoveFromWorld();
+			}
 			CreateLateBlight = false;
 			CreateFleshBlight = false;
 			CreateBlight = false;

--- a/GameServer/scripts/namedmobs/Hibernia Named Mobs/Classic Zones/Blight.cs
+++ b/GameServer/scripts/namedmobs/Hibernia Named Mobs/Classic Zones/Blight.cs
@@ -10,6 +10,7 @@ namespace DOL.GS
 	public class Blight : GameEpicBoss
 	{
 		public Blight() : base() { }
+		public BlightController Owner;
 
 		[ScriptLoadedEvent]
 		public static void ScriptLoaded(DOLEvent e, object sender, EventArgs args)
@@ -118,28 +119,22 @@ namespace DOL.GS
         }
 		private int SpawnFireBlight(ECSGameTimer timer)
         {
-			BlightControllerBrain.CreateLateBlight = false;
-			BlightControllerBrain.CreateFleshBlight = false;
-			BlightControllerBrain.CreateBlight = false;
-			FireBlight.FireBlightCount = 0;
-			LateBlight.LateBlightCount = 0;
-			FleshBlight.FleshBlightCount = 0;
-
-			for (int i = 0; i < 8; i++)
+			BlightController controller = Owner;
+			if (controller == null)
 			{
 				foreach (GameNPC npc in GetNPCsInRadius(8000))
 				{
-					if (npc.Brain is BlightControllerBrain)
-                    {
-						FireBlight boss = new FireBlight();
-						boss.X = npc.X + Util.Random(-500, 500);
-						boss.Y = npc.Y + Util.Random(-500, 500);
-						boss.Z = npc.Z;
-						boss.Heading = npc.Heading;
-						boss.CurrentRegion = npc.CurrentRegion;
-						boss.AddToWorld();
+					if (npc is BlightController found)
+					{
+						controller = found;
+						break;
 					}
 				}
+			}
+			if (controller != null && controller.Brain is BlightControllerBrain brain)
+			{
+				brain.ResetBlightCycle();
+				controller.SpawnFireBlight();
 			}
 			return 0;
 		}
@@ -237,6 +232,7 @@ namespace DOL.GS
 		public FireBlight() : base()
 		{
 		}
+		public BlightController Owner;
 		public override int GetResist(eDamageType damageType)
 		{
 			switch (damageType)
@@ -263,7 +259,6 @@ namespace DOL.GS
 		}
 		public override short Quickness { get => base.Quickness; set => base.Quickness = 80; }
 		public override short Strength { get => base.Strength; set => base.Strength = 150; }
-		public static int FireBlightCount = 0;
 		public override bool AddToWorld()
 		{
 			Model = 26;
@@ -300,7 +295,8 @@ namespace DOL.GS
 		#endregion
 		public override void ProcessDeath(GameObject killer)
         {
-			++FireBlightCount;
+			if (Owner?.Brain is BlightControllerBrain brain)
+				++brain.FireBlightsKilled;
 			base.ProcessDeath(killer);
         }
     }
@@ -344,6 +340,7 @@ namespace DOL.GS
 		public LateBlight() : base()
 		{
 		}
+		public BlightController Owner;
 		public override int GetResist(eDamageType damageType)
 		{
 			switch (damageType)
@@ -370,7 +367,6 @@ namespace DOL.GS
 		}
 		public override short Quickness { get => base.Quickness; set => base.Quickness = 80; }
 		public override short Strength { get => base.Strength; set => base.Strength = 200; }
-		public static int LateBlightCount = 0;
 		public override bool AddToWorld()
 		{
 			Model = 26;
@@ -406,7 +402,8 @@ namespace DOL.GS
 		#endregion
 		public override void ProcessDeath(GameObject killer)
 		{
-			++LateBlightCount;
+			if (Owner?.Brain is BlightControllerBrain brain)
+				++brain.LateBlightsKilled;
 			base.ProcessDeath(killer);
 		}
 	}
@@ -450,6 +447,7 @@ namespace DOL.GS
 		public FleshBlight() : base()
 		{
 		}
+		public BlightController Owner;
 		public override int GetResist(eDamageType damageType)
 		{
 			switch (damageType)
@@ -476,7 +474,6 @@ namespace DOL.GS
 		}
 		public override short Quickness { get => base.Quickness; set => base.Quickness = 80; }
 		public override short Strength { get => base.Strength; set => base.Strength = 200; }
-		public static int FleshBlightCount = 0;
 		public override bool AddToWorld()
 		{
 			Model = 26;
@@ -512,7 +509,8 @@ namespace DOL.GS
 		#endregion
 		public override void ProcessDeath(GameObject killer)
 		{
-			++FleshBlightCount;
+			if (Owner?.Brain is BlightControllerBrain brain)
+				++brain.FleshBlightsKilled;
 			base.ProcessDeath(killer);
 		}
 	}
@@ -577,13 +575,6 @@ namespace DOL.GS
 		}
 		public void SpawnFireBlight()
 		{
-			BlightControllerBrain.CreateLateBlight = false;
-			BlightControllerBrain.CreateFleshBlight = false;
-			BlightControllerBrain.CreateBlight = false;
-			FireBlight.FireBlightCount = 0;
-			LateBlight.LateBlightCount = 0;
-			FleshBlight.FleshBlightCount = 0;
-
 			foreach (GameNPC npc in GetNPCsInRadius(8000))
 			{
 				if (npc.Brain is FireBlightBrain)
@@ -597,6 +588,7 @@ namespace DOL.GS
 				boss.Z = Z;
 				boss.Heading = Heading;
 				boss.CurrentRegion = CurrentRegion;
+				boss.Owner = this;
 				boss.AddToWorld();
 			}
 		}
@@ -614,17 +606,30 @@ namespace DOL.AI.Brain
 		{
 			ThinkInterval = 1000;
 		}
-		public static bool CreateLateBlight = false;
-		public static bool CreateFleshBlight = false;
-		public static bool CreateBlight = false;
+		private bool CreateLateBlight = false;
+		private bool CreateFleshBlight = false;
+		private bool CreateBlight = false;
+		public int FireBlightsKilled = 0;
+		public int LateBlightsKilled = 0;
+		public int FleshBlightsKilled = 0;
+
+		public void ResetBlightCycle()
+		{
+			CreateLateBlight = false;
+			CreateFleshBlight = false;
+			CreateBlight = false;
+			FireBlightsKilled = 0;
+			LateBlightsKilled = 0;
+			FleshBlightsKilled = 0;
+		}
 
 		public override void Think()
 		{
-			if(FireBlight.FireBlightCount == 8)
+			if(FireBlightsKilled == 8)
 				SpawnLateBlight();
-			if (LateBlight.LateBlightCount == 4)
+			if (LateBlightsKilled == 4)
 				SpawnFleshBlight();
-			if (FleshBlight.FleshBlightCount == 2)
+			if (FleshBlightsKilled == 2)
 				SpawnBlight();
 		}
 
@@ -635,7 +640,7 @@ namespace DOL.AI.Brain
 				if (npc.Brain is LateBlightBrain)
 					return;
 			}
-			if (FireBlight.FireBlightCount == 8 && !CreateLateBlight)
+			if (FireBlightsKilled == 8 && !CreateLateBlight)
 			{
 				for (int i = 0; i < 4; i++)
 				{
@@ -645,6 +650,7 @@ namespace DOL.AI.Brain
 					boss.Z = Body.Z;
 					boss.Heading = Body.Heading;
 					boss.CurrentRegion = Body.CurrentRegion;
+					boss.Owner = Body as BlightController;
 					boss.AddToWorld();
 				}
 				CreateLateBlight = true;
@@ -657,7 +663,7 @@ namespace DOL.AI.Brain
 				if (npc.Brain is FleshBlightBrain)
 					return;
 			}
-			if (LateBlight.LateBlightCount == 4 && FireBlight.FireBlightCount == 8 && !CreateFleshBlight)
+			if (LateBlightsKilled == 4 && FireBlightsKilled == 8 && !CreateFleshBlight)
 			{
 				for (int i = 0; i < 2; i++)
 				{
@@ -667,6 +673,7 @@ namespace DOL.AI.Brain
 					boss.Z = Body.Z;
 					boss.Heading = Body.Heading;
 					boss.CurrentRegion = Body.CurrentRegion;
+					boss.Owner = Body as BlightController;
 					boss.AddToWorld();
 				}
 				CreateFleshBlight = true;
@@ -679,7 +686,7 @@ namespace DOL.AI.Brain
 				if (npc.Brain is BlightBrain)
 					return;
 			}
-			if (FleshBlight.FleshBlightCount == 2 && LateBlight.LateBlightCount == 4 && FireBlight.FireBlightCount == 8 && !CreateBlight)
+			if (FleshBlightsKilled == 2 && LateBlightsKilled == 4 && FireBlightsKilled == 8 && !CreateBlight)
 			{
 				Blight boss = new Blight();
 				boss.X = Body.X + Util.Random(-500, 500);
@@ -687,6 +694,7 @@ namespace DOL.AI.Brain
 				boss.Z = Body.Z;
 				boss.Heading = Body.Heading;
 				boss.CurrentRegion = Body.CurrentRegion;
+				boss.Owner = Body as BlightController;
 				boss.AddToWorld();
 				CreateBlight = true;
 			}

--- a/GameServer/scripts/namedmobs/Hibernia Named Mobs/Classic Zones/Caithor.cs
+++ b/GameServer/scripts/namedmobs/Hibernia Named Mobs/Classic Zones/Caithor.cs
@@ -56,7 +56,11 @@ namespace DOL.GS
 			RealCaithorUp = true;
 
 			SpawnDorochas();
-			CaithorDorocha.DorochaKilled = 0;
+			foreach (GameNPC npc in WorldMgr.GetNPCsFromRegion(CurrentRegionID))
+			{
+				if (npc.Brain is GhostOfCaithorBrain brain)
+					brain.DorochaKilled = 0;
+			}
 			CaithorBrain sbrain = new CaithorBrain();
 			SetOwnBrain(sbrain);
 			LoadedFromScript = true;
@@ -247,9 +251,10 @@ namespace DOL.AI.Brain
 		bool changed;
 		public static bool despawnGiantCaithor = false;
 		public static bool CanDespawn = false;
+		public int DorochaKilled = 0;
 		public override void Think()
 		{
-			if (CaithorDorocha.DorochaKilled >= 5 && !Caithor.RealCaithorUp)
+			if (DorochaKilled >= 5 && !Caithor.RealCaithorUp)
 			{
 				if (changed)
 				{
@@ -293,7 +298,7 @@ namespace DOL.AI.Brain
 					despawnGiantCaithorTimer.Stop();
 					Body.TempProperties.RemoveProperty("giantcaithor_despawn");
 				}				
-				CaithorDorocha.DorochaKilled = 0;
+				DorochaKilled = 0;
 				oldFlags = Body.Flags;
 				Body.Flags ^= GameNPC.eFlags.CANTTARGET;
 				Body.Flags ^= GameNPC.eFlags.DONTSHOWNAME;
@@ -332,11 +337,26 @@ namespace DOL.GS
 			base.AddToWorld();
 			return true;
 		}
-		public static int DorochaKilled = 0;
+		private GhostOfCaithorBrain _ghostBrain;
         public override void ProcessDeath(GameObject killer)
         {
-			if(!Caithor.RealCaithorUp)
-			++DorochaKilled;
+			if (!Caithor.RealCaithorUp)
+			{
+				if (_ghostBrain == null || _ghostBrain.Body == null || _ghostBrain.Body.Brain != _ghostBrain || _ghostBrain.Body.ObjectState is not eObjectState.Active)
+				{
+					_ghostBrain = null;
+					foreach (GameNPC npc in WorldMgr.GetNPCsFromRegion(CurrentRegionID))
+					{
+						if (npc.Brain is GhostOfCaithorBrain brain)
+						{
+							_ghostBrain = brain;
+							break;
+						}
+					}
+				}
+				if (_ghostBrain != null)
+					++_ghostBrain.DorochaKilled;
+			}
             base.ProcessDeath(killer);
         }
     }

--- a/GameServer/scripts/namedmobs/Hibernia Named Mobs/Classic Zones/Caithor.cs
+++ b/GameServer/scripts/namedmobs/Hibernia Named Mobs/Classic Zones/Caithor.cs
@@ -48,19 +48,15 @@ namespace DOL.GS
 		{
 			get { return 10000; }
 		}
-		public static bool RealCaithorUp = false;
+		public GhostOfCaithor GhostOwner;
 		public override bool AddToWorld()
 		{
 			INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(50023);
 			LoadTemplate(npcTemplate);
-			RealCaithorUp = true;
 
 			SpawnDorochas();
-			foreach (GameNPC npc in WorldMgr.GetNPCsFromRegion(CurrentRegionID))
-			{
-				if (npc.Brain is GhostOfCaithorBrain brain)
-					brain.DorochaKilled = 0;
-			}
+			if (GhostOwner?.Brain is GhostOfCaithorBrain brain)
+				brain.DorochaKilled = 0;
 			CaithorBrain sbrain = new CaithorBrain();
 			SetOwnBrain(sbrain);
 			LoadedFromScript = true;
@@ -87,7 +83,6 @@ namespace DOL.GS
 		}
 		public override void ProcessDeath(GameObject killer)
         {
-			RealCaithorUp = false;
 			foreach(GameNPC npc in GetNPCsInRadius(8000))
             {
 				if (npc.IsAlive && npc != null && npc.PackageID == "RealCaithorDorocha")
@@ -178,7 +173,11 @@ namespace DOL.GS
 		public override short Quickness { get => base.Quickness; set => base.Quickness = 80; }
 		public override short Strength { get => base.Strength; set => base.Strength = 400; }
 		#endregion
-		public static bool GhostCaithorUP = false;
+		private Caithor _realCaithor;
+		public bool IsRealCaithorUp()
+		{
+			return _realCaithor != null && _realCaithor.IsAlive && _realCaithor.ObjectState is eObjectState.Active;
+		}
 		public override bool AddToWorld()
 		{
 			foreach (GameNPC npc in GetNPCsInRadius(8000))
@@ -193,9 +192,6 @@ namespace DOL.GS
 			TetherRange = 4000;
 			Flags = 0;
 			LoadEquipmentTemplateFromDatabase("65b95161-a813-41cb-be0c-a57d132f8173");
-			GhostCaithorUP = true;
-			GhostOfCaithorBrain.CanDespawn = false;
-			GhostOfCaithorBrain.despawnGiantCaithor = false;
 
 			GhostOfCaithorBrain sbrain = new GhostOfCaithorBrain();
 			SetOwnBrain(sbrain);
@@ -219,7 +215,6 @@ namespace DOL.GS
 				despawnGiantCaithorTimer.Stop();
 				TempProperties.RemoveProperty("giantcaithor_despawn");
 			}
-			GhostCaithorUP = false;
 			SpawnCaithor();
             base.ProcessDeath(killer);
         }
@@ -231,6 +226,8 @@ namespace DOL.GS
 			npc.Z = 4984;
 			npc.Heading = 3319;
 			npc.CurrentRegion = CurrentRegion;
+			npc.GhostOwner = this;
+			_realCaithor = npc;
 			npc.AddToWorld();
 		}
 	}
@@ -249,12 +246,12 @@ namespace DOL.AI.Brain
 		ushort oldModel;
 		GameNPC.eFlags oldFlags;
 		bool changed;
-		public static bool despawnGiantCaithor = false;
-		public static bool CanDespawn = false;
+		public bool despawnGiantCaithor = false;
 		public int DorochaKilled = 0;
 		public override void Think()
 		{
-			if (DorochaKilled >= 5 && !Caithor.RealCaithorUp)
+			bool realCaithorUp = Body is GhostOfCaithor ghost && ghost.IsRealCaithorUp();
+			if (DorochaKilled >= 5 && !realCaithorUp)
 			{
 				if (changed)
 				{
@@ -340,23 +337,20 @@ namespace DOL.GS
 		private GhostOfCaithorBrain _ghostBrain;
         public override void ProcessDeath(GameObject killer)
         {
-			if (!Caithor.RealCaithorUp)
+			if (_ghostBrain == null || _ghostBrain.Body == null || _ghostBrain.Body.Brain != _ghostBrain || _ghostBrain.Body.ObjectState is not eObjectState.Active)
 			{
-				if (_ghostBrain == null || _ghostBrain.Body == null || _ghostBrain.Body.Brain != _ghostBrain || _ghostBrain.Body.ObjectState is not eObjectState.Active)
+				_ghostBrain = null;
+				foreach (GameNPC npc in WorldMgr.GetNPCsFromRegion(CurrentRegionID))
 				{
-					_ghostBrain = null;
-					foreach (GameNPC npc in WorldMgr.GetNPCsFromRegion(CurrentRegionID))
+					if (npc.Brain is GhostOfCaithorBrain brain)
 					{
-						if (npc.Brain is GhostOfCaithorBrain brain)
-						{
-							_ghostBrain = brain;
-							break;
-						}
+						_ghostBrain = brain;
+						break;
 					}
 				}
-				if (_ghostBrain != null)
-					++_ghostBrain.DorochaKilled;
 			}
+			if (_ghostBrain != null && _ghostBrain.Body is GhostOfCaithor ghost && !ghost.IsRealCaithorUp())
+				++_ghostBrain.DorochaKilled;
             base.ProcessDeath(killer);
         }
     }

--- a/GameServer/scripts/namedmobs/Hibernia Named Mobs/Classic Zones/Develin.cs
+++ b/GameServer/scripts/namedmobs/Hibernia Named Mobs/Classic Zones/Develin.cs
@@ -7,7 +7,7 @@ namespace DOL.GS
 	{
 		public Develin() : base() { }
 
-		public static int KillsRequireToSpawn = 20;
+		public int KillsRequireToSpawn = 20;
 		public override bool AddToWorld()
 		{
 			foreach (GameNPC npc in GetNPCsInRadius(8000))
@@ -20,7 +20,6 @@ namespace DOL.GS
 			KillsRequireToSpawn = Util.Random(20, 40);
 			//log.Warn("KillsRequireToSpawn = " + KillsRequireToSpawn);
 
-			DevelinAdd.DevelinAddCount = 0;
 			DevelinBrain sbrain = new DevelinBrain();
 			SetOwnBrain(sbrain);
 			LoadedFromScript = false;//load from database
@@ -44,9 +43,10 @@ namespace DOL.AI.Brain
 		ushort oldModel;
 		GameNPC.eFlags oldFlags;
 		bool changed;
+		public int DevelinAddsKilled = 0;
 		public override void Think()
 		{
-			if (DevelinAdd.DevelinAddCount >= Develin.KillsRequireToSpawn && Body.CurrentRegion.IsNightTime)
+			if (Body is Develin develin && DevelinAddsKilled >= develin.KillsRequireToSpawn && Body.CurrentRegion.IsNightTime)
 			{
 				if (changed)
 				{
@@ -106,11 +106,26 @@ namespace DOL.GS
 			base.AddToWorld();
 			return true;
 		}
-		public static int DevelinAddCount = 0;
+		private DevelinBrain _develinBrain;
 		public override void ProcessDeath(GameObject killer)
 		{
 			if (CurrentRegion.IsNightTime)
-				++DevelinAddCount;
+			{
+				if (_develinBrain == null || _develinBrain.Body == null || _develinBrain.Body.Brain != _develinBrain || _develinBrain.Body.ObjectState is not eObjectState.Active)
+				{
+					_develinBrain = null;
+					foreach (GameNPC npc in WorldMgr.GetNPCsFromRegion(CurrentRegionID))
+					{
+						if (npc.Brain is DevelinBrain brain)
+						{
+							_develinBrain = brain;
+							break;
+						}
+					}
+				}
+				if (_develinBrain != null)
+					++_develinBrain.DevelinAddsKilled;
+			}
 			base.ProcessDeath(killer);
 		}
 	}

--- a/GameServer/scripts/namedmobs/Hibernia Named Mobs/Classic Zones/GreenMaw.cs
+++ b/GameServer/scripts/namedmobs/Hibernia Named Mobs/Classic Zones/GreenMaw.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Numerics;
 using DOL.AI.Brain;
 using DOL.Database;
@@ -75,8 +76,6 @@ namespace DOL.GS
 			}
 			INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(50022);
 			LoadTemplate(npcTemplate);
-			GreenMawAdd.GreenMawRedCount = 0;
-			GreenMawAdd2.GreenMawOrangeCount = 0;
 
 			RespawnInterval = ServerProperties.Properties.SET_EPIC_QUEST_ENCOUNTER_RESPAWNINTERVAL * 60000;//1min is 60000 miliseconds
 			GreenMawBrain sbrain = new GreenMawBrain();
@@ -97,6 +96,7 @@ namespace DOL.GS
 			Zone zone = CurrentZone;
 			bool usePathfinding = zone != null && zone.IsPathfindingEnabled;
 			EDtPolyFlags[] filters = usePathfinding ? PathfindingProvider.Instance.DefaultFilters : null;
+			List<GameNPC> wave = new();
 
 			for (int i = 0; i < 3; i++)
 			{
@@ -111,7 +111,9 @@ namespace DOL.GS
 				npc.Z = (int) spawnPoint.Z;
 				npc.Heading = Heading;
 				npc.CurrentRegion = CurrentRegion;
+				npc.Wave = wave;
 				npc.AddToWorld();
+				wave.Add(npc);
 			}
 		}
 	}
@@ -150,6 +152,7 @@ namespace DOL.GS
 		private const int DESPAWN_RETRY_INTERVAL = 30000;
 
 		public GreenMawAdd() : base() { }
+		public List<GameNPC> Wave;
 		public override int GetResist(eDamageType damageType)
 		{
 			switch (damageType)
@@ -204,15 +207,27 @@ namespace DOL.GS
 			if (InCombat || Brain is StandardMobBrain { HasAggro: true })
 				return DESPAWN_RETRY_INTERVAL;
 
+			if (Wave != null)
+			{
+				lock (Wave)
+					Wave.Remove(this);
+			}
 			RemoveFromWorld();
 			return 0;
 		}
 
-		public static int GreenMawRedCount = 0;
         public override void ProcessDeath(GameObject killer)
         {
-			++GreenMawRedCount;
-			if (GreenMawRedCount >= 3)
+			bool lastAlive = false;
+			if (Wave != null)
+			{
+				lock (Wave)
+				{
+					Wave.Remove(this);
+					lastAlive = Wave.Count == 0;
+				}
+			}
+			if (lastAlive)
 				SpawnCopies();
 			base.ProcessDeath(killer);
         }
@@ -223,6 +238,7 @@ namespace DOL.GS
 			Zone zone = CurrentZone;
 			bool usePathfinding = zone != null && zone.IsPathfindingEnabled;
 			EDtPolyFlags[] filters = usePathfinding ? PathfindingProvider.Instance.DefaultFilters : null;
+			List<GameNPC> wave = new();
 
 			for (int i = 0; i < 4; i++)
 			{
@@ -237,7 +253,9 @@ namespace DOL.GS
 				npc.Z = (int) spawnPoint.Z;
 				npc.Heading = Heading;
 				npc.CurrentRegion = CurrentRegion;
+				npc.Wave = wave;
 				npc.AddToWorld();
+				wave.Add(npc);
 			}
 		}
 	}
@@ -300,6 +318,7 @@ namespace DOL.GS
 		public override short Quickness { get => base.Quickness; set => base.Quickness = 80; }
 		public override short Strength { get => base.Strength; set => base.Strength = 150; }
 		#endregion
+		public List<GameNPC> Wave;
 		public override bool AddToWorld()
 		{
 			Name = "Part of Green Maw";
@@ -324,15 +343,27 @@ namespace DOL.GS
 			if (InCombat || Brain is StandardMobBrain { HasAggro: true })
 				return DESPAWN_RETRY_INTERVAL;
 
+			if (Wave != null)
+			{
+				lock (Wave)
+					Wave.Remove(this);
+			}
 			RemoveFromWorld();
 			return 0;
 		}
 
-		public static int GreenMawOrangeCount = 0;
 		public override void ProcessDeath(GameObject killer)
 		{
-			++GreenMawOrangeCount;
-			if (GreenMawOrangeCount >= 4)
+			bool lastAlive = false;
+			if (Wave != null)
+			{
+				lock (Wave)
+				{
+					Wave.Remove(this);
+					lastAlive = Wave.Count == 0;
+				}
+			}
+			if (lastAlive)
 				SpawnCopies();
 			base.ProcessDeath(killer);
 		}

--- a/GameServer/scripts/namedmobs/Hibernia Named Mobs/Classic Zones/GreenMaw.cs
+++ b/GameServer/scripts/namedmobs/Hibernia Named Mobs/Classic Zones/GreenMaw.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Threading;
 using DOL.AI.Brain;
 using DOL.Database;
 using DOL.Events;
@@ -96,7 +97,7 @@ namespace DOL.GS
 			Zone zone = CurrentZone;
 			bool usePathfinding = zone != null && zone.IsPathfindingEnabled;
 			EDtPolyFlags[] filters = usePathfinding ? PathfindingProvider.Instance.DefaultFilters : null;
-			List<GameNPC> wave = new();
+			GreenMawWave wave = new();
 
 			for (int i = 0; i < 3; i++)
 			{
@@ -112,9 +113,40 @@ namespace DOL.GS
 				npc.Heading = Heading;
 				npc.CurrentRegion = CurrentRegion;
 				npc.Wave = wave;
-				npc.AddToWorld();
 				wave.Add(npc);
+				npc.AddToWorld();
 			}
+		}
+	}
+
+	public class GreenMawWave
+	{
+		private readonly List<GameNPC> _members = new();
+		private int _nextWaveTriggered;
+
+		public void Add(GameNPC npc)
+		{
+			lock (_members)
+				_members.Add(npc);
+		}
+
+		public void Remove(GameNPC npc)
+		{
+			lock (_members)
+				_members.Remove(npc);
+		}
+
+		public bool RemoveAndCheckLastAlive(GameNPC npc)
+		{
+			lock (_members)
+			{
+				_members.Remove(npc);
+
+				if (_members.Count > 0)
+					return false;
+			}
+
+			return Interlocked.Exchange(ref _nextWaveTriggered, 1) == 0;
 		}
 	}
 }
@@ -152,7 +184,7 @@ namespace DOL.GS
 		private const int DESPAWN_RETRY_INTERVAL = 30000;
 
 		public GreenMawAdd() : base() { }
-		public List<GameNPC> Wave;
+		public GreenMawWave Wave;
 		public override int GetResist(eDamageType damageType)
 		{
 			switch (damageType)
@@ -207,27 +239,14 @@ namespace DOL.GS
 			if (InCombat || Brain is StandardMobBrain { HasAggro: true })
 				return DESPAWN_RETRY_INTERVAL;
 
-			if (Wave != null)
-			{
-				lock (Wave)
-					Wave.Remove(this);
-			}
+			Wave?.Remove(this);
 			RemoveFromWorld();
 			return 0;
 		}
 
         public override void ProcessDeath(GameObject killer)
         {
-			bool lastAlive = false;
-			if (Wave != null)
-			{
-				lock (Wave)
-				{
-					Wave.Remove(this);
-					lastAlive = Wave.Count == 0;
-				}
-			}
-			if (lastAlive)
+			if (Wave != null && Wave.RemoveAndCheckLastAlive(this))
 				SpawnCopies();
 			base.ProcessDeath(killer);
         }
@@ -238,7 +257,7 @@ namespace DOL.GS
 			Zone zone = CurrentZone;
 			bool usePathfinding = zone != null && zone.IsPathfindingEnabled;
 			EDtPolyFlags[] filters = usePathfinding ? PathfindingProvider.Instance.DefaultFilters : null;
-			List<GameNPC> wave = new();
+			GreenMawWave wave = new();
 
 			for (int i = 0; i < 4; i++)
 			{
@@ -254,8 +273,8 @@ namespace DOL.GS
 				npc.Heading = Heading;
 				npc.CurrentRegion = CurrentRegion;
 				npc.Wave = wave;
-				npc.AddToWorld();
 				wave.Add(npc);
+				npc.AddToWorld();
 			}
 		}
 	}
@@ -318,7 +337,7 @@ namespace DOL.GS
 		public override short Quickness { get => base.Quickness; set => base.Quickness = 80; }
 		public override short Strength { get => base.Strength; set => base.Strength = 150; }
 		#endregion
-		public List<GameNPC> Wave;
+		public GreenMawWave Wave;
 		public override bool AddToWorld()
 		{
 			Name = "Part of Green Maw";
@@ -343,27 +362,14 @@ namespace DOL.GS
 			if (InCombat || Brain is StandardMobBrain { HasAggro: true })
 				return DESPAWN_RETRY_INTERVAL;
 
-			if (Wave != null)
-			{
-				lock (Wave)
-					Wave.Remove(this);
-			}
+			Wave?.Remove(this);
 			RemoveFromWorld();
 			return 0;
 		}
 
 		public override void ProcessDeath(GameObject killer)
 		{
-			bool lastAlive = false;
-			if (Wave != null)
-			{
-				lock (Wave)
-				{
-					Wave.Remove(this);
-					lastAlive = Wave.Count == 0;
-				}
-			}
-			if (lastAlive)
+			if (Wave != null && Wave.RemoveAndCheckLastAlive(this))
 				SpawnCopies();
 			base.ProcessDeath(killer);
 		}

--- a/GameServer/scripts/namedmobs/Hibernia Named Mobs/Classic Zones/MelancholicFairyQueen.cs
+++ b/GameServer/scripts/namedmobs/Hibernia Named Mobs/Classic Zones/MelancholicFairyQueen.cs
@@ -58,7 +58,6 @@ namespace DOL.GS
 		public override short Quickness { get => base.Quickness; set => base.Quickness = 80; }
 		public override short Strength { get => base.Strength; set => base.Strength = 200; }
 		#endregion
-		public static bool IsKilled = false;
 		public override bool AddToWorld()
 		{			
 			Name = "Melancholic Fairy Queen";
@@ -68,7 +67,6 @@ namespace DOL.GS
 			TetherRange = 2600;
 			Flags = eFlags.FLYING;
 			MaxSpeedBase = 250;
-			IsKilled = false;
 
 			RespawnInterval = ServerProperties.Properties.SET_EPIC_GAME_ENCOUNTER_RESPAWNINTERVAL * 60000;//1min is 60000 miliseconds
 			MelancholicFairyQueenBrain sbrain = new MelancholicFairyQueenBrain();
@@ -80,7 +78,6 @@ namespace DOL.GS
 		}
         public override void ProcessDeath(GameObject killer)
         {
-			IsKilled = true;
 			foreach (GameNPC adds in GetNPCsInRadius(8000))
 			{
 				if (adds != null && adds.IsAlive && adds.Brain is MFQGuardsBrain)

--- a/GameServer/scripts/namedmobs/Hibernia Named Mobs/Shrouded Isles/DremcisFuiloltair.cs
+++ b/GameServer/scripts/namedmobs/Hibernia Named Mobs/Shrouded Isles/DremcisFuiloltair.cs
@@ -52,7 +52,6 @@ namespace DOL.GS
 		{
 			INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(60160146);
 			LoadTemplate(npcTemplate);
-			DremcisFuiloltairBrain.CanSpawnStag = false;
 
 			RespawnInterval = ServerProperties.Properties.SET_EPIC_GAME_ENCOUNTER_RESPAWNINTERVAL * 60000;//1min is 60000 miliseconds
 			DremcisFuiloltairBrain sbrain = new DremcisFuiloltairBrain();
@@ -90,7 +89,7 @@ namespace DOL.AI.Brain
 			ThinkInterval = 1500;
 		}
 
-		public static bool CanSpawnStag = false;
+		private bool CanSpawnStag = false;
 		private bool CanSpawnBlobs = false;
 		private bool RemoveAdds = false;
 		public override void Think()

--- a/GameServer/scripts/namedmobs/IarnvidiurLair/AncientSyver.cs
+++ b/GameServer/scripts/namedmobs/IarnvidiurLair/AncientSyver.cs
@@ -115,7 +115,7 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsPulled = false;
+		public bool IsPulled = false;
 		public override void Think()
 		{
 			if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/IarnvidiurLair/Delegalt.cs
+++ b/GameServer/scripts/namedmobs/IarnvidiurLair/Delegalt.cs
@@ -120,7 +120,7 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsPulled = false;
+		public bool IsPulled = false;
 		public override void Think()
 		{
 			if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/IarnvidiurLair/Droom.cs
+++ b/GameServer/scripts/namedmobs/IarnvidiurLair/Droom.cs
@@ -75,7 +75,7 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsPulled = false;
+		public bool IsPulled = false;
 		public override void Think()
 		{
 			if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/IarnvidiurLair/Dyranapur.cs
+++ b/GameServer/scripts/namedmobs/IarnvidiurLair/Dyranapur.cs
@@ -120,7 +120,7 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsPulled = false;
+		public bool IsPulled = false;
 		public override void Think()
 		{
 			if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/IarnvidiurLair/Hati.cs
+++ b/GameServer/scripts/namedmobs/IarnvidiurLair/Hati.cs
@@ -115,7 +115,7 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsPulled = false;
+		public bool IsPulled = false;
 		public override void Think()
 		{
 			if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/IarnvidiurLair/Hurjavelen.cs
+++ b/GameServer/scripts/namedmobs/IarnvidiurLair/Hurjavelen.cs
@@ -118,7 +118,7 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsPulled = false;
+		public bool IsPulled = false;
 		public override void Think()
 		{
 			if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/IarnvidiurLair/Iarnvidiur.cs
+++ b/GameServer/scripts/namedmobs/IarnvidiurLair/Iarnvidiur.cs
@@ -81,10 +81,10 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsTargetTeleported = false;
+		public bool IsTargetTeleported = false;
 		#region Pick player to port
-		public static GamePlayer teleporttarget = null;
-		public static GamePlayer TeleportTarget
+		public GamePlayer teleporttarget = null;
+		public GamePlayer TeleportTarget
 		{
 			get { return teleporttarget; }
 			set { teleporttarget = value; }
@@ -154,9 +154,9 @@ namespace DOL.AI.Brain
         }
 		#endregion
 		#region DD or Dot random player
-		public static bool IsTargetPicked = false;
-		public static GamePlayer randomtarget = null;
-		public static GamePlayer RandomTarget
+		public bool IsTargetPicked = false;
+		public GamePlayer randomtarget = null;
+		public GamePlayer RandomTarget
 		{
 			get { return randomtarget; }
 			set { randomtarget = value; }

--- a/GameServer/scripts/namedmobs/IarnvidiurLair/Lydsyg.cs
+++ b/GameServer/scripts/namedmobs/IarnvidiurLair/Lydsyg.cs
@@ -120,7 +120,7 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsPulled = false;
+		public bool IsPulled = false;
 		public override void Think()
 		{
 			if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/IarnvidiurLair/Mahattava.cs
+++ b/GameServer/scripts/namedmobs/IarnvidiurLair/Mahattava.cs
@@ -79,7 +79,7 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsPulled = false;
+		public bool IsPulled = false;
 		public override void Think()
 		{
 			if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/IarnvidiurLair/Skoll.cs
+++ b/GameServer/scripts/namedmobs/IarnvidiurLair/Skoll.cs
@@ -118,7 +118,7 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsPulled = false;
+		public bool IsPulled = false;
 		public override void Think()
 		{
 			if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/IarnvidiurLair/Stanga.cs
+++ b/GameServer/scripts/namedmobs/IarnvidiurLair/Stanga.cs
@@ -76,7 +76,7 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsPulled = false;
+		public bool IsPulled = false;
 		public override void Think()
 		{
 			if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/Krondon/BeranSupplyMaster.cs
+++ b/GameServer/scripts/namedmobs/Krondon/BeranSupplyMaster.cs
@@ -88,8 +88,8 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool Ignite_Barrel = false;
-		public static bool BringAdds = false;
+		public bool Ignite_Barrel = false;
+		public bool BringAdds = false;
 		private bool RemoveAdds = false;
 		public override void Think()
 		{

--- a/GameServer/scripts/namedmobs/Krondon/Fuladl.cs
+++ b/GameServer/scripts/namedmobs/Krondon/Fuladl.cs
@@ -169,7 +169,6 @@ namespace DOL.AI.Brain
 				npc.Z = Body.Z;
 				npc.Heading = Body.Heading;
 				npc.CurrentRegion = Body.CurrentRegion;
-				npc.RespawnInterval = -1;
 				npc.AddToWorld();
 				if (Body is Fuladl boss)
 					boss.RegisterPart(npc);
@@ -218,7 +217,7 @@ namespace DOL.GS
 			Name = "Part of Fuladl";
 			Size = (byte)(Util.Random(50,70));
 			MaxSpeedBase = 250;
-			RespawnInterval = ServerProperties.Properties.SET_SI_EPIC_ENCOUNTER_RESPAWNINTERVAL * 60000;//1min is 60000 miliseconds
+			RespawnInterval = -1;
 
 			Faction = FactionMgr.GetFactionByID(8);
 

--- a/GameServer/scripts/namedmobs/Krondon/Fuladl.cs
+++ b/GameServer/scripts/namedmobs/Krondon/Fuladl.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using DOL.AI.Brain;
 using DOL.Database;
 using DOL.Events;
@@ -16,9 +17,27 @@ namespace DOL.GS
 			if (log.IsInfoEnabled)
 				log.Info("Fuladl Initializing...");
 		}
+		private readonly List<FuladlAdd> _parts = new();
+		public void RegisterPart(FuladlAdd part)
+		{
+			_parts.RemoveAll(p => !p.IsAlive || p.ObjectState != eObjectState.Active);
+			_parts.Add(part);
+		}
+		public bool HasAliveParts
+		{
+			get
+			{
+				foreach (FuladlAdd part in _parts)
+				{
+					if (part.IsAlive && part.ObjectState == eObjectState.Active)
+						return true;
+				}
+				return false;
+			}
+		}
 		public override int GetResist(eDamageType damageType)
 		{
-			if (FuladlAdd.PartsCount > 0)
+			if (HasAliveParts)
 			{
 				switch (damageType)
 				{
@@ -123,7 +142,6 @@ namespace DOL.AI.Brain
 							if (npc.IsAlive && npc.Brain is FuladlAddBrain)
 							{
 								npc.RemoveFromWorld();
-								FuladlAdd.PartsCount = 0;
 							}
 						}
 					}
@@ -153,6 +171,8 @@ namespace DOL.AI.Brain
 				npc.CurrentRegion = Body.CurrentRegion;
 				npc.RespawnInterval = -1;
 				npc.AddToWorld();
+				if (Body is Fuladl boss)
+					boss.RegisterPart(npc);
 			}
 		}
 	}
@@ -189,12 +209,6 @@ namespace DOL.GS
 		{
 			get { return 3000; }
 		}
-		public static int PartsCount = 0;
-        public override void ProcessDeath(GameObject killer)
-        {
-			--PartsCount;
-            base.ProcessDeath(killer);
-        }
         public override short Quickness { get => base.Quickness; set => base.Quickness = 80; }
         public override short Strength { get => base.Strength; set => base.Strength = 150; }		
         public override bool AddToWorld()
@@ -203,7 +217,6 @@ namespace DOL.GS
 			Level = (byte)(Util.Random(65, 68));
 			Name = "Part of Fuladl";
 			Size = (byte)(Util.Random(50,70));
-			++PartsCount;
 			MaxSpeedBase = 250;
 			RespawnInterval = ServerProperties.Properties.SET_SI_EPIC_ENCOUNTER_RESPAWNINTERVAL * 60000;//1min is 60000 miliseconds
 

--- a/GameServer/scripts/namedmobs/Krondon/Fulafeallan.cs
+++ b/GameServer/scripts/namedmobs/Krondon/Fulafeallan.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using DOL.AI.Brain;
 using DOL.Database;
 using DOL.Events;
@@ -16,9 +17,27 @@ namespace DOL.GS
 			if (log.IsInfoEnabled)
 				log.Info("Fulafeallan Initializing...");
 		}
+		private readonly List<FulafeallanAdd> _parts = new();
+		public void RegisterPart(FulafeallanAdd part)
+		{
+			_parts.RemoveAll(p => !p.IsAlive || p.ObjectState != eObjectState.Active);
+			_parts.Add(part);
+		}
+		public bool HasAliveParts
+		{
+			get
+			{
+				foreach (FulafeallanAdd part in _parts)
+				{
+					if (part.IsAlive && part.ObjectState == eObjectState.Active)
+						return true;
+				}
+				return false;
+			}
+		}
 		public override int GetResist(eDamageType damageType)
 		{
-			if (FulafeallanAdd.PartsCount2 > 0)
+			if (HasAliveParts)
 			{
 				switch (damageType)
 				{
@@ -123,7 +142,6 @@ namespace DOL.AI.Brain
 							if (npc.IsAlive && npc.Brain is FulafeallanAddBrain)
 							{
 								npc.RemoveFromWorld();
-								FulafeallanAdd.PartsCount2 = 0;
 							}
 						}
 					}
@@ -153,6 +171,8 @@ namespace DOL.AI.Brain
 				npc.CurrentRegion = Body.CurrentRegion;
 				npc.RespawnInterval = -1;
 				npc.AddToWorld();
+				if (Body is Fulafeallan boss)
+					boss.RegisterPart(npc);
 			}
 		}
 	}
@@ -189,12 +209,6 @@ namespace DOL.GS
 		{
 			get { return 3000; }
 		}
-		public static int PartsCount2 = 0;
-		public override void ProcessDeath(GameObject killer)
-		{
-			--PartsCount2;
-			base.ProcessDeath(killer);
-		}
 		public override short Quickness { get => base.Quickness; set => base.Quickness = 80; }
 		public override short Strength { get => base.Strength; set => base.Strength = 150; }
 		public override bool AddToWorld()
@@ -203,7 +217,6 @@ namespace DOL.GS
 			Level = (byte)(Util.Random(65, 68));
 			Name = "Part of Fulafeallan";
 			Size = (byte)(Util.Random(50, 70));
-			++PartsCount2;
 			MaxSpeedBase = 250;
 			RespawnInterval = ServerProperties.Properties.SET_SI_EPIC_ENCOUNTER_RESPAWNINTERVAL * 60000;//1min is 60000 miliseconds
 

--- a/GameServer/scripts/namedmobs/Krondon/Fulafeallan.cs
+++ b/GameServer/scripts/namedmobs/Krondon/Fulafeallan.cs
@@ -169,7 +169,6 @@ namespace DOL.AI.Brain
 				npc.Z = Body.Z;
 				npc.Heading = Body.Heading;
 				npc.CurrentRegion = Body.CurrentRegion;
-				npc.RespawnInterval = -1;
 				npc.AddToWorld();
 				if (Body is Fulafeallan boss)
 					boss.RegisterPart(npc);
@@ -218,7 +217,7 @@ namespace DOL.GS
 			Name = "Part of Fulafeallan";
 			Size = (byte)(Util.Random(50, 70));
 			MaxSpeedBase = 250;
-			RespawnInterval = ServerProperties.Properties.SET_SI_EPIC_ENCOUNTER_RESPAWNINTERVAL * 60000;//1min is 60000 miliseconds
+			RespawnInterval = -1;
 
 			Faction = FactionMgr.GetFactionByID(8);
 

--- a/GameServer/scripts/namedmobs/Krondon/LurfosHerald.cs
+++ b/GameServer/scripts/namedmobs/Krondon/LurfosHerald.cs
@@ -85,11 +85,11 @@ namespace DOL.GS
 		}
         public override void OnAttackEnemy(AttackData ad)
         {
-			if(ad != null && (ad.AttackResult == eAttackResult.HitUnstyled || ad.AttackResult == eAttackResult.HitStyle))
+			if(ad != null && (ad.AttackResult == eAttackResult.HitUnstyled || ad.AttackResult == eAttackResult.HitStyle) && Brain is LurfosHeraldBrain brain)
             {
-				if(LurfosHeraldBrain.IsColdWeapon)
+				if(brain.IsColdWeapon)
 					CastSpell(Weapon_Cold, SkillBase.GetSpellLine(GlobalSpellsLines.Mob_Spells));
-				if (LurfosHeraldBrain.IsHeatWeapon)
+				if (brain.IsHeatWeapon)
 					CastSpell(Weapon_Heat, SkillBase.GetSpellLine(GlobalSpellsLines.Mob_Spells));
 			}
             base.OnAttackEnemy(ad);
@@ -162,10 +162,10 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsColdWeapon = false;
-		public static bool IsHeatWeapon = false;
-		public static bool IsNormalWeapon = false;
-		public static bool StartSwitchWeapons = false;
+		public bool IsColdWeapon = false;
+		public bool IsHeatWeapon = false;
+		public bool IsNormalWeapon = false;
+		public bool StartSwitchWeapons = false;
 		public int SwitchToCold(ECSGameTimer timer)
         {
 			if (HasAggro)

--- a/GameServer/scripts/namedmobs/Krondon/MorgusUrgalorg .cs
+++ b/GameServer/scripts/namedmobs/Krondon/MorgusUrgalorg .cs
@@ -95,14 +95,14 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static GamePlayer randomtarget = null;
-		public static GamePlayer RandomTarget
+		public GamePlayer randomtarget = null;
+		public GamePlayer RandomTarget
 		{
 			get { return randomtarget; }
 			set { randomtarget = value; }
 		}
-		public static bool IsPulled = false;
-		public static bool CanCast = false;
+		public bool IsPulled = false;
+		public bool CanCast = false;
 		List<GamePlayer> Enemys_To_DD = new List<GamePlayer>();
 		public void PickRandomTarget()
 		{
@@ -122,7 +122,7 @@ namespace DOL.AI.Brain
 				if (CanCast == false)
 				{
 					GamePlayer Target = Enemys_To_DD[Util.Random(0, Enemys_To_DD.Count - 1)];//pick random target from list
-					RandomTarget = Target;//set random target to static RandomTarget
+					RandomTarget = Target;
 					new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(ResetTarget), 4500);
 					CanCast = true;
 				}

--- a/GameServer/scripts/namedmobs/Krondon/OrylleAndOrshom.cs
+++ b/GameServer/scripts/namedmobs/Krondon/OrylleAndOrshom.cs
@@ -151,7 +151,7 @@ namespace DOL.AI.Brain
 			}
 			if (HasAggro && Body.TargetObject != null)
 			{
-				if (IsTargetPicked == false && OrshomFire.FireCount > 0)
+				if (IsTargetPicked == false && IsFireAlive())
 				{
 					new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(ThrowPlayer), Util.Random(15000, 20000));//timer to port and pick player
 					IsTargetPicked = true;
@@ -174,6 +174,22 @@ namespace DOL.AI.Brain
 			}
 			base.Think();
 		}
+		private Orshom _orshom;
+		private bool IsFireAlive()
+		{
+			if (_orshom == null)
+			{
+				foreach (GameNPC npc in Body.GetNPCsInRadius(8000))
+				{
+					if (npc is Orshom orshom)
+					{
+						_orshom = orshom;
+						break;
+					}
+				}
+			}
+			return _orshom?.Fire != null && _orshom.Fire.IsAlive && _orshom.Fire.ObjectState is GameObject.eObjectState.Active;
+		}
 	}
 }
 /////////////////////////////////////////////////////////////Orshom////////////////////////////////
@@ -182,6 +198,7 @@ namespace DOL.GS
     public class Orshom : GameEpicBoss
 	{
 		public Orshom() : base() { }
+		public OrshomFire Fire;
 
 		[ScriptLoadedEvent]
 		public static void ScriptLoaded(DOLEvent e, object sender, EventArgs args)
@@ -284,7 +301,6 @@ namespace DOL.AI.Brain
 							if (npc.IsAlive && npc.Brain is OrshomFireBrain)
 							{
 								npc.RemoveFromWorld();
-								OrshomFire.FireCount = 0;
 							}
 						}
 					}
@@ -318,13 +334,10 @@ namespace DOL.AI.Brain
 		}
 		public void SpawnFire()
 		{
-			foreach (GameNPC mob in Body.GetNPCsInRadius(8000))
-			{
-				if (mob.Brain is OrshomFireBrain)
-				{
-					return;
-				}
-			}
+			if (Body is not Orshom orshom)
+				return;
+			if (orshom.Fire != null && orshom.Fire.IsAlive && orshom.Fire.ObjectState is GameObject.eObjectState.Active)
+				return;
 			OrshomFire npc = new OrshomFire();
 			npc.X = 31406;
 			npc.Y = 69599;
@@ -333,6 +346,7 @@ namespace DOL.AI.Brain
 			npc.CurrentRegion = Body.CurrentRegion;
 			npc.RespawnInterval = -1;
 			npc.AddToWorld();
+			orshom.Fire = npc;
 		}
 	}
 }
@@ -405,12 +419,6 @@ namespace DOL.GS
 		{
 			get { return 10000; }
 		}
-		public static int FireCount = 0;
-        public override void ProcessDeath(GameObject killer)
-        {
-			--FireCount;
-            base.ProcessDeath(killer);
-        }
         public override bool AddToWorld()
 		{
 			Model = 665;
@@ -422,7 +430,6 @@ namespace DOL.GS
 			Intelligence = 200;
 			Charisma = 200;
 			Empathy = 200;
-			++FireCount;
 
 			MaxSpeedBase = 0;
 			RespawnInterval = -1;

--- a/GameServer/scripts/namedmobs/Krondon/OrylleAndOrshom.cs
+++ b/GameServer/scripts/namedmobs/Krondon/OrylleAndOrshom.cs
@@ -179,7 +179,7 @@ namespace DOL.AI.Brain
 		{
 			if (_orshom == null)
 			{
-				foreach (GameNPC npc in Body.GetNPCsInRadius(8000))
+				foreach (GameNPC npc in WorldMgr.GetNPCsFromRegion(Body.CurrentRegionID))
 				{
 					if (npc is Orshom orshom)
 					{

--- a/GameServer/scripts/namedmobs/Krondon/OrylleAndOrshom.cs
+++ b/GameServer/scripts/namedmobs/Krondon/OrylleAndOrshom.cs
@@ -95,12 +95,12 @@ namespace DOL.AI.Brain
 			ThinkInterval = 1500;
 			CanBaf = false;
 		}
-		public static bool IsPulled = false;
+		public bool IsPulled = false;
         #region Throw Player
         List<GamePlayer> Port_Enemys = new List<GamePlayer>();
-		public static bool IsTargetPicked = false;
-		public static GamePlayer randomtarget = null;
-		public static GamePlayer RandomTarget
+		public bool IsTargetPicked = false;
+		public GamePlayer randomtarget = null;
+		public GamePlayer RandomTarget
 		{
 			get { return randomtarget; }
 			set { randomtarget = value; }
@@ -148,6 +148,7 @@ namespace DOL.AI.Brain
 				Body.Health = Body.MaxHealth;
 				RandomTarget = null;//throw
 				IsTargetPicked = false;//throw
+				IsPulled = false;
 			}
 			if (HasAggro && Body.TargetObject != null)
 			{

--- a/GameServer/scripts/namedmobs/Krondon/ScurceolHyrde.cs
+++ b/GameServer/scripts/namedmobs/Krondon/ScurceolHyrde.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using DOL.AI.Brain;
 using DOL.Database;
 using DOL.Events;
@@ -27,11 +28,33 @@ namespace DOL.GS
 				default: return 30;// dmg reduction for rest resists
 			}
 		}
+		private readonly List<GameNPC> _orbs = new();
+		public bool OrbsAlive
+		{
+			get
+			{
+				foreach (GameNPC orb in _orbs)
+				{
+					if (orb.IsAlive && orb.ObjectState == eObjectState.Active)
+						return true;
+				}
+				return false;
+			}
+		}
+		private bool HasOrb(Type orbType)
+		{
+			foreach (GameNPC orb in _orbs)
+			{
+				if (orb.GetType() == orbType)
+					return true;
+			}
+			return false;
+		}
 		public override void TakeDamage(GameObject source, eDamageType damageType, int damageAmount, int criticalAmount)
 		{
 			if (source is GamePlayer || source is GameSummonedPet)
 			{
-				if (LyftMihtOne.Orb1Count > 0 || LyftMihtTwo.Orb2Count > 0 || LyftMihtThree.Orb3Count > 0 || LyftMihtFour.Orb4Count > 0)
+				if (OrbsAlive)
 				{
 					if (damageType == eDamageType.Body || damageType == eDamageType.Cold || damageType == eDamageType.Energy || damageType == eDamageType.Heat
 						|| damageType == eDamageType.Matter || damageType == eDamageType.Spirit || damageType == eDamageType.Crush || damageType == eDamageType.Thrust
@@ -116,10 +139,6 @@ namespace DOL.GS
 					if (npc.IsAlive && (npc.Brain is LyftMihtBrain1 || npc.Brain is LyftMihtBrain2 || npc.Brain is LyftMihtBrain3 || npc.Brain is LyftMihtBrain4))
 					{
 						npc.RemoveFromWorld();
-						LyftMihtOne.Orb1Count = 0;
-						LyftMihtTwo.Orb2Count = 0;
-						LyftMihtThree.Orb3Count = 0;
-						LyftMihtFour.Orb4Count = 0;
 					}
 				}
 			}
@@ -127,29 +146,34 @@ namespace DOL.GS
         }
         public void SpawnOrbs()
 		{
-			if (LyftMihtOne.Orb1Count == 0)
+			_orbs.RemoveAll(o => !o.IsAlive || o.ObjectState != eObjectState.Active);
+			if (!HasOrb(typeof(LyftMihtOne)))
 			{
 				LyftMihtOne Add = new LyftMihtOne();
 				Add.CurrentRegion = CurrentRegion;
 				Add.AddToWorld();
+				_orbs.Add(Add);
 			}
-			if (LyftMihtTwo.Orb2Count == 0)
+			if (!HasOrb(typeof(LyftMihtTwo)))
 			{
 				LyftMihtTwo Add = new LyftMihtTwo();
 				Add.CurrentRegion = CurrentRegion;
 				Add.AddToWorld();
+				_orbs.Add(Add);
 			}
-			if (LyftMihtThree.Orb3Count == 0)
+			if (!HasOrb(typeof(LyftMihtThree)))
 			{
 				LyftMihtThree Add = new LyftMihtThree();
 				Add.CurrentRegion = CurrentRegion;
 				Add.AddToWorld();
+				_orbs.Add(Add);
 			}
-			if (LyftMihtFour.Orb4Count == 0)
+			if (!HasOrb(typeof(LyftMihtFour)))
 			{
 				LyftMihtFour Add = new LyftMihtFour();
 				Add.CurrentRegion = CurrentRegion;
 				Add.AddToWorld();
+				_orbs.Add(Add);
 			}
 		}
 	}
@@ -176,7 +200,7 @@ namespace DOL.AI.Brain
 			}
 			if (HasAggro && Body.TargetObject != null)
 			{
-				if ((LyftMihtOne.Orb1Count > 0 || LyftMihtTwo.Orb2Count > 0 || LyftMihtThree.Orb3Count > 0 || LyftMihtFour.Orb4Count > 0))
+				if (Body is ScurceolHyrde boss && boss.OrbsAlive)
 					Body.Strength = 320;
 				else
 					Body.Strength = 260;
@@ -226,12 +250,6 @@ namespace DOL.GS
         public override void StartAttack(GameObject target)
         {
         }
-		public static int Orb1Count = 0;
-        public override void ProcessDeath(GameObject killer)
-        {
-			--Orb1Count;
-            base.ProcessDeath(killer);
-        }
         public override bool AddToWorld()
 		{
 			Model = 2049;
@@ -245,7 +263,6 @@ namespace DOL.GS
 			MaxSpeedBase = 0;
 			RespawnInterval = -1;//Util.Random(180000, 480000);
 			Flags = eFlags.FLYING;
-			++Orb1Count;
 
 			Faction = FactionMgr.GetFactionByID(8);
 
@@ -357,12 +374,6 @@ namespace DOL.GS
 		public override void StartAttack(GameObject target)
 		{
 		}
-		public static int Orb2Count = 0;
-        public override void ProcessDeath(GameObject killer)
-        {
-			--Orb2Count;
-            base.ProcessDeath(killer);
-        }
         public override bool AddToWorld()
 		{
 			Model = 2049;
@@ -376,7 +387,6 @@ namespace DOL.GS
 			MaxSpeedBase = 0;
 			RespawnInterval = -1;// Util.Random(180000, 480000);
 			Flags = eFlags.FLYING;
-			++Orb2Count;
 
 			Faction = FactionMgr.GetFactionByID(8);
 
@@ -488,12 +498,6 @@ namespace DOL.GS
 		public override void StartAttack(GameObject target)
 		{
 		}
-		public static int Orb3Count = 0;
-        public override void ProcessDeath(GameObject killer)
-        {
-			--Orb3Count;
-            base.ProcessDeath(killer);
-        }
         public override bool AddToWorld()
 		{
 			Model = 2049;
@@ -507,7 +511,6 @@ namespace DOL.GS
 			MaxSpeedBase = 0;
 			RespawnInterval = -1;// Util.Random(180000, 480000);
 			Flags = eFlags.FLYING;
-			++Orb3Count;
 
 			Faction = FactionMgr.GetFactionByID(8);
 
@@ -619,12 +622,6 @@ namespace DOL.GS
 		public override void StartAttack(GameObject target)
 		{
 		}
-		public static int Orb4Count = 0;
-        public override void ProcessDeath(GameObject killer)
-        {
-			--Orb4Count;
-            base.ProcessDeath(killer);
-        }
         public override bool AddToWorld()
 		{
 			Model = 2049;
@@ -638,7 +635,6 @@ namespace DOL.GS
 			Flags = eFlags.FLYING;
 			MaxSpeedBase = 0;
 			RespawnInterval = -1;// Util.Random(180000, 480000);
-			++Orb4Count;
 
 			Faction = FactionMgr.GetFactionByID(8);
 

--- a/GameServer/scripts/namedmobs/Krondon/ScurceolHyrde.cs
+++ b/GameServer/scripts/namedmobs/Krondon/ScurceolHyrde.cs
@@ -286,9 +286,9 @@ namespace DOL.AI.Brain
 			AggroRange = 250;
 			ThinkInterval = 1500;
 		}
-		private protected static bool IsTargetPicked = false;
-		private protected static GamePlayer randomtarget = null;
-		private protected static GamePlayer RandomTarget
+		private protected bool IsTargetPicked = false;
+		private protected GamePlayer randomtarget = null;
+		private protected GamePlayer RandomTarget
 		{
 			get { return randomtarget; }
 			set { randomtarget = value; }
@@ -410,9 +410,9 @@ namespace DOL.AI.Brain
 			AggroRange = 250;
 			ThinkInterval = 1500;
 		}
-		private protected static bool IsTargetPicked = false;
-		private protected static GamePlayer randomtarget = null;
-		private protected static GamePlayer RandomTarget
+		private protected bool IsTargetPicked = false;
+		private protected GamePlayer randomtarget = null;
+		private protected GamePlayer RandomTarget
 		{
 			get { return randomtarget; }
 			set { randomtarget = value; }
@@ -534,9 +534,9 @@ namespace DOL.AI.Brain
 			AggroRange = 250;
 			ThinkInterval = 1500;
 		}
-		private protected static bool IsTargetPicked = false;
-		private protected static GamePlayer randomtarget = null;
-		private protected static GamePlayer RandomTarget
+		private protected bool IsTargetPicked = false;
+		private protected GamePlayer randomtarget = null;
+		private protected GamePlayer RandomTarget
 		{
 			get { return randomtarget; }
 			set { randomtarget = value; }
@@ -658,9 +658,9 @@ namespace DOL.AI.Brain
 			AggroRange = 250;
 			ThinkInterval = 1500;
 		}
-		private protected static bool IsTargetPicked = false;
-		private protected static GamePlayer randomtarget = null;
-		private protected static GamePlayer RandomTarget
+		private protected bool IsTargetPicked = false;
+		private protected GamePlayer randomtarget = null;
+		private protected GamePlayer RandomTarget
 		{
 			get { return randomtarget; }
 			set { randomtarget = value; }

--- a/GameServer/scripts/namedmobs/MarfachCaverns/AncientBlackOak.cs
+++ b/GameServer/scripts/namedmobs/MarfachCaverns/AncientBlackOak.cs
@@ -86,12 +86,6 @@ namespace DOL.GS
 
             return base.HasAbility(keyName);
         }
-        public static int OakCount = 0;
-        public override void ProcessDeath(GameObject killer)
-        {
-            OakCount=0;
-            base.ProcessDeath(killer);
-        }
         public override bool AddToWorld()
         {
             INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(8823);
@@ -99,7 +93,6 @@ namespace DOL.GS
             Faction = FactionMgr.GetFactionByID(187);
             BodyType = (ushort)NpcTemplateMgr.eBodyType.Plant;
             AncientBlackOakBrain.IsPulled = false;
-            OakCount =1;
             MeleeDamageType = eDamageType.Matter;
             AncientBlackOakBrain sbrain = new AncientBlackOakBrain();
             SetOwnBrain(sbrain);

--- a/GameServer/scripts/namedmobs/MarfachCaverns/AncientBlackOak.cs
+++ b/GameServer/scripts/namedmobs/MarfachCaverns/AncientBlackOak.cs
@@ -92,7 +92,6 @@ namespace DOL.GS
             LoadTemplate(npcTemplate);
             Faction = FactionMgr.GetFactionByID(187);
             BodyType = (ushort)NpcTemplateMgr.eBodyType.Plant;
-            AncientBlackOakBrain.IsPulled = false;
             MeleeDamageType = eDamageType.Matter;
             AncientBlackOakBrain sbrain = new AncientBlackOakBrain();
             SetOwnBrain(sbrain);
@@ -148,7 +147,7 @@ namespace DOL.AI.Brain
             AggroRange = 400;
             ThinkInterval = 1500;
         }
-        public static bool IsPulled = false;
+        public bool IsPulled = false;
         public override void Think()
         {
             if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/MarfachCaverns/BlackLady.cs
+++ b/GameServer/scripts/namedmobs/MarfachCaverns/BlackLady.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using DOL.AI.Brain;
 using DOL.Database;
 using DOL.Events;
@@ -110,7 +111,6 @@ namespace DOL.GS
             MeleeDamageType = eDamageType.Crush;
             BodyType = 6;
             IsCloakHoodUp = true;
-            Ogress.OgressCount = 0;
             BlackLadyBrain blackladybrain = new BlackLadyBrain();
             SetOwnBrain(blackladybrain);
             base.AddToWorld();
@@ -136,7 +136,6 @@ namespace DOL.GS
                 if (npc.Brain is OgressBrain)
                 {
                     npc.RemoveFromWorld();
-                    Ogress.OgressCount = 0;
                 }
             }
             foreach (GameNPC npc2 in WorldMgr.GetNPCsFromRegion(CurrentRegionID))
@@ -177,7 +176,6 @@ namespace DOL.AI.Brain
                             if (npc.IsAlive && npc.Brain is OgressBrain)
                             {
                                 npc.RemoveFromWorld();
-                                Ogress.OgressCount = 0;
                             }
                         }
                     }
@@ -196,9 +194,11 @@ namespace DOL.AI.Brain
             }
             base.Think();
         }
+        private readonly List<GameNPC> _ogresses = new List<GameNPC>();
         public void SpawnOgress()
         {
-            if (Ogress.OgressCount < 5)
+            _ogresses.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not GameObject.eObjectState.Active);
+            if (_ogresses.Count < 5)
             {
                 switch (Util.Random(1, 2))
                 {
@@ -212,6 +212,7 @@ namespace DOL.AI.Brain
                             Add1.RespawnInterval = -1;
                             Add1.Heading = 3618;
                             Add1.AddToWorld();
+                            _ogresses.Add(Add1);
                         }
                         break;
                     case 2:
@@ -224,6 +225,7 @@ namespace DOL.AI.Brain
                             Add2.RespawnInterval = -1;
                             Add2.Heading = 2114;
                             Add2.AddToWorld();
+                            _ogresses.Add(Add2);
                         }
                         break;
                 }
@@ -295,12 +297,6 @@ namespace DOL.GS
         {
             get { return 2500; }
         }
-        public static int OgressCount = 0;
-        public override void ProcessDeath(GameObject killer)
-        {
-            --OgressCount;
-            base.ProcessDeath(killer);
-        }
         public override bool AddToWorld()
         {
             Model = 402;
@@ -313,7 +309,6 @@ namespace DOL.GS
             Realm = eRealm.None;
             TetherRange = 0;
 
-            ++OgressCount;
             Strength = 50;
             Dexterity = 200;
             Constitution = 100;

--- a/GameServer/scripts/namedmobs/MarfachCaverns/BlackLady.cs
+++ b/GameServer/scripts/namedmobs/MarfachCaverns/BlackLady.cs
@@ -101,12 +101,7 @@ namespace DOL.GS
             Inventory = template.CloseTemplate();
             SwitchWeapon(eActiveWeaponSlot.TwoHanded);
             // humanoid
-            IsOakUp = false;
-            if (IsOakUp == false)
-            {
-                SpawnOak();
-                IsOakUp = true;
-            }
+            SpawnOak();
             VisibleActiveWeaponSlots = 34;
             MeleeDamageType = eDamageType.Crush;
             BodyType = 6;
@@ -116,7 +111,6 @@ namespace DOL.GS
             base.AddToWorld();
             return true;
         }
-        public static bool IsOakUp = false;
         public void SpawnOak()
         {
                 AncientBlackOak Add1 = new AncientBlackOak();

--- a/GameServer/scripts/namedmobs/MarfachCaverns/BlueLady.cs
+++ b/GameServer/scripts/namedmobs/MarfachCaverns/BlueLady.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using DOL.AI.Brain;
 using DOL.Database;
 using DOL.Events;
@@ -161,19 +162,24 @@ namespace DOL.AI.Brain
             {
                 RemoveAdds = false;
                 Body.CastSpell(BlueLady_DD, SkillBase.GetSpellLine(GlobalSpellsLines.Mob_Spells));
-                if ((BlueLadySwordAdd.SwordCount < 10 || BlueLadyAxeAdd.AxeCount < 10) && CanSpawnAdds == false)
+                if (CanSpawnAdds == false)
                 {
-                    new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(SpawnAdds), Util.Random(25000, 45000));
-                    CanSpawnAdds = true;
+                    CountAdds(out int swordCount, out int axeCount);
+                    if (swordCount < 10 || axeCount < 10)
+                    {
+                        new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(SpawnAdds), Util.Random(25000, 45000));
+                        CanSpawnAdds = true;
+                    }
                 }
             }
             base.Think();
         }
         private int SpawnAdds(ECSGameTimer timer)
         {
+            CountAdds(out int swordCount, out int axeCount);
             for (int i = 0; i < 10; i++)
             {
-                if (BlueLadySwordAdd.SwordCount < 10)
+                if (swordCount < 10)
                 {
                     BlueLadySwordAdd add = new BlueLadySwordAdd();
                     add.X = Body.X + Util.Random(-100, 100);
@@ -182,11 +188,13 @@ namespace DOL.AI.Brain
                     add.CurrentRegion = Body.CurrentRegion;
                     add.Heading = Body.Heading;
                     add.AddToWorld();
+                    _swordAdds.Add(add);
+                    ++swordCount;
                 }
             }
             for (int i = 0; i < 10; i++)
             {
-                if (BlueLadyAxeAdd.AxeCount < 10)
+                if (axeCount < 10)
                 {
                     BlueLadyAxeAdd add2 = new BlueLadyAxeAdd();
                     add2.X = Body.X + Util.Random(-100, 100);
@@ -195,10 +203,21 @@ namespace DOL.AI.Brain
                     add2.CurrentRegion = Body.CurrentRegion;
                     add2.Heading = Body.Heading;
                     add2.AddToWorld();
+                    _axeAdds.Add(add2);
+                    ++axeCount;
                 }
             }
             CanSpawnAdds = false;
             return 0;
+        }
+        private readonly List<GameNPC> _swordAdds = new List<GameNPC>();
+        private readonly List<GameNPC> _axeAdds = new List<GameNPC>();
+        private void CountAdds(out int swordCount, out int axeCount)
+        {
+            _swordAdds.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not GameObject.eObjectState.Active);
+            _axeAdds.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not GameObject.eObjectState.Active);
+            swordCount = _swordAdds.Count;
+            axeCount = _axeAdds.Count;
         }
         public Spell m_BlueLady_DD;
         public Spell BlueLady_DD
@@ -257,12 +276,6 @@ namespace DOL.GS
             // 85% ABS is cap.
             return 0.15;
         }
-        public static int SwordCount = 0;
-        public override void ProcessDeath(GameObject killer)
-        {
-            --SwordCount;
-            base.ProcessDeath(killer);
-        }
         public override long ExperienceValue => 0;
         public override bool CanDropLoot => false;
         public override short Quickness { get => base.Quickness; set => base.Quickness = 125; }
@@ -276,7 +289,6 @@ namespace DOL.GS
             Level = (byte)Util.Random(50, 55);
             Realm = 0;
 
-            ++SwordCount;
             RespawnInterval = -1;
             Faction = FactionMgr.GetFactionByID(187);
 
@@ -320,12 +332,6 @@ namespace DOL.GS
             // 85% ABS is cap.
             return 0.15;
         }
-        public static int AxeCount = 0;
-        public override void ProcessDeath(GameObject killer)
-        {
-            --AxeCount;
-            base.ProcessDeath(killer);
-        }
         public override long ExperienceValue => 0;
         public override bool CanDropLoot => false;
         public override short Quickness { get => base.Quickness; set => base.Quickness = 125; }
@@ -344,7 +350,6 @@ namespace DOL.GS
             Inventory = templateHib.CloseTemplate();
             VisibleActiveWeaponSlots = (byte)eActiveWeaponSlot.Standard;
 
-            ++AxeCount;
             RespawnInterval = -1;
             Faction = FactionMgr.GetFactionByID(187);
 

--- a/GameServer/scripts/namedmobs/MarfachCaverns/ChieftainCaimheul.cs
+++ b/GameServer/scripts/namedmobs/MarfachCaverns/ChieftainCaimheul.cs
@@ -139,9 +139,6 @@ namespace DOL.GS
             if (!Styles.Contains(AfterParry))
                 Styles.Add(AfterParry);
 
-            ChieftainCaimheulBrain.Phase2 = false;
-            ChieftainCaimheulBrain.CanWalk = false;
-            ChieftainCaimheulBrain.IsPulled = false;
             VisibleActiveWeaponSlots = 16;
             MeleeDamageType = eDamageType.Slash;
             ChieftainCaimheulBrain sbrain = new ChieftainCaimheulBrain();
@@ -201,9 +198,9 @@ namespace DOL.AI.Brain
             AggroRange = 500;
             ThinkInterval = 1500;
         }
-        public static bool Phase2 = false;
-        public static bool CanWalk = false;
-        public static bool IsPulled = false;
+        public bool Phase2 = false;
+        public bool CanWalk = false;
+        public bool IsPulled = false;
         public override void Think()
         {
             if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/MarfachCaverns/RedLady.cs
+++ b/GameServer/scripts/namedmobs/MarfachCaverns/RedLady.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using DOL.AI.Brain;
 using DOL.Database;
 using DOL.Events;
@@ -85,7 +86,6 @@ namespace DOL.GS
 
             Faction = FactionMgr.GetFactionByID(187);
             RespawnInterval = ServerProperties.Properties.SET_EPIC_GAME_ENCOUNTER_RESPAWNINTERVAL * 60000; //1min is 60000 miliseconds
-            SpecialInnocent.InnocentCount = 0;
 
             GameNpcInventoryTemplate template = new GameNpcInventoryTemplate();
             template.AddNPCEquipment(eInventorySlot.TorsoArmor, 58, 67, 0, 0);//modelID,color,effect,extension
@@ -135,9 +135,10 @@ namespace DOL.AI.Brain
         private bool CanSpawnAdds = false;
         private int SpawnAdd(ECSGameTimer timer)
         {
+            int innocentCount = CountInnocents();
             for (int i = 0; i < 8; i++)
             {
-                if (SpecialInnocent.InnocentCount < 9)
+                if (innocentCount < 9)
                 {
                     SpecialInnocent add = new SpecialInnocent();
                     add.X = Body.X + Util.Random(-100, 100);
@@ -147,10 +148,18 @@ namespace DOL.AI.Brain
                     add.RespawnInterval = -1;
                     add.Heading = Body.Heading;
                     add.AddToWorld();
+                    _innocents.Add(add);
+                    ++innocentCount;
                 }
             }
             CanSpawnAdds = false;
             return 0;
+        }
+        private readonly List<GameNPC> _innocents = new List<GameNPC>();
+        private int CountInnocents()
+        {
+            _innocents.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not GameObject.eObjectState.Active);
+            return _innocents.Count;
         }
         private bool RemoveAdds = false;
         public override void Think()
@@ -159,7 +168,6 @@ namespace DOL.AI.Brain
             {
                 FSM.SetCurrentState(eFSMStateType.RETURN_TO_SPAWN);
                 Body.Health = Body.MaxHealth;
-                SpecialInnocent.InnocentCount = 0;
                 CanSpawnAdds = false;
                 if (!RemoveAdds)
                 {
@@ -176,7 +184,7 @@ namespace DOL.AI.Brain
             if (HasAggro && Body.InCombat && Body.TargetObject != null)
             {
                 RemoveAdds = false;
-                if(SpecialInnocent.InnocentCount<9 && CanSpawnAdds == false)
+                if(CanSpawnAdds == false && CountInnocents() < 9)
                 {
                     new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(SpawnAdd), Util.Random(20000, 30000));
                     CanSpawnAdds=true;
@@ -251,7 +259,6 @@ namespace DOL.GS
             }
             base.OnAttackEnemy(ad);
         }
-        public static int InnocentCount = 0;
         public override bool AddToWorld()
         {
             Model = (ushort)Util.Random(442, 446);
@@ -262,7 +269,6 @@ namespace DOL.GS
             TetherRange = 0;
             Faction = FactionMgr.GetFactionByID(187);
 
-            ++InnocentCount;
             Strength = 50;
             Dexterity = 120;
             Constitution = 100;
@@ -271,11 +277,6 @@ namespace DOL.GS
             SetOwnBrain(innocentbrain);
             base.AddToWorld();
             return true;
-        }
-        public override void ProcessDeath(GameObject killer)
-        {
-            --InnocentCount;
-            base.ProcessDeath(killer);
         }
         public override double GetArmorAF(eArmorSlot slot)
         {

--- a/GameServer/scripts/namedmobs/Midgard Named Mobs/Classic Zones/Loken.cs
+++ b/GameServer/scripts/namedmobs/Midgard Named Mobs/Classic Zones/Loken.cs
@@ -1,4 +1,5 @@
-﻿using DOL.AI.Brain;
+﻿using System.Collections.Generic;
+using DOL.AI.Brain;
 using DOL.Database;
 using DOL.GS;
 using DOL.GS.PacketHandler;
@@ -97,6 +98,7 @@ namespace DOL.GS
         private void SpawnWolfs()
 		{
 			Point3D spawn = new Point3D(636780, 762427, 4597);
+			Wolves.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not eObjectState.Active);
 			for (int i = 0; i < 2; i++)
 			{
 				LokenWolf npc = new LokenWolf();
@@ -106,8 +108,10 @@ namespace DOL.GS
 				npc.Heading = Heading;
 				npc.CurrentRegion = CurrentRegion;
 				npc.AddToWorld();
+				Wolves.Add(npc);
 			}
 		}
+		public readonly List<GameNPC> Wolves = new List<GameNPC>();
 	}
 }
 namespace DOL.AI.Brain
@@ -137,7 +141,7 @@ namespace DOL.AI.Brain
 				Body.Health = Body.MaxHealth;
 				INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(60163372);
 				Body.MaxSpeedBase = npcTemplate.MaxSpeed;
-				if (LokenWolf.WolfsCount < 2 && !SpawnWolf)
+				if (!SpawnWolf && AliveWolfCount() < 2)
                 {
 					SpawnWolfs();
 					SpawnWolf = true;
@@ -175,12 +179,30 @@ namespace DOL.AI.Brain
 			}
 			base.Think();
 		}
+		private int AliveWolfCount()
+		{
+			if (Body is not Loken loken)
+				return 0;
+
+			int count = 0;
+			foreach (GameNPC npc in loken.Wolves)
+			{
+				if (npc != null && npc.IsAlive && npc.ObjectState is GameObject.eObjectState.Active)
+					++count;
+			}
+			return count;
+		}
 		private void SpawnWolfs()
 		{
+			if (Body is not Loken loken)
+				return;
+
 			Point3D spawn = new Point3D(636780, 762427, 4597);
+			loken.Wolves.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not GameObject.eObjectState.Active);
+			int wolfsCount = loken.Wolves.Count;
 			for (int i = 0; i < 2; i++)
 			{
-				if (LokenWolf.WolfsCount < 2)
+				if (wolfsCount < 2)
 				{
 					LokenWolf npc = new LokenWolf();
 					npc.X = spawn.X + Util.Random(-100, 100);
@@ -189,6 +211,8 @@ namespace DOL.AI.Brain
 					npc.Heading = Body.Heading;
 					npc.CurrentRegion = Body.CurrentRegion;
 					npc.AddToWorld();
+					loken.Wolves.Add(npc);
+					++wolfsCount;
 				}
 			}
 		}
@@ -303,19 +327,12 @@ namespace DOL.GS
 			Size = 45;
 			LokenWolfBrain sbrain = new LokenWolfBrain();
 			SetOwnBrain(sbrain);
-			++WolfsCount;
 			MaxSpeedBase = 225;
 			LoadedFromScript = true;
 			RespawnInterval = -1;
 			base.AddToWorld();
 			return true;
 		}
-		public static int WolfsCount = 0;
-        public override void ProcessDeath(GameObject killer)
-        {
-			--WolfsCount;
-            base.ProcessDeath(killer);
-        }
     }
 }
 namespace DOL.AI.Brain

--- a/GameServer/scripts/namedmobs/Midgard Named Mobs/Classic Zones/Ulfketill.cs
+++ b/GameServer/scripts/namedmobs/Midgard Named Mobs/Classic Zones/Ulfketill.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using DOL.AI.Brain;
 using DOL.Database;
 using DOL.Events;
@@ -9,6 +10,7 @@ namespace DOL.GS
 	public class Ulfketill : GameEpicBoss
 	{
 		public Ulfketill() : base() { }
+		public readonly List<GameNPC> Jotuns = new List<GameNPC>();
 
 		[ScriptLoadedEvent]
 		public static void ScriptLoaded(DOLEvent e, object sender, EventArgs args)
@@ -84,7 +86,7 @@ namespace DOL.AI.Brain
 				FSM.SetCurrentState(eFSMStateType.RETURN_TO_SPAWN);
 				Body.Health = Body.MaxHealth;
 			}
-			if (UlfketillAdds.JotunsCount < 3 && !HasAggro)
+			if (!HasAggro && AliveJotunCount() < 3)
 			{
 				SpawnJotuns();
 			}
@@ -102,11 +104,29 @@ namespace DOL.AI.Brain
             }
 			base.Think();
 		}
+		private int AliveJotunCount()
+		{
+			if (Body is not Ulfketill ulfketill)
+				return 0;
+
+			int count = 0;
+			foreach (GameNPC npc in ulfketill.Jotuns)
+			{
+				if (npc != null && npc.IsAlive && npc.ObjectState is GameObject.eObjectState.Active)
+					++count;
+			}
+			return count;
+		}
 		private void SpawnJotuns()
 		{
+			if (Body is not Ulfketill ulfketill)
+				return;
+
+			ulfketill.Jotuns.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not GameObject.eObjectState.Active);
+			int jotunsCount = ulfketill.Jotuns.Count;
 			for (int i = 0; i < 3; i++)
 			{
-				if (UlfketillAdds.JotunsCount < 3)
+				if (jotunsCount < 3)
 				{
 					UlfketillAdds add = new UlfketillAdds();
 					add.X = Body.X + Util.Random(-500, 500);
@@ -115,6 +135,8 @@ namespace DOL.AI.Brain
 					add.Heading = Body.Heading;
 					add.CurrentRegion = Body.CurrentRegion;
 					add.AddToWorld();
+					ulfketill.Jotuns.Add(add);
+					++jotunsCount;
 				}
 			}
 		}
@@ -156,7 +178,6 @@ namespace DOL.GS
 		}
 		public override short Quickness { get => base.Quickness; set => base.Quickness = 80; }
 		public override short Strength { get => base.Strength; set => base.Strength = 200; }
-		public static int JotunsCount = 0;
 		public override bool AddToWorld()
 		{
 			Model = 1770;
@@ -165,7 +186,6 @@ namespace DOL.GS
 			RespawnInterval = -1;
 			Level = (byte)Util.Random(50, 55);
 			MaxSpeedBase = 225;
-			++JotunsCount;
 
 			UlfketillAddsBrain sbrain = new UlfketillAddsBrain();
 			SetOwnBrain(sbrain);
@@ -173,11 +193,6 @@ namespace DOL.GS
 			base.AddToWorld();
 			return true;
 		}
-        public override void ProcessDeath(GameObject killer)
-        {
-			--JotunsCount;
-            base.ProcessDeath(killer);
-        }
 		public override bool CanDropLoot => false;
 		public override long ExperienceValue => 0;
 	}

--- a/GameServer/scripts/namedmobs/Midgard Named Mobs/Shrouded Isles/Boligar.cs
+++ b/GameServer/scripts/namedmobs/Midgard Named Mobs/Shrouded Isles/Boligar.cs
@@ -102,10 +102,10 @@ namespace DOL.AI.Brain
 			}
 			base.Think();
 		}
-		public static bool IsTargetTeleported = false;
+		public bool IsTargetTeleported = false;
 		#region Pick player to port
-		public static GamePlayer teleporttarget = null;
-		public static GamePlayer TeleportTarget
+		public GamePlayer teleporttarget = null;
+		public GamePlayer TeleportTarget
 		{
 			get { return teleporttarget; }
 			set { teleporttarget = value; }

--- a/GameServer/scripts/namedmobs/Midgard Named Mobs/Shrouded Isles/Mortufoghus.cs
+++ b/GameServer/scripts/namedmobs/Midgard Named Mobs/Shrouded Isles/Mortufoghus.cs
@@ -140,9 +140,9 @@ namespace DOL.AI.Brain
 		}
 		#region Throw Player
 		List<GamePlayer> Port_Enemys = new List<GamePlayer>();
-		public static bool IsTargetPicked = false;
-		public static GamePlayer randomtarget = null;
-		public static GamePlayer RandomTarget
+		public bool IsTargetPicked = false;
+		public GamePlayer randomtarget = null;
+		public GamePlayer RandomTarget
 		{
 			get { return randomtarget; }
 			set { randomtarget = value; }

--- a/GameServer/scripts/namedmobs/MoranTheMighty.cs
+++ b/GameServer/scripts/namedmobs/MoranTheMighty.cs
@@ -66,7 +66,6 @@ namespace DOL.GS
             RespawnInterval = ServerProperties.Properties.SET_EPIC_GAME_ENCOUNTER_RESPAWNINTERVAL * 60000;//1min is 60000 miliseconds
 
             MoranBrain sBrain = new MoranBrain();
-            MoranBrain._aggroStart = true;
             SetOwnBrain(sBrain);
             base.AddToWorld();
             return true;
@@ -80,7 +79,7 @@ namespace DOL.AI.Brain
     {
         private static readonly Logging.Logger log = Logging.LoggerManager.Create(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        public static bool _aggroStart = true;
+        public bool _aggroStart = true;
         
         public MoranBrain()
             : base()

--- a/GameServer/scripts/namedmobs/OFGreenKnight.cs
+++ b/GameServer/scripts/namedmobs/OFGreenKnight.cs
@@ -69,24 +69,6 @@ namespace DOL.GS
             Styles.Add(taunt);
             MaxSpeedBase = 400;
 
-            OFGreenKnightBrain.walk1 = false;
-            OFGreenKnightBrain.walk2 = false;
-            OFGreenKnightBrain.walk3 = false;
-            OFGreenKnightBrain.walk4 = false;
-            OFGreenKnightBrain.walk5 = false;
-            OFGreenKnightBrain.Pick_healer = false;
-            OFGreenKnightBrain.walk6 = false;
-            OFGreenKnightBrain.IsSpawningTrees = false;
-            OFGreenKnightBrain.walk7 = false;
-            OFGreenKnightBrain.IsWalking = false;
-            OFGreenKnightBrain.walk8 = false;
-            OFGreenKnightBrain.walk9 = false;
-            OFGreenKnightBrain.CanHeal1 = false;
-            OFGreenKnightBrain.CanHeal2 = false;
-            OFGreenKnightBrain.CanHeal3 = false;
-            OFGreenKnightBrain.CanHeal4 = false;
-            OFGreenKnightBrain.PickPortPoint = false;
-
             Flags = eFlags.PEACE;
             VisibleActiveWeaponSlots = 34;
             MeleeDamageType = eDamageType.Slash;
@@ -285,8 +267,8 @@ namespace DOL.AI.Brain
                 base.OnAttackedByEnemy(ad);
         }
         #region GK pick random healer
-        public static GamePlayer randomtarget = null;
-        public static GamePlayer RandomTarget
+        public GamePlayer randomtarget = null;
+        public GamePlayer RandomTarget
         {
             get { return randomtarget; }
             set { randomtarget = value; }
@@ -318,14 +300,14 @@ namespace DOL.AI.Brain
                         if (healer.Count > 0)
                         {
                             GamePlayer Target =(GamePlayer) healer[Util.Random(0, healer.Count - 1)]; //pick random target from list
-                            RandomTarget = Target; //set random target to static RandomTarget
+                            RandomTarget = Target;
                             if (RandomTarget != null) //check if it's not null
                             {
                                 ClearAggroList(); //clear aggro list or it may still stick to current target
                                 AddToAggroList(RandomTarget, 550); //set that target big aggro so boss will attack him
                                 Body.StartAttack(RandomTarget); //attack target
                             }
-                            RandomTarget = null; //reset static ranmdomtarget to null
+                            RandomTarget = null;
                             Pick_healer = false; //reset flag
                         }
                     }
@@ -335,19 +317,19 @@ namespace DOL.AI.Brain
         }
         #endregion
         #region GK check flags & strings & PortPoints list
-        public static bool Pick_healer = false;
-        public static bool IsSpawningTrees = false;
-        public static bool walk1 = false;
-        public static bool walk2 = false;
-        public static bool walk3 = false;
-        public static bool walk4 = false;
-        public static bool walk5 = false;
-        public static bool walk6 = false;
-        public static bool walk7 = false;
-        public static bool walk8 = false;
-        public static bool walk9 = false;
+        public bool Pick_healer = false;
+        public bool IsSpawningTrees = false;
+        public bool walk1 = false;
+        public bool walk2 = false;
+        public bool walk3 = false;
+        public bool walk4 = false;
+        public bool walk5 = false;
+        public bool walk6 = false;
+        public bool walk7 = false;
+        public bool walk8 = false;
+        public bool walk9 = false;
 
-        public static bool IsWalking = false;
+        public bool IsWalking = false;
         public List<string> PortPoints = new List<string>();
         public static string string1 = "point1";
         public static string string2 = "point2";
@@ -355,7 +337,7 @@ namespace DOL.AI.Brain
         public static string string4 = "point4";
         #endregion
         #region GK Teleport/Walk method
-        public static bool PickPortPoint = false;
+        public bool PickPortPoint = false;
         public int GkTeleport(ECSGameTimer timer)
         {
             if (Body.IsAlive)
@@ -423,10 +405,10 @@ namespace DOL.AI.Brain
             return 0;
         }
         #endregion
-        public static bool CanHeal1 = false;
-        public static bool CanHeal2 = false;
-        public static bool CanHeal3 = false;
-        public static bool CanHeal4 = false;
+        public bool CanHeal1 = false;
+        public bool CanHeal2 = false;
+        public bool CanHeal3 = false;
+        public bool CanHeal4 = false;
         public int StartHeal(ECSGameTimer timer)
         {
             IsWalking = false;

--- a/GameServer/scripts/namedmobs/SummonersHall/GrandSummonerGovannon.cs
+++ b/GameServer/scripts/namedmobs/SummonersHall/GrandSummonerGovannon.cs
@@ -219,6 +219,8 @@ namespace DOL.AI.Brain
 		}
 		public static bool SpawnSacrifices1 = false;
 		public static bool Stage2 = false;
+		public bool SacrificeCompleted = false;
+		public bool DemonCompleted = false;
 		public void BroadcastMessage(String message)
 		{
 			foreach (GamePlayer player in Body.GetPlayersInRadius(WorldMgr.VISIBILITY_DISTANCE))
@@ -235,6 +237,8 @@ namespace DOL.AI.Brain
 				FSM.SetCurrentState(eFSMStateType.RETURN_TO_SPAWN);
 				Stage2 = false;
 				SpawnSacrifices1 = false;
+				SacrificeCompleted = false;
+				DemonCompleted = false;
 				Body.Health = Body.MaxHealth;
 				if (!RemoveAdds)
 				{
@@ -314,6 +318,7 @@ namespace DOL.AI.Brain
 			Add1.Heading = 3054;
 			Add1.LoadedFromScript = true;
 			Add1.Faction = FactionMgr.GetFactionByID(187);
+			Add1.OwnerBrain = this;
 			Add1.AddToWorld();
 
 			SummonedDemon Add2 = new SummonedDemon();
@@ -324,13 +329,15 @@ namespace DOL.AI.Brain
 			Add2.Heading = 1004;
 			Add2.LoadedFromScript = true;
 			Add2.Faction = FactionMgr.GetFactionByID(187);
+			Add2.OwnerBrain = this;
 			Add2.AddToWorld();
 		}
+		private ShadeOfAelfgar _shade;
 		public void SpawnShadeOfAelfgar()
         {
-			if (SummonedSacrifice.SacrificeKilledCount == 1 && SummonedDemon.SummonedDemonCount == 1)//both summoned demon and sacrifice must be killed
+			if (SacrificeCompleted && DemonCompleted)//both summoned demon and sacrifice must be killed
 			{
-				if (ShadeOfAelfgar.ShadeOfAelfgarCount == 0)//make sure there is only 1 always
+				if (_shade == null || !_shade.IsAlive || _shade.ObjectState is not GameObject.eObjectState.Active)//make sure there is only 1 always
 				{
 					ShadeOfAelfgar Add1 = new ShadeOfAelfgar();
 					Add1.X = 32128;
@@ -341,8 +348,9 @@ namespace DOL.AI.Brain
 					Add1.LoadedFromScript = true;
 					Add1.Faction = FactionMgr.GetFactionByID(187);
 					Add1.AddToWorld();
-					SummonedDemon.SummonedDemonCount = 0;
-					SummonedSacrifice.SacrificeKilledCount = 0;
+					_shade = Add1;
+					DemonCompleted = false;
+					SacrificeCompleted = false;
 				}
 			}
 		}
@@ -414,7 +422,7 @@ namespace DOL.GS
 				default: return 55;// dmg reduction for rest resists
 			}
 		}
-		public static int SacrificeKilledCount = 0;
+		public GrandSummonerGovannonBrain OwnerBrain;
         public override void Die(GameObject killer)
         {
             base.Die(killer);
@@ -423,7 +431,6 @@ namespace DOL.GS
 		{
 			Model = 122;
 			Name = "summoned sacrifice";
-			SacrificeKilledCount = 0;
 			RespawnInterval = -1;
 			Size = 45;
 			Level = (byte)Util.Random(62, 68);
@@ -462,7 +469,8 @@ namespace DOL.AI.Brain
             }
 			else
             {
-				SummonedSacrifice.SacrificeKilledCount = 1;
+				if (Body is SummonedSacrifice sacrifice && sacrifice.OwnerBrain != null)
+					sacrifice.OwnerBrain.SacrificeCompleted = true;
 				Body.Die(Body);//is at point so it die
             }
 			base.Think();
@@ -499,7 +507,7 @@ namespace DOL.GS
 				default: return 55;// dmg reduction for rest resists
 			}
 		}
-		public static int SummonedDemonCount = 0;
+		public GrandSummonerGovannonBrain OwnerBrain;
 		public override void Die(GameObject killer)
 		{
 			base.Die(killer);
@@ -508,7 +516,6 @@ namespace DOL.GS
 		{
 			Model = 253;
 			Name = "summoned demon";
-			SummonedDemonCount = 0;
 			RespawnInterval = -1;
 			Size = 30;
 			Level = (byte)Util.Random(62, 68);
@@ -547,7 +554,8 @@ namespace DOL.AI.Brain
 			}
 			else
 			{
-				SummonedDemon.SummonedDemonCount = 1;
+				if (Body is SummonedDemon demon && demon.OwnerBrain != null)
+					demon.OwnerBrain.DemonCompleted = true;
 				Body.Die(Body);//is at point so it die
 			}
 			base.Think();
@@ -584,12 +592,6 @@ namespace DOL.GS
 				default: return 55;// dmg reduction for rest resists
 			}
 		}
-		public static int ShadeOfAelfgarCount = 0;
-		public override void ProcessDeath(GameObject killer)
-		{
-			++ShadeOfAelfgarCount;
-			base.ProcessDeath(killer);
-		}
 		public override bool AddToWorld()
 		{
 			INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(18803);
@@ -597,7 +599,6 @@ namespace DOL.GS
 
 			ShadeOfAelfgarBrain.RandomTarget = null;
 			ShadeOfAelfgarBrain.CanPort = false;
-			ShadeOfAelfgarCount = 0;
 			RespawnInterval = -1;
 			Faction = FactionMgr.GetFactionByID(187);
 			ShadeOfAelfgarBrain sacrifice = new ShadeOfAelfgarBrain();

--- a/GameServer/scripts/namedmobs/SummonersHall/GrandSummonerGovannon.cs
+++ b/GameServer/scripts/namedmobs/SummonersHall/GrandSummonerGovannon.cs
@@ -310,6 +310,8 @@ namespace DOL.AI.Brain
         }
 		public void SpawnDemonAndSacrifice() // spawn sacrifice and demon
 		{
+			SacrificeCompleted = false;
+			DemonCompleted = false;
 			SummonedSacrifice Add1 = new SummonedSacrifice();
 			Add1.X = 31018;
 			Add1.Y = 40889;

--- a/GameServer/scripts/namedmobs/SummonersHall/GrandSummonerGovannon.cs
+++ b/GameServer/scripts/namedmobs/SummonersHall/GrandSummonerGovannon.cs
@@ -72,7 +72,7 @@ namespace DOL.GS
 		}
         public override void OnAttackEnemy(AttackData ad)
         {
-			if(ad != null && GrandSummonerGovannonBrain.Stage2==true)
+			if(ad != null && Brain is GrandSummonerGovannonBrain govannonBrain && govannonBrain.Stage2==true)
             {
 				if(Util.Chance(35))//30% chance to make a bleed
                 {
@@ -100,8 +100,6 @@ namespace DOL.GS
 			LoadTemplate(npcTemplate);
 			RespawnInterval = ServerProperties.Properties.SET_SI_EPIC_ENCOUNTER_RESPAWNINTERVAL * 60000;//1min is 60000 miliseconds
 			Faction = FactionMgr.GetFactionByID(206);
-			GrandSummonerGovannonBrain.SpawnSacrifices1 = false;
-			GrandSummonerGovannonBrain.Stage2 = false;
 
 			GameNpcInventoryTemplate template = new GameNpcInventoryTemplate();
 			template.AddNPCEquipment(eInventorySlot.TorsoArmor, 86, 43, 0, 0); //Slot,model,color,effect,extension
@@ -217,8 +215,8 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool SpawnSacrifices1 = false;
-		public static bool Stage2 = false;
+		public bool SpawnSacrifices1 = false;
+		public bool Stage2 = false;
 		public bool SacrificeCompleted = false;
 		public bool DemonCompleted = false;
 		public void BroadcastMessage(String message)
@@ -599,8 +597,6 @@ namespace DOL.GS
 			INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(18803);
 			LoadTemplate(npcTemplate);
 
-			ShadeOfAelfgarBrain.RandomTarget = null;
-			ShadeOfAelfgarBrain.CanPort = false;
 			RespawnInterval = -1;
 			Faction = FactionMgr.GetFactionByID(187);
 			ShadeOfAelfgarBrain sacrifice = new ShadeOfAelfgarBrain();
@@ -660,14 +656,14 @@ namespace DOL.AI.Brain
 			AggroLevel = 100;
 			AggroRange = 800;
 		}
-		public static GamePlayer randomtarget = null;
-		public static GamePlayer RandomTarget
+		public GamePlayer randomtarget = null;
+		public GamePlayer RandomTarget
 		{
 			get { return randomtarget; }
 			set { randomtarget = value; }
 		}
 		List<GamePlayer> Enemys_To_Port = new List<GamePlayer>();
-		public static bool CanPort = false;
+		public bool CanPort = false;
 		public void PickRandomTarget()
 		{
 			foreach (GamePlayer player in Body.GetPlayersInRadius(2000))
@@ -686,7 +682,7 @@ namespace DOL.AI.Brain
 				if (CanPort == false)
 				{
 					GamePlayer Target = (GamePlayer)Enemys_To_Port[Util.Random(0, Enemys_To_Port.Count - 1)];//pick random target from list
-					RandomTarget = Target;//set random target to static RandomTarget
+					RandomTarget = Target;
 					RandomTarget.MoveTo(Body.CurrentRegionID, 32091, 39684, 16302, 4094);
 					new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(ResetPort), Util.Random(10000,20000));//port every 10-20s
 					CanPort = true;

--- a/GameServer/scripts/namedmobs/SummonersHall/SummonerCunovinda.cs
+++ b/GameServer/scripts/namedmobs/SummonersHall/SummonerCunovinda.cs
@@ -75,8 +75,6 @@ namespace DOL.GS
 			INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(18805);
 			LoadTemplate(npcTemplate);
 			RespawnInterval = ServerProperties.Properties.SET_SI_EPIC_ENCOUNTER_RESPAWNINTERVAL * 60000;//1min is 60000 miliseconds
-			SummonerCunovindaBrain.RandomTarget = null;
-			SummonerCunovindaBrain.CanCast = false;
 			Faction = FactionMgr.GetFactionByID(187);
 			IsCloakHoodUp = true;
 
@@ -190,13 +188,13 @@ namespace DOL.AI.Brain
 			}
 			base.Think();
 		}
-		public static GamePlayer randomtarget = null;
-		public static GamePlayer RandomTarget
+		public GamePlayer randomtarget = null;
+		public GamePlayer RandomTarget
 		{
 			get { return randomtarget; }
 			set { randomtarget = value; }
 		}
-		public static bool CanCast = false;
+		public bool CanCast = false;
 		List<GamePlayer> Enemys_To_DD = new List<GamePlayer>();
 		public void PickRandomTarget()
 		{
@@ -216,7 +214,7 @@ namespace DOL.AI.Brain
 				if (CanCast == false)
 				{
 					GamePlayer Target = (GamePlayer)Enemys_To_DD[Util.Random(0, Enemys_To_DD.Count - 1)];//pick random target from list
-					RandomTarget = Target;//set random target to static RandomTarget
+					RandomTarget = Target;
 					new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(CastBolt), 1000);
 					CanCast = true;
 				}

--- a/GameServer/scripts/namedmobs/SummonersHall/SummonerLossren.cs
+++ b/GameServer/scripts/namedmobs/SummonersHall/SummonerLossren.cs
@@ -75,6 +75,18 @@ namespace DOL.GS
 
 			return base.HasAbility(keyName);
 		}
+		public override void ProcessDeath(GameObject killer)
+		{
+			foreach (GameNPC npc in WorldMgr.GetNPCsFromRegion(this.CurrentRegionID))
+			{
+				if (npc != null)
+				{
+					if (npc.IsAlive && (npc.Brain is TorturedSoulsBrain || npc.Brain is ExplodeUndeadBrain))
+						npc.RemoveFromWorld();
+				}
+			}
+			base.ProcessDeath(killer);
+		}
 		public override bool AddToWorld()
 		{
 			INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(18806);

--- a/GameServer/scripts/namedmobs/SummonersHall/SummonerLossren.cs
+++ b/GameServer/scripts/namedmobs/SummonersHall/SummonerLossren.cs
@@ -83,7 +83,6 @@ namespace DOL.GS
 			Faction = FactionMgr.GetFactionByID(206);
 			IsCloakHoodUp = true;
 			SummonerLossrenBrain.IsCreatingSouls = false;
-			TorturedSouls.TorturedSoulKilled = 0;
 
 			SummonerLossrenBrain sbrain = new SummonerLossrenBrain();
 			SetOwnBrain(sbrain);
@@ -156,7 +155,23 @@ namespace DOL.AI.Brain
 			ThinkInterval = 1500;
 		}
 		public static bool IsCreatingSouls = false;
+		public int TorturedSoulKilled = 0;
 		private bool RemoveAdds = false;
+		private readonly List<GameNPC> _souls = new List<GameNPC>();
+		private GameNPC _explodeZombie;
+		private bool IsTorturedSoulUp()
+		{
+			foreach (GameNPC npc in _souls)
+			{
+				if (npc != null && npc.IsAlive && npc.ObjectState is GameObject.eObjectState.Active)
+					return true;
+			}
+			return false;
+		}
+		private bool IsExplodeZombieUp()
+		{
+			return _explodeZombie != null && _explodeZombie.IsAlive && _explodeZombie.ObjectState is GameObject.eObjectState.Active;
+		}
 		public override void Think()
 		{
 			if (!CheckProximityAggro())
@@ -164,8 +179,7 @@ namespace DOL.AI.Brain
 				//set state to RETURN TO SPAWN
 				FSM.SetCurrentState(eFSMStateType.RETURN_TO_SPAWN);
 				Body.Health = Body.MaxHealth;
-				TorturedSouls.TorturedSoulKilled = 0;
-				TorturedSouls.TorturedSoulCount = 0;
+				TorturedSoulKilled = 0;
 				if (!RemoveAdds)
 				{
 					foreach (GameNPC souls in Body.GetNPCsInRadius(5000))
@@ -210,7 +224,7 @@ namespace DOL.AI.Brain
         {
 			if (Body.InCombat && Body.IsAlive && HasAggro)
 			{
-				if(TorturedSouls.TorturedSoulCount == 0)
+				if(!IsTorturedSoulUp())
 					SpawnSouls();
 			}
 			SpawnBigZombie();
@@ -223,6 +237,7 @@ namespace DOL.AI.Brain
 			Point3D point2 = new Point3D(38505, 41211, 16001);
 			Point3D point3 = new Point3D(39180, 40583, 16000);
 			Point3D point4 = new Point3D(39745, 41176, 16001);
+			_souls.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not GameObject.eObjectState.Active);
 
 			for (int i = 0; i < Util.Random(18, 25); i++)//create 18-25 souls every time timer will launch
 			{
@@ -261,9 +276,10 @@ namespace DOL.AI.Brain
 				}
 				add.CurrentRegion = Body.CurrentRegion;
 				add.Heading = Body.Heading;
+				add.OwnerBrain = this;
 				add.AddToWorld();
 				add.LoadedFromScript = true;
-				++TorturedSouls.TorturedSoulCount;
+				_souls.Add(add);
 			}
 		}
 		public void SpawnBigZombie()
@@ -272,7 +288,7 @@ namespace DOL.AI.Brain
 			Point3D point2 = new Point3D(38505, 41211, 16001);
 			Point3D point3 = new Point3D(39180, 40583, 16000);
 			Point3D point4 = new Point3D(39745, 41176, 16001);
-			if (TorturedSouls.TorturedSoulKilled == 20 && ExplodeUndead.ExplodeZombieCount==0)//spawn explode zombie
+			if (TorturedSoulKilled == 20 && !IsExplodeZombieUp())//spawn explode zombie
 			{
 				ExplodeUndead add2 = new ExplodeUndead();
 				switch (Util.Random(1, 4))
@@ -310,8 +326,8 @@ namespace DOL.AI.Brain
 				add2.Heading = Body.Heading;
 				add2.AddToWorld();
 				add2.LoadedFromScript = true;
-				TorturedSouls.TorturedSoulKilled = 0;
-				++ExplodeUndead.ExplodeZombieCount;
+				_explodeZombie = add2;
+				TorturedSoulKilled = 0;
 			}
 		}
 	}
@@ -366,12 +382,11 @@ namespace DOL.GS
 			}
 		}
 
-		public static int TorturedSoulCount = 0;
-		public static int TorturedSoulKilled = 0;
+		public SummonerLossrenBrain OwnerBrain;
 		public override void ProcessDeath(GameObject killer)
         {
-			--TorturedSoulCount;
-			++TorturedSoulKilled;
+			if (OwnerBrain != null && OwnerBrain.Body != null && OwnerBrain.Body.IsAlive)
+				++OwnerBrain.TorturedSoulKilled;
             base.ProcessDeath(killer);
         }
 		public override bool CanDropLoot => false;
@@ -528,10 +543,8 @@ namespace DOL.GS
 			}
 		}
 
-		public static int ExplodeZombieCount = 0;
 		public override void ProcessDeath(GameObject killer)
 		{
-			--ExplodeZombieCount;
 			RandomTarget = null;
 			base.ProcessDeath(killer);
 		}
@@ -549,7 +562,6 @@ namespace DOL.GS
 			RandomTarget = null;
 			ExplodeUndeadBrain.IsKilled = false;
 			ExplodeUndeadBrain.SetAggroAmount = false;
-			ExplodeZombieCount = 0;
 			Zombie_Targets.Clear();
 			Name = "infected ghoul";
 			RespawnInterval = -1;

--- a/GameServer/scripts/namedmobs/SummonersHall/SummonerLossren.cs
+++ b/GameServer/scripts/namedmobs/SummonersHall/SummonerLossren.cs
@@ -94,7 +94,6 @@ namespace DOL.GS
 			RespawnInterval = ServerProperties.Properties.SET_SI_EPIC_ENCOUNTER_RESPAWNINTERVAL * 60000;//1min is 60000 miliseconds
 			Faction = FactionMgr.GetFactionByID(206);
 			IsCloakHoodUp = true;
-			SummonerLossrenBrain.IsCreatingSouls = false;
 
 			SummonerLossrenBrain sbrain = new SummonerLossrenBrain();
 			SetOwnBrain(sbrain);
@@ -166,7 +165,7 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsCreatingSouls = false;
+		public bool IsCreatingSouls = false;
 		public int TorturedSoulKilled = 0;
 		private bool RemoveAdds = false;
 		private readonly List<GameNPC> _souls = new List<GameNPC>();
@@ -204,6 +203,14 @@ namespace DOL.AI.Brain
 							}
 						}
 					}
+					foreach (GameNPC souls in _souls)
+					{
+						if (souls != null && souls.ObjectState is GameObject.eObjectState.Active)
+							souls.RemoveFromWorld();
+					}
+					_souls.Clear();
+					if (IsExplodeZombieUp())
+						_explodeZombie.RemoveFromWorld();
 					RemoveAdds = true;
 				}
 			}
@@ -449,15 +456,16 @@ namespace DOL.AI.Brain
 			AggroRange = 800;
 		}
 		private static readonly Logging.Logger log = Logging.LoggerManager.Create(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
-		public static bool IsKilled = false;
-		public static bool SetAggroAmount = false;
+		public bool IsKilled = false;
+		public bool SetAggroAmount = false;
 		public override void Think()
 		{
+			GamePlayer randomTarget = Body is ExplodeUndead undead ? undead.RandomTarget : null;
 			if (Body.IsAlive)
 			{
-				if (Body.TargetObject == null && ExplodeUndead.RandomTarget != null)
+				if (Body.TargetObject == null && randomTarget != null)
 				{
-					Body.TargetObject = ExplodeUndead.RandomTarget;
+					Body.TargetObject = randomTarget;
 				}
 				if (Body.TargetObject != null)
 				{
@@ -472,11 +480,11 @@ namespace DOL.AI.Brain
 					}
 				}
 			}
-			if (Body.IsAlive && ExplodeUndead.RandomTarget != null )
+			if (Body.IsAlive && randomTarget != null )
             {
 				if (SetAggroAmount == false)
 				{
-					AddToAggroList(ExplodeUndead.RandomTarget, 2000);
+					AddToAggroList(randomTarget, 2000);
 					SetAggroAmount = true;
 				}
 			}
@@ -561,8 +569,8 @@ namespace DOL.GS
 			base.ProcessDeath(killer);
 		}
         public override bool CanDropLoot => false;
-        public static GamePlayer randomtarget = null;
-		public static GamePlayer RandomTarget
+        public GamePlayer randomtarget = null;
+		public GamePlayer RandomTarget
 		{
 			get { return randomtarget; }
 			set { randomtarget = value; }
@@ -572,8 +580,6 @@ namespace DOL.GS
 		{
 			Model = 923;
 			RandomTarget = null;
-			ExplodeUndeadBrain.IsKilled = false;
-			ExplodeUndeadBrain.SetAggroAmount = false;
 			Zombie_Targets.Clear();
 			Name = "infected ghoul";
 			RespawnInterval = -1;

--- a/GameServer/scripts/namedmobs/SummonersHall/SummonerRoesia.cs
+++ b/GameServer/scripts/namedmobs/SummonersHall/SummonerRoesia.cs
@@ -73,8 +73,6 @@ namespace DOL.GS
 			INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(18804);
 			LoadTemplate(npcTemplate);
 			RespawnInterval = ServerProperties.Properties.SET_SI_EPIC_ENCOUNTER_RESPAWNINTERVAL * 60000;//1min is 60000 miliseconds
-			SummonerRoesiaBrain.RandomTarget = null;
-			SummonerRoesiaBrain.CanCast = false;
 			Faction = FactionMgr.GetFactionByID(187);
 			IsCloakHoodUp = true;
 
@@ -224,13 +222,13 @@ namespace DOL.AI.Brain
 			}
 			base.Think();
 		}
-		public static GamePlayer randomtarget = null;
-		public static GamePlayer RandomTarget
+		public GamePlayer randomtarget = null;
+		public GamePlayer RandomTarget
 		{
 			get { return randomtarget; }
 			set { randomtarget = value; }
 		}
-		public static bool CanCast = false;
+		public bool CanCast = false;
 		List<GamePlayer> Enemys_To_DD = new List<GamePlayer>();
 		public void PickRandomTarget()
         {
@@ -250,7 +248,7 @@ namespace DOL.AI.Brain
 				if (CanCast==false)
 				{
 					GamePlayer Target = Enemys_To_DD[Util.Random(0, Enemys_To_DD.Count - 1)];//pick random target from list
-					RandomTarget = Target;//set random target to static RandomTarget
+					RandomTarget = Target;
 					new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(ResetDot), 3000);
 					CanCast = true;
 				}				

--- a/GameServer/scripts/namedmobs/Trollheim/Dagar.cs
+++ b/GameServer/scripts/namedmobs/Trollheim/Dagar.cs
@@ -74,7 +74,6 @@ namespace DOL.AI.Brain
 			AggroLevel = 100;
 			AggroRange = 500;
 		}
-		public static bool IsPulled = false;
 		public override void Think()
 		{
 			if (HasAggro && Body.TargetObject != null)

--- a/GameServer/scripts/namedmobs/Trollheim/Nosdoden.cs
+++ b/GameServer/scripts/namedmobs/Trollheim/Nosdoden.cs
@@ -366,7 +366,6 @@ namespace DOL.AI.Brain
 			AggroLevel = 100;
 			AggroRange = 800;
 		}
-		public static bool IsPulled = false;
 		private bool SpawnAdds1 = false;
 		private bool SpawnAdds2 = false;
 		private bool SpawnAdds3 = false;
@@ -384,10 +383,10 @@ namespace DOL.AI.Brain
 			}
 		}
 		#region Worm Dot
-		public static bool CanCast2 = false;
-		public static bool StartCastDOT = false;
-		public static GamePlayer randomtarget2 = null;
-		public static GamePlayer RandomTarget2
+		public bool CanCast2 = false;
+		public bool StartCastDOT = false;
+		public GamePlayer randomtarget2 = null;
+		public GamePlayer RandomTarget2
 		{
 			get { return randomtarget2; }
 			set { randomtarget2 = value; }
@@ -415,7 +414,7 @@ namespace DOL.AI.Brain
 					if (CanCast2 == false)
 					{
 						GamePlayer Target = (GamePlayer)Enemys_To_DOT[Util.Random(0, Enemys_To_DOT.Count - 1)];//pick random target from list
-						RandomTarget2 = Target;//set random target to static RandomTarget
+						RandomTarget2 = Target;
 						new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(CastDOT), 2000);
 						CanCast2 = true;
 					}
@@ -449,10 +448,10 @@ namespace DOL.AI.Brain
 		}
 		#endregion
 		#region Worm DD
-		public static bool CanCast = false;
-		public static bool StartCastDD = false;
-		public static GamePlayer randomtarget = null;
-		public static GamePlayer RandomTarget
+		public bool CanCast = false;
+		public bool StartCastDD = false;
+		public GamePlayer randomtarget = null;
+		public GamePlayer RandomTarget
 		{
 			get { return randomtarget; }
 			set { randomtarget = value; }
@@ -480,7 +479,7 @@ namespace DOL.AI.Brain
 					if (CanCast == false)
 					{
 						GamePlayer Target = (GamePlayer)Enemys_To_DD[Util.Random(0, Enemys_To_DD.Count - 1)];//pick random target from list
-						RandomTarget = Target;//set random target to static RandomTarget
+						RandomTarget = Target;
 						new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(CastDD), 5000);
 						BroadcastMessage(String.Format(Body.Name + " starts casting void magic at " + RandomTarget.Name + "."));
 						CanCast = true;
@@ -514,14 +513,14 @@ namespace DOL.AI.Brain
 			return 0;
 		}
 		#endregion
-		public static GameNPC spiritmob = null;
-		public static GameNPC SpiritMob
+		public GameNPC spiritmob = null;
+		public GameNPC SpiritMob
 		{
 			get { return spiritmob; }
 			set { spiritmob = value; }
 		}
-		public static GamePlayer playerrezzed = null;
-		public static GamePlayer PlayerRezzed
+		public GamePlayer playerrezzed = null;
+		public GamePlayer PlayerRezzed
 		{
 			get { return playerrezzed; }
 			set { playerrezzed = value; }
@@ -541,6 +540,8 @@ namespace DOL.AI.Brain
 				RandomTarget = null;
 				RandomTarget2 = null;
 				CanKillSpirit = false;
+				SpiritMob = null;
+				PlayerRezzed = null;
 				SpawnAdds1 = false;
 				SpawnAdds2 = false;
 				SpawnAdds3 = false;

--- a/GameServer/scripts/namedmobs/Trollheim/Rift.cs
+++ b/GameServer/scripts/namedmobs/Trollheim/Rift.cs
@@ -81,7 +81,6 @@ namespace DOL.GS
 			RespawnInterval = ServerProperties.Properties.SET_EPIC_GAME_ENCOUNTER_RESPAWNINTERVAL * 60000;//1min is 60000 miliseconds
 
 			Faction = FactionMgr.GetFactionByID(150);
-			RiftBrain.IsValkyn = false;
 
 			RiftBrain sbrain = new RiftBrain();
 			SetOwnBrain(sbrain);
@@ -104,9 +103,9 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool IsPulled = false;
-		public static bool IsValkyn = false;
-		public static bool IsRift = false;
+		public bool IsPulled = false;
+		public bool IsValkyn = false;
+		public bool IsRift = false;
 		public void ChangeAppearance()
         {
 			if (!HasAggro && Body.IsAlive && IsValkyn == false)
@@ -191,7 +190,7 @@ namespace DOL.AI.Brain
 			}
 			base.Think();
 		}
-		public static bool SpawnMoreAdds = false;
+		public bool SpawnMoreAdds = false;
 		public int SpawnAdds(ECSGameTimer timer)
         {
 			if (Body.IsAlive && HasAggro && IsRift)

--- a/GameServer/scripts/namedmobs/Trollheim/Rotoddjur.cs
+++ b/GameServer/scripts/namedmobs/Trollheim/Rotoddjur.cs
@@ -81,7 +81,7 @@ namespace DOL.AI.Brain
 			AggroLevel = 100;
 			AggroRange = 500;
 		}
-		public static bool IsPulled = false;
+		public bool IsPulled = false;
 		private bool RemoveAdds = false;
 		public override void Think()
 		{

--- a/GameServer/scripts/namedmobs/TurSuil/AbomosSoultrapper.cs
+++ b/GameServer/scripts/namedmobs/TurSuil/AbomosSoultrapper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using DOL.AI.Brain;
 using DOL.Database;
 using DOL.Events;
@@ -10,6 +11,7 @@ namespace DOL.GS
 	public class AbomosSoultrapper : GameEpicBoss
 	{
 		public AbomosSoultrapper() : base() { }
+		public readonly List<GameNPC> Adds = new List<GameNPC>();
 
 		[ScriptLoadedEvent]
 		public static void ScriptLoaded(DOLEvent e, object sender, EventArgs args)
@@ -183,9 +185,14 @@ namespace DOL.AI.Brain
 		}
 		public void SpawnAdds()
 		{
+			if (Body is not AbomosSoultrapper abomos)
+				return;
+
+			abomos.Adds.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not GameObject.eObjectState.Active);
+			int addsCount = abomos.Adds.Count;
 			for (int i = 0; i < 2; i++)
 			{
-				if (AbomosAdd.AddsCount < 3)
+				if (addsCount < 3)
 				{
 					AbomosAdd Add1 = new AbomosAdd();
 					Add1.X = Body.X;
@@ -195,6 +202,8 @@ namespace DOL.AI.Brain
 					Add1.Heading = Body.Heading;
 					Add1.RespawnInterval = -1;
 					Add1.AddToWorld();
+					abomos.Adds.Add(Add1);
+					++addsCount;
 				}
 			}
 		}
@@ -222,12 +231,6 @@ namespace DOL.GS
 		{
 			get { return 5000; }
 		}
-		public static int AddsCount= 0;
-		public override void ProcessDeath(GameObject killer)
-		{
-			--AddsCount;
-			base.ProcessDeath(killer);
-		}
 		public override bool CanDropLoot => false;
 		public override long ExperienceValue => 0;
 		public override bool AddToWorld()
@@ -235,7 +238,6 @@ namespace DOL.GS
 			Model = 826;
 			Name = "Abomos Servant";
 			RespawnInterval = -1;
-			++AddsCount;
 
 			Size = (byte)Util.Random(80, 100);
 			Level = (byte)Util.Random(50,55);

--- a/GameServer/scripts/namedmobs/TurSuil/Balor.cs
+++ b/GameServer/scripts/namedmobs/TurSuil/Balor.cs
@@ -76,7 +76,6 @@ namespace DOL.GS
 			LoadTemplate(npcTemplate);
 			RespawnInterval = ServerProperties.Properties.SET_EPIC_GAME_ENCOUNTER_RESPAWNINTERVAL * 60000;//1min is 60000 miliseconds
 
-			BalorBrain.spawn_eye = false;
 			Faction = FactionMgr.GetFactionByID(93);
 			IsCloakHoodUp = true;
 
@@ -106,7 +105,6 @@ namespace DOL.AI.Brain
 			AggroRange = 600;
 			ThinkInterval = 1500;
 		}
-		public static bool spawn_eye = false;
 		private bool IsEyeOfBalorUp()
 		{
 			return Body is Balor balor && balor.Eye != null && balor.Eye.IsAlive && balor.Eye.ObjectState is GameObject.eObjectState.Active;
@@ -194,8 +192,8 @@ namespace DOL.AI.Brain
 			AggroRange = 1500;
 			ThinkInterval = 500;
 		}
-		public static bool PickTarget = false;
-		public static bool Cancast = false;
+		public bool PickTarget = false;
+		public bool Cancast = false;
 		public void BroadcastMessage(String message)
 		{
 			foreach (GamePlayer player in Body.GetPlayersInRadius(WorldMgr.VISIBILITY_DISTANCE))
@@ -221,8 +219,8 @@ namespace DOL.AI.Brain
 			}
 			base.Think();
 		}
-		public static GamePlayer randomtarget = null;
-		public static GamePlayer RandomTarget
+		public GamePlayer randomtarget = null;
+		public GamePlayer RandomTarget
 		{
 			get { return randomtarget; }
 			set { randomtarget = value; }
@@ -247,7 +245,7 @@ namespace DOL.AI.Brain
 			if (Enemys_To_DD.Count > 0)
 			{
 				GamePlayer Target = Enemys_To_DD[Util.Random(0, Enemys_To_DD.Count - 1)];//pick random target from list
-				RandomTarget = Target;//set random target to static RandomTarget
+				RandomTarget = Target;
 				new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(StartCast), 3000);
 			}
 		}
@@ -312,9 +310,6 @@ namespace DOL.GS
 			Flags ^= eFlags.DONTSHOWNAME;
 			//Flags ^= eFlags.STATUE;
 
-			BalorEyeBrain.PickTarget = false;
-			BalorEyeBrain.RandomTarget = null;
-			BalorEyeBrain.Cancast = false;
 			Size = 20;
 			Level = (byte)Util.Random(65, 70);
 			Faction = FactionMgr.GetFactionByID(93);

--- a/GameServer/scripts/namedmobs/TurSuil/Balor.cs
+++ b/GameServer/scripts/namedmobs/TurSuil/Balor.cs
@@ -10,6 +10,7 @@ namespace DOL.GS
 	public class Balor : GameEpicBoss
 	{
 		public Balor() : base() { }
+		public BalorEye Eye;
 		public override int GetResist(eDamageType damageType)
 		{
 			switch (damageType)
@@ -106,9 +107,13 @@ namespace DOL.AI.Brain
 			ThinkInterval = 1500;
 		}
 		public static bool spawn_eye = false;
+		private bool IsEyeOfBalorUp()
+		{
+			return Body is Balor balor && balor.Eye != null && balor.Eye.IsAlive && balor.Eye.ObjectState is GameObject.eObjectState.Active;
+		}
 		public void SpawnEyeOfBalor()
 		{
-			if (BalorEye.EyeCount == 0)
+			if (!IsEyeOfBalorUp())
 			{
 				BalorEye Add1 = new BalorEye();
 				Add1.X = Body.X;
@@ -118,6 +123,8 @@ namespace DOL.AI.Brain
 				Add1.Heading = Body.Heading;
 				Add1.RespawnInterval = -1;
 				Add1.AddToWorld();
+				if (Body is Balor balor)
+					balor.Eye = Add1;
 			}
 		}
 		private int m_stage = 10;
@@ -290,12 +297,6 @@ namespace DOL.GS
         public override void StartAttack(GameObject target)
         {
         }
-		public static int EyeCount = 0;
-        public override void ProcessDeath(GameObject killer)
-        {
-			--EyeCount;
-            base.ProcessDeath(killer);
-        }
         public override bool AddToWorld()
 		{
 			Model = 665;
@@ -314,7 +315,6 @@ namespace DOL.GS
 			BalorEyeBrain.PickTarget = false;
 			BalorEyeBrain.RandomTarget = null;
 			BalorEyeBrain.Cancast = false;
-			++EyeCount;
 			Size = 20;
 			Level = (byte)Util.Random(65, 70);
 			Faction = FactionMgr.GetFactionByID(93);

--- a/GameServer/scripts/namedmobs/TurSuil/KieracDestroyerAndMasterOfPain.cs
+++ b/GameServer/scripts/namedmobs/TurSuil/KieracDestroyerAndMasterOfPain.cs
@@ -126,7 +126,7 @@ namespace DOL.GS
 			}
 			return success;
 		}
-		private static bool SpawnMoP=false;
+		private bool SpawnMoP=false;
 		public override void ProcessDeath(GameObject killer)
 		{
 			if (SpawnMoP == false)

--- a/GameServer/scripts/namedmobs/TurSuil/QueenQunilaria.cs
+++ b/GameServer/scripts/namedmobs/TurSuil/QueenQunilaria.cs
@@ -133,8 +133,6 @@ namespace DOL.GS
 				Add1.Heading = Heading;
 				Add1.RespawnInterval = -1;
 				Add1.AddToWorld();
-				lock (MinionsLock)
-					Minions.Add(Add1);
 			}
 		}
 	}

--- a/GameServer/scripts/namedmobs/TurSuil/QueenQunilaria.cs
+++ b/GameServer/scripts/namedmobs/TurSuil/QueenQunilaria.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Numerics;
 using DOL.AI.Brain;
 using DOL.Database;
@@ -13,6 +14,8 @@ namespace DOL.GS
 	public class QueenQunilaria : GameEpicBoss
 	{
 		public QueenQunilaria() : base() { }
+		public readonly List<GameNPC> Minions = new List<GameNPC>();
+		public readonly object MinionsLock = new object();
 
 		[ScriptLoadedEvent]
 		public static void ScriptLoaded(DOLEvent e, object sender, EventArgs args)
@@ -130,6 +133,8 @@ namespace DOL.GS
 				Add1.Heading = Heading;
 				Add1.RespawnInterval = -1;
 				Add1.AddToWorld();
+				lock (MinionsLock)
+					Minions.Add(Add1);
 			}
 		}
 	}
@@ -147,19 +152,29 @@ namespace DOL.AI.Brain
 		}
 		public void SpawnAdds()
 		{
-			for (int i = 0; i < 3; i++)
+			if (Body is not QueenQunilaria queen)
+				return;
+
+			lock (queen.MinionsLock)
 			{
-				if (QunilariaAdd.MinionCount < 4)
+				queen.Minions.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not GameObject.eObjectState.Active);
+				int minionCount = queen.Minions.Count;
+				for (int i = 0; i < 3; i++)
 				{
-					QunilariaAdd Add1 = new QunilariaAdd();
-					Add1.X = Body.X + Util.Random(-100, 100);
-					Add1.Y = Body.Y + Util.Random(-100, 100);
-					Add1.Z = Body.Z;
-					Add1.CurrentRegion = Body.CurrentRegion;
-					Add1.Heading = Body.Heading;
-					Add1.RespawnInterval = -1;
-					Add1.PackageID = "QunilariaCombatAdd";
-					Add1.AddToWorld();
+					if (minionCount < 4)
+					{
+						QunilariaAdd Add1 = new QunilariaAdd();
+						Add1.X = Body.X + Util.Random(-100, 100);
+						Add1.Y = Body.Y + Util.Random(-100, 100);
+						Add1.Z = Body.Z;
+						Add1.CurrentRegion = Body.CurrentRegion;
+						Add1.Heading = Body.Heading;
+						Add1.RespawnInterval = -1;
+						Add1.PackageID = "QunilariaCombatAdd";
+						Add1.AddToWorld();
+						queen.Minions.Add(Add1);
+						++minionCount;
+					}
 				}
 			}
 		}
@@ -248,14 +263,8 @@ namespace DOL.GS
 			get { return 3000; }
 		}
 
-		public static int MinionCount = 0;
 		public override bool CanDropLoot => false;
 		public override long ExperienceValue => 0;
-		public override void ProcessDeath(GameObject killer)
-		{
-			--MinionCount;
-			base.ProcessDeath(killer);
-		}
 		public override bool AddToWorld()
 		{
 			Model = 764;
@@ -267,7 +276,6 @@ namespace DOL.GS
 			RespawnInterval = -1;
 			MaxSpeedBase = 225;
 
-			++MinionCount;
 			Size = (byte)Util.Random(80, 100);
 			Level = (byte)Util.Random(58, 64);
 			Faction = FactionMgr.GetFactionByID(93);

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/CouncilOtrygg.cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/CouncilOtrygg.cs
@@ -128,7 +128,7 @@ namespace DOL.AI.Brain
             }
             base.Think();
         }
-        public static bool IsPulled = false;
+        public bool IsPulled = false;
         private readonly List<GameNPC> _pets = new List<GameNPC>();
         private readonly object _petsLock = new object();
         public override void OnAttackedByEnemy(AttackData ad)

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/CouncilOtrygg.cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/CouncilOtrygg.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using DOL.AI.Brain;
 using DOL.Events;
 using DOL.Database;
@@ -62,7 +63,6 @@ namespace DOL.GS
             LoadTemplate(npcTemplate);
             Faction = FactionMgr.GetFactionByID(140);
             RespawnInterval = ServerProperties.Properties.SET_SI_EPIC_ENCOUNTER_RESPAWNINTERVAL * 60000; //1min is 60000 miliseconds
-            OtryggAdd.PetsCount = 0;
             OtryggBrain sbrain = new OtryggBrain();
             SetOwnBrain(sbrain);
             LoadedFromScript = false; //load from database
@@ -112,25 +112,40 @@ namespace DOL.AI.Brain
             if (HasAggro && Body.TargetObject != null)
             {
                 RemoveAdds = false;
-                if (OtryggAdd.PetsCount is < 8 and >= 0)
+                lock (_petsLock)
                 {
-                    SpawnPetsMore();
+                    int petsCount = 0;
+                    foreach (GameNPC npc in _pets)
+                    {
+                        if (npc != null && npc.IsAlive && npc.ObjectState is GameObject.eObjectState.Active)
+                            petsCount++;
+                    }
+                    if (petsCount < 8)
+                    {
+                        SpawnPetsMore();
+                    }
                 }
             }
             base.Think();
         }
         public static bool IsPulled = false;
+        private readonly List<GameNPC> _pets = new List<GameNPC>();
+        private readonly object _petsLock = new object();
         public override void OnAttackedByEnemy(AttackData ad)
         {
             if (IsPulled == false)
             {
-                SpawnPets();
+                lock (_petsLock)
+                {
+                    SpawnPets();
+                }
                 IsPulled = true;
             }
             base.OnAttackedByEnemy(ad);
         }
         public void SpawnPets()
         {
+            _pets.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not GameObject.eObjectState.Active);
             for (int i = 0; i < 8; i++) // Spawn 8 pets
             {
                 OtryggAdd Add = new OtryggAdd();
@@ -140,11 +155,12 @@ namespace DOL.AI.Brain
                 Add.CurrentRegion = Body.CurrentRegion;
                 Add.Heading = Body.Heading;
                 Add.AddToWorld();
-                OtryggAdd.PetsCount++;
+                _pets.Add(Add);
             }
         }
         public void SpawnPetsMore()
         {
+            _pets.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not GameObject.eObjectState.Active);
             OtryggAdd Add = new OtryggAdd();
             Add.X = Body.SpawnPoint.X + Util.Random(-50, 80);
             Add.Y = Body.SpawnPoint.Y + Util.Random(-50, 80);
@@ -152,7 +168,7 @@ namespace DOL.AI.Brain
             Add.CurrentRegion = Body.CurrentRegion;
             Add.Heading = Body.Heading;
             Add.AddToWorld();
-            OtryggAdd.PetsCount++;
+            _pets.Add(Add);
         }
     }
 }
@@ -189,13 +205,7 @@ namespace DOL.GS
         {
             get { return 10000; }
         }
-        public override void ProcessDeath(GameObject killer)
-        {
-            PetsCount--;
-            base.ProcessDeath(killer);
-        }
         public override bool CanDropLoot => false;
-        public static int PetsCount = 0;
         #region Stats
         public override short Charisma { get => base.Charisma; set => base.Charisma = 200; }
         public override short Piety { get => base.Piety; set => base.Piety = 200; }

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/CouncilVagnAndNokkvi.cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/CouncilVagnAndNokkvi.cs
@@ -73,7 +73,7 @@ namespace DOL.AI.Brain
             AggroRange = 600;
             ThinkInterval = 2000;
         }
-        public static bool IsPulled = false;
+        public bool IsPulled = false;
         public override void OnAttackedByEnemy(AttackData ad)
         {
             if (IsPulled == false)
@@ -212,7 +212,7 @@ namespace DOL.AI.Brain
             AggroRange = 600;
             ThinkInterval = 2000;
         }
-        public static bool IsPulled2 = false;
+        public bool IsPulled2 = false;
         public override void OnAttackedByEnemy(AttackData ad)
         {
             if (IsPulled2 == false)

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/ElderCouncilBirghirAndGuthlac.cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/ElderCouncilBirghirAndGuthlac.cs
@@ -56,9 +56,6 @@ namespace DOL.GS
             template.AddNPCEquipment(eInventorySlot.TwoHandWeapon, 19, 0);
             Inventory = template.CloseTemplate();
             SwitchWeapon(eActiveWeaponSlot.TwoHanded);
-            BirghirBrain.IsTargetPicked = false;
-            BirghirBrain.message1 = false;
-            BirghirBrain.IsPulled = false;
 
             VisibleActiveWeaponSlots = 34;
             MeleeDamageType = eDamageType.Crush;
@@ -92,8 +89,8 @@ namespace DOL.AI.Brain
                 player.Out.SendMessage(message, eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow);
             }
         }
-        public static GamePlayer randomtarget = null;
-        public static GamePlayer RandomTarget
+        public GamePlayer randomtarget = null;
+        public GamePlayer RandomTarget
         {
             get { return randomtarget; }
             set { randomtarget = value; }
@@ -164,9 +161,9 @@ namespace DOL.AI.Brain
             }
             return 0;
         }
-        public static bool IsTargetPicked = false;
-        public static bool message1 = false;
-        public static bool IsPulled = false;
+        public bool IsTargetPicked = false;
+        public bool message1 = false;
+        public bool IsPulled = false;
         public override void OnAttackedByEnemy(AttackData ad)
         {
             if (IsPulled == false)
@@ -424,11 +421,6 @@ namespace DOL.GS
             Inventory = template.CloseTemplate();
             SwitchWeapon(eActiveWeaponSlot.TwoHanded);
 
-            GuthlacBrain.message1 = false;
-            GuthlacBrain.IsBombUp = false;
-            GuthlacBrain.RandomTarget = null;
-            GuthlacBrain.IsPulled2 = false;
-
             VisibleActiveWeaponSlots = 34;
             MeleeDamageType = eDamageType.Crush;
             GuthlacBrain sbrain = new GuthlacBrain();
@@ -460,10 +452,10 @@ namespace DOL.AI.Brain
                 player.Out.SendMessage(message, eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow);
             }
         }
-        public static bool message1 = false;
-        public static bool IsBombUp = false;
-        public static GameLiving randomtarget = null;
-        public static GameLiving RandomTarget
+        public bool message1 = false;
+        public bool IsBombUp = false;
+        public GameLiving randomtarget = null;
+        public GameLiving RandomTarget
         {
             get { return randomtarget; }
             set { randomtarget = value; }
@@ -471,10 +463,10 @@ namespace DOL.AI.Brain
         List<GamePlayer> PlayersToDD = new List<GamePlayer>();
 
         #region Root && debuff
-        public static bool CanCast = false;
-        public static bool StartCastRoot = false;
-        public static GameLiving randomtarget2 = null;
-        public static GameLiving RandomTarget2
+        public bool CanCast = false;
+        public bool StartCastRoot = false;
+        public GameLiving randomtarget2 = null;
+        public GameLiving RandomTarget2
         {
             get { return randomtarget2; }
             set { randomtarget2 = value; }
@@ -498,7 +490,7 @@ namespace DOL.AI.Brain
                     if (CanCast == false)
                     {
                         GamePlayer Target = (GamePlayer)Enemys_To_Root[Util.Random(0, Enemys_To_Root.Count - 1)];//pick random target from list
-                        RandomTarget2 = Target;//set random target to static RandomTarget
+                        RandomTarget2 = Target;
                         new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(CastRoot), 1000);
                         CanCast = true;
                     }
@@ -533,7 +525,7 @@ namespace DOL.AI.Brain
         }
         #endregion
 
-        public static bool IsPulled2 = false;
+        public bool IsPulled2 = false;
         public override void OnAttackedByEnemy(AttackData ad)
         {
             if (IsPulled2 == false)

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/ElderCouncilBirghirAndGuthlac.cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/ElderCouncilBirghirAndGuthlac.cs
@@ -562,7 +562,6 @@ namespace DOL.AI.Brain
                 Body.Health = Body.MaxHealth;
                 IsPulled2 = false;
                 RandomTarget = null;
-                FrozenBomb.FrozenBombCount = 0;
                 message1 = false;
                 IsBombUp = false;
                 StartCastRoot = false;
@@ -607,7 +606,7 @@ namespace DOL.AI.Brain
                             PlayersToDD.Add(player);
                     }
                 }
-                if (IsBombUp == false && FrozenBomb.FrozenBombCount == 0)
+                if (IsBombUp == false && !IsFrozenBombUp())
                 {
                     if (PlayersToDD.Count > 0)
                     {
@@ -630,9 +629,14 @@ namespace DOL.AI.Brain
         }
 
         #region Spawn Frost Bomb
+        private GameNPC _frozenBomb;
+        private bool IsFrozenBombUp()
+        {
+            return _frozenBomb != null && _frozenBomb.IsAlive && _frozenBomb.ObjectState is GameObject.eObjectState.Active;
+        }
         public int SpawnBombTimer(ECSGameTimer timer)
         {
-            if (FrozenBomb.FrozenBombCount == 0)
+            if (!IsFrozenBombUp())
                 SpawnFrozenBomb();
 
             new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(ResetBomb), 5000);
@@ -667,6 +671,7 @@ namespace DOL.AI.Brain
             npc.Heading = Body.Heading;
             npc.CurrentRegion = Body.CurrentRegion;
             npc.AddToWorld();
+            _frozenBomb = npc;
         }
         #endregion
 
@@ -831,15 +836,9 @@ namespace DOL.GS
             // 85% ABS is cap.
             return 0.15;
         }
-        public static int FrozenBombCount = 0;
         public override void Die(GameObject killer)
         {
             base.Die(null);
-        }
-        public override void ProcessDeath(GameObject killer)
-        {
-            FrozenBombCount = 0;
-            base.ProcessDeath(killer);
         }
         public override int MaxHealth
         {
@@ -850,7 +849,6 @@ namespace DOL.GS
             Model = 665;
             Size = 100;
             MaxSpeedBase = 0;
-            FrozenBombCount = 1;
             Name = "Ice Spike";
             Level = (byte)Util.Random(62, 66);
 

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/ElderIcelordHjalmarAndSuttung.cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/ElderIcelordHjalmarAndSuttung.cs
@@ -668,11 +668,37 @@ namespace DOL.GS
         public GameNPC HjalmarBoss;
         public bool IsSuttungUp()
         {
-            return SuttungBoss != null && SuttungBoss.IsAlive && SuttungBoss.ObjectState is eObjectState.Active;
+            if (SuttungBoss != null && SuttungBoss.IsAlive && SuttungBoss.ObjectState is eObjectState.Active)
+                return true;
+
+            return IsOtherSuttungUp();
         }
         public bool IsHjalmarUp()
         {
-            return HjalmarBoss != null && HjalmarBoss.IsAlive && HjalmarBoss.ObjectState is eObjectState.Active;
+            if (HjalmarBoss != null && HjalmarBoss.IsAlive && HjalmarBoss.ObjectState is eObjectState.Active)
+                return true;
+
+            return IsOtherHjalmarUp();
+        }
+        private bool IsOtherSuttungUp()
+        {
+            foreach (GameNPC npc in WorldMgr.GetNPCsFromRegion(CurrentRegionID))
+            {
+                if (npc is Suttung && npc.IsAlive && npc.ObjectState is eObjectState.Active)
+                    return true;
+            }
+
+            return false;
+        }
+        private bool IsOtherHjalmarUp()
+        {
+            foreach (GameNPC npc in WorldMgr.GetNPCsFromRegion(CurrentRegionID))
+            {
+                if (npc is Hjalmar && npc.IsAlive && npc.ObjectState is eObjectState.Active)
+                    return true;
+            }
+
+            return false;
         }
         public void SpawnSuttung()
         {

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/ElderIcelordHjalmarAndSuttung.cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/ElderIcelordHjalmarAndSuttung.cs
@@ -64,14 +64,20 @@ namespace DOL.GS
             template.AddNPCEquipment(eInventorySlot.RightHandWeapon, 573, 0);
             Inventory = template.CloseTemplate();
             SwitchWeapon(eActiveWeaponSlot.Standard);
-            SuttungBrain.message1 = false;
-            SuttungBrain.message2 = false;
 
             VisibleActiveWeaponSlots = 16;
             SuttungBrain sbrain = new SuttungBrain();
             SetOwnBrain(sbrain);
-            LoadedFromScript = true; 
+            LoadedFromScript = true;
             base.AddToWorld();
+            foreach (GameNPC npc in GetNPCsInRadius(8000))
+            {
+                if (npc is HjalmarSuttungController controller)
+                {
+                    controller.SuttungBoss = this;
+                    break;
+                }
+            }
             return true;
         }
         public override void OnAttackEnemy(AttackData ad) //on enemy actions
@@ -140,7 +146,7 @@ namespace DOL.AI.Brain
             }
         }
 
-        public static bool IsBerserker = false;
+        public bool IsBerserker = false;
 
         public int BerserkerPhase(ECSGameTimer timer)
         {
@@ -170,9 +176,9 @@ namespace DOL.AI.Brain
             return 0;
         }
 
-        public static bool message1 = false;
-        public static bool message2 = false;
-        public static bool AggroText = false;
+        public bool message1 = false;
+        public bool message2 = false;
+        public bool AggroText = false;
 
         public override void Think()
         {
@@ -340,8 +346,6 @@ namespace DOL.GS
             Faction = FactionMgr.GetFactionByID(140);
             RespawnInterval = -1;
             BodyType = (ushort)NpcTemplateMgr.eBodyType.Giant;
-            HjalmarBrain.message1 = false;
-            HjalmarBrain.message2 = false;
 
             if(!Styles.Contains(taunt))
                 Styles.Add(taunt);
@@ -359,6 +363,14 @@ namespace DOL.GS
             SetOwnBrain(sbrain);
             LoadedFromScript = true;
             base.AddToWorld();
+            foreach (GameNPC npc in GetNPCsInRadius(8000))
+            {
+                if (npc is HjalmarSuttungController controller)
+                {
+                    controller.HjalmarBoss = this;
+                    break;
+                }
+            }
             return true;
         }
         public void BroadcastMessage(String message)
@@ -405,9 +417,8 @@ namespace DOL.AI.Brain
             }
         }
 
-        public static bool message1 = false;
-        public static bool message2 = false;
-        public static bool AggroText = false;
+        public bool message1 = false;
+        public bool message2 = false;
         private bool RemoveAdds = false;
         public override void Think()
         {
@@ -668,37 +679,11 @@ namespace DOL.GS
         public GameNPC HjalmarBoss;
         public bool IsSuttungUp()
         {
-            if (SuttungBoss != null && SuttungBoss.IsAlive && SuttungBoss.ObjectState is eObjectState.Active)
-                return true;
-
-            return IsOtherSuttungUp();
+            return SuttungBoss != null && SuttungBoss.IsAlive && SuttungBoss.ObjectState is eObjectState.Active;
         }
         public bool IsHjalmarUp()
         {
-            if (HjalmarBoss != null && HjalmarBoss.IsAlive && HjalmarBoss.ObjectState is eObjectState.Active)
-                return true;
-
-            return IsOtherHjalmarUp();
-        }
-        private bool IsOtherSuttungUp()
-        {
-            foreach (GameNPC npc in WorldMgr.GetNPCsFromRegion(CurrentRegionID))
-            {
-                if (npc is Suttung && npc.IsAlive && npc.ObjectState is eObjectState.Active)
-                    return true;
-            }
-
-            return false;
-        }
-        private bool IsOtherHjalmarUp()
-        {
-            foreach (GameNPC npc in WorldMgr.GetNPCsFromRegion(CurrentRegionID))
-            {
-                if (npc is Hjalmar && npc.IsAlive && npc.ObjectState is eObjectState.Active)
-                    return true;
-            }
-
-            return false;
+            return HjalmarBoss != null && HjalmarBoss.IsAlive && HjalmarBoss.ObjectState is eObjectState.Active;
         }
         public void SpawnSuttung()
         {
@@ -712,7 +697,8 @@ namespace DOL.GS
                 boss.CurrentRegion = CurrentRegion;
                 boss.AddToWorld();
                 SuttungBoss = boss;
-                HjalmarSuttungControllerBrain.Spawn_Boss = false;
+                if (Brain is HjalmarSuttungControllerBrain controllerBrain)
+                    controllerBrain.Spawn_Boss = false;
             }
         }
         public void SpawnHjalmar()
@@ -727,7 +713,8 @@ namespace DOL.GS
                 boss.CurrentRegion = CurrentRegion;
                 boss.AddToWorld();
                 HjalmarBoss = boss;
-                HjalmarSuttungControllerBrain.Spawn_Boss = false;
+                if (Brain is HjalmarSuttungControllerBrain controllerBrain)
+                    controllerBrain.Spawn_Boss = false;
             }
         }
     }
@@ -744,7 +731,7 @@ namespace DOL.AI.Brain
         {
             ThinkInterval = 1000;
         }
-        public static bool Spawn_Boss = false;
+        public bool Spawn_Boss = false;
         public override void Think()
         {
             int respawn = GS.ServerProperties.Properties.SET_SI_EPIC_ENCOUNTER_RESPAWNINTERVAL * 60000;

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/ElderIcelordHjalmarAndSuttung.cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/ElderIcelordHjalmarAndSuttung.cs
@@ -66,7 +66,6 @@ namespace DOL.GS
             SwitchWeapon(eActiveWeaponSlot.Standard);
             SuttungBrain.message1 = false;
             SuttungBrain.message2 = false;
-            SuttungCount = 1;
 
             VisibleActiveWeaponSlots = 16;
             SuttungBrain sbrain = new SuttungBrain();
@@ -74,12 +73,6 @@ namespace DOL.GS
             LoadedFromScript = true; 
             base.AddToWorld();
             return true;
-        }
-        public static int SuttungCount = 0;
-        public override void ProcessDeath(GameObject killer)
-        {
-            SuttungCount = 0;
-            base.ProcessDeath(killer);
         }
         public override void OnAttackEnemy(AttackData ad) //on enemy actions
         {
@@ -330,13 +323,6 @@ namespace DOL.GS
         {
             get { return 100000; }
         }
-        public static int HjalmarCount = 0;
-        public override void ProcessDeath(GameObject killer) //on kill generate orbs
-        {
-            HjalmarCount = 0;
-            base.ProcessDeath(killer);
-        }
-
         public override void OnAttackEnemy(AttackData ad)
         {
             if (ad != null && (ad.AttackResult == eAttackResult.HitStyle || ad.AttackResult == eAttackResult.HitUnstyled))
@@ -356,7 +342,6 @@ namespace DOL.GS
             BodyType = (ushort)NpcTemplateMgr.eBodyType.Giant;
             HjalmarBrain.message1 = false;
             HjalmarBrain.message2 = false;
-            HjalmarCount = 1;
 
             if(!Styles.Contains(taunt))
                 Styles.Add(taunt);
@@ -679,9 +664,19 @@ namespace DOL.GS
                 case 2: SpawnHjalmar(); break;
             }
         }
-        private void SpawnSuttung()
+        public GameNPC SuttungBoss;
+        public GameNPC HjalmarBoss;
+        public bool IsSuttungUp()
         {
-            if (Suttung.SuttungCount == 0)
+            return SuttungBoss != null && SuttungBoss.IsAlive && SuttungBoss.ObjectState is eObjectState.Active;
+        }
+        public bool IsHjalmarUp()
+        {
+            return HjalmarBoss != null && HjalmarBoss.IsAlive && HjalmarBoss.ObjectState is eObjectState.Active;
+        }
+        public void SpawnSuttung()
+        {
+            if (!IsSuttungUp())
             {
                 Suttung boss = new Suttung();
                 boss.X = 32055;
@@ -690,12 +685,13 @@ namespace DOL.GS
                 boss.Heading = 2084;
                 boss.CurrentRegion = CurrentRegion;
                 boss.AddToWorld();
+                SuttungBoss = boss;
                 HjalmarSuttungControllerBrain.Spawn_Boss = false;
             }
         }
-        private void SpawnHjalmar()
+        public void SpawnHjalmar()
         {
-            if (Hjalmar.HjalmarCount == 0)
+            if (!IsHjalmarUp())
             {
                 Hjalmar boss = new Hjalmar();
                 boss.X = 32079;
@@ -704,6 +700,7 @@ namespace DOL.GS
                 boss.Heading = 21;
                 boss.CurrentRegion = CurrentRegion;
                 boss.AddToWorld();
+                HjalmarBoss = boss;
                 HjalmarSuttungControllerBrain.Spawn_Boss = false;
             }
         }
@@ -725,60 +722,28 @@ namespace DOL.AI.Brain
         public override void Think()
         {
             int respawn = GS.ServerProperties.Properties.SET_SI_EPIC_ENCOUNTER_RESPAWNINTERVAL * 60000;
-            if (Body.IsAlive)
+            if (Body.IsAlive && Body is HjalmarSuttungController controller)
             {
-                if (Suttung.SuttungCount == 1 || Hjalmar.HjalmarCount == 1)//one of them is up
+                if (!Spawn_Boss && !controller.IsSuttungUp() && !controller.IsHjalmarUp())//noone of them is up
                 {
-                    //log.Warn("Suttung or Hjalmar is around");
-                }
-                if(Suttung.SuttungCount == 0 && Hjalmar.HjalmarCount == 0)//noone of them is up
-                {
-                    if (!Spawn_Boss)
-                    {
-                        //log.Warn("Trying to respawn Suttung or Hjalmar");
-                        new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(SpawnBoss), respawn);
-                        Spawn_Boss = true;
-                    }
+                    //log.Warn("Trying to respawn Suttung or Hjalmar");
+                    new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(SpawnBoss), respawn);
+                    Spawn_Boss = true;
                 }
             }
         }
 
         private int SpawnBoss(ECSGameTimer timer)
         {
-            switch(Util.Random(1,2))
+            if (Body is HjalmarSuttungController controller)
             {
-                case 1: SpawnSuttung(); break;
-                case 2: SpawnHjalmar(); break;
+                switch(Util.Random(1,2))
+                {
+                    case 1: controller.SpawnSuttung(); break;
+                    case 2: controller.SpawnHjalmar(); break;
+                }
             }
             return 0;
-        }
-        private void SpawnSuttung()
-        {
-            if (Suttung.SuttungCount == 0)
-            {
-                Suttung boss = new Suttung();
-                boss.X = 32055;
-                boss.Y = 54253;
-                boss.Z = 11883;
-                boss.Heading = 2084;
-                boss.CurrentRegion = Body.CurrentRegion;
-                boss.AddToWorld();
-                Spawn_Boss = false;
-            }
-        }
-        private void SpawnHjalmar()
-        {
-            if (Hjalmar.HjalmarCount == 0)
-            {
-                Hjalmar boss = new Hjalmar();
-                boss.X = 32079;
-                boss.Y = 53415;
-                boss.Z = 11885;
-                boss.Heading = 21;
-                boss.CurrentRegion = Body.CurrentRegion;
-                boss.AddToWorld();
-                Spawn_Boss = false;
-            }
         }
     }
 }

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/Fornfrusonen.cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/Fornfrusonen.cs
@@ -200,7 +200,7 @@ namespace DOL.AI.Brain
             base.Think();
         }
 
-        public static bool FornInCombat = false;
+        public bool FornInCombat = false;
         public void SpawnShards()
         {
             for (int i = 0; i < Util.Random(2, 3); i++)

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/IcelordAgmundr.cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/IcelordAgmundr.cs
@@ -59,8 +59,6 @@ namespace DOL.GS
             VisibleActiveWeaponSlots = 34;
             MeleeDamageType = eDamageType.Crush;
 
-            AgmundrBrain.IsChanged = false;
-            AgmundrBrain.IsPulled = false;
             AgmundrBrain sbrain = new AgmundrBrain();
             SetOwnBrain(sbrain);
             LoadedFromScript = false; //load from database
@@ -97,8 +95,8 @@ namespace DOL.AI.Brain
             ThinkInterval = 2000;
         }
 
-        public static bool IsPulled = false;
-        public static bool IsChanged = false;
+        public bool IsPulled = false;
+        public bool IsChanged = false;
         private bool PulledText = false;
         public void BroadcastMessage(String message)
         {

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/IcelordHakr.cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/IcelordHakr.cs
@@ -106,8 +106,22 @@ namespace DOL.GS
             else
                 log.Warn("Icelord Hakr exist ingame, remove it and restart server if you want to add by script code.");
         }
+        public readonly List<GameNPC> Iceweavers = new List<GameNPC>();
+        public bool IsIceweaverUp
+        {
+            get
+            {
+                foreach (GameNPC npc in Iceweavers)
+                {
+                    if (npc != null && npc.IsAlive && npc.ObjectState is eObjectState.Active)
+                        return true;
+                }
+                return false;
+            }
+        }
         public void SpawnSnakes()
         {
+            Iceweavers.RemoveAll(npc => npc == null || !npc.IsAlive || npc.ObjectState is not eObjectState.Active);
             for (int i = 0; i < 2; i++)
             {
                 HakrAdd Add1 = new HakrAdd();
@@ -118,7 +132,7 @@ namespace DOL.GS
                 Add1.Heading = Heading;
                 Add1.PackageID = "HakrBaf";
                 Add1.AddToWorld();
-                ++HakrAdd.IceweaverCount;
+                Iceweavers.Add(Add1);
             }
             for (int i = 0; i < 2; i++)
             {
@@ -129,7 +143,7 @@ namespace DOL.GS
                 Add2.CurrentRegion = CurrentRegion;
                 Add2.Heading = Heading;
                 Add2.AddToWorld();
-                ++HakrAdd.IceweaverCount;
+                Iceweavers.Add(Add2);
             }
         }
     }
@@ -170,7 +184,7 @@ namespace DOL.AI.Brain
         }
         public void TeleportPlayer()
         {
-            if (HakrAdd.IceweaverCount > 0)
+            if (Body is Hakr hakr && hakr.IsIceweaverUp)
             {
                 List<GameLiving> enemies = GetUnorderedAggroList();
                 foreach (GamePlayer player in Body.GetPlayersInRadius(1100))
@@ -237,7 +251,8 @@ namespace DOL.AI.Brain
         public static bool spam_message1 = false;
         public override void Think()
         {
-            if (HakrAdd.IceweaverCount == 0 && spam_message1 == false && Body.IsAlive)
+            bool iceweaverUp = Body is Hakr hakr && hakr.IsIceweaverUp;
+            if (spam_message1 == false && Body.IsAlive && !iceweaverUp)
             {
                 BroadcastMessage(String.Format("Magic barrier fades away from Icelord Hakr!"));
                 spam_message1 = true;
@@ -253,7 +268,7 @@ namespace DOL.AI.Brain
             }
             if (HasAggro)
             {
-                if (spam_teleport == false && Body.TargetObject != null && HakrAdd.IceweaverCount > 0)
+                if (spam_teleport == false && Body.TargetObject != null && iceweaverUp)
                 {
                     int rand = Util.Random(10000, 20000);
                     new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(PortTimer), rand);
@@ -296,12 +311,6 @@ namespace DOL.GS
         public override int MaxHealth
         {
             get { return 20000; }
-        }
-        public static int IceweaverCount = 0;
-        public override void ProcessDeath(GameObject killer)
-        {
-            --IceweaverCount;
-            base.ProcessDeath(killer);
         }
         public override short Quickness { get => base.Quickness; set => base.Quickness = 80; }
         public override short Strength { get => base.Strength; set => base.Strength = 250; }

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/IcelordHakr.cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/IcelordHakr.cs
@@ -47,24 +47,15 @@ namespace DOL.GS
         }
         public override void ProcessDeath(GameObject killer) //on kill generate orbs
         {
-            Spawn_Snakes = false;
-            HakrBrain.spam_message1 = false;
             base.ProcessDeath(killer);
         }
-        public static bool Spawn_Snakes = false;
         public override bool AddToWorld()
         {
             INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(60162347);
             LoadTemplate(npcTemplate);
             Faction = FactionMgr.GetFactionByID(140);
             RespawnInterval = ServerProperties.Properties.SET_SI_EPIC_ENCOUNTER_RESPAWNINTERVAL * 60000; //1min is 60000 miliseconds
-            Spawn_Snakes = false;
-            HakrBrain.spam_message1 = false;
-            if (Spawn_Snakes == false)
-            {
-                SpawnSnakes();
-                Spawn_Snakes = true;
-            }
+            SpawnSnakes();
             HakrBrain sbrain = new HakrBrain();
             SetOwnBrain(sbrain);
             LoadedFromScript = false; //load from database
@@ -161,7 +152,7 @@ namespace DOL.AI.Brain
             AggroRange = 600;
             ThinkInterval = 1500;
         }
-        public static bool IsPulled = false;
+        public bool IsPulled = false;
         public override void OnAttackedByEnemy(AttackData ad)
         {
             if (IsPulled == false)
@@ -247,8 +238,8 @@ namespace DOL.AI.Brain
                 player.Out.SendMessage(message, eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow);
             }
         }
-        public static bool spam_teleport = false;
-        public static bool spam_message1 = false;
+        public bool spam_teleport = false;
+        public bool spam_message1 = false;
         public override void Think()
         {
             bool iceweaverUp = Body is Hakr hakr && hakr.IsIceweaverUp;
@@ -350,7 +341,7 @@ namespace DOL.AI.Brain
             AggroLevel = 100;
             AggroRange = 500;
         }
-        public static bool IsPulled = false;
+        public bool IsPulled = false;
         public override void OnAttackedByEnemy(AttackData ad)
         {
             if (IsPulled == false)

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/IcelordKvasir.cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/IcelordKvasir.cs
@@ -140,7 +140,7 @@ namespace DOL.AI.Brain
             ThinkInterval = 2000;
         }
 
-        public static bool IsPulled = false;
+        public bool IsPulled = false;
         private bool StartMezz = false;
         private bool AggroText = false;
         public void BroadcastMessage(String message)
@@ -319,8 +319,6 @@ namespace DOL.GS
             Size = 50;
             Level = 50;
             MaxSpeedBase = 0;
-            TunnelsBrain.message1 = false;
-            TunnelsBrain.message2 = false;
 
             Faction = FactionMgr.GetFactionByID(140);
 
@@ -343,8 +341,8 @@ namespace DOL.AI.Brain
             AggroLevel = 0;
             AggroRange = 0;
         }
-        public static bool message1 = false;
-        public static bool message2 = false;
+        public bool message1 = false;
+        public bool message2 = false;
         public void BroadcastMessage(String message)
         {
             foreach (GamePlayer player in Body.GetPlayersInRadius(WorldMgr.VISIBILITY_DISTANCE))

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/IcelordSteinvorAndSkuf .cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/IcelordSteinvorAndSkuf .cs
@@ -74,11 +74,6 @@ namespace DOL.GS
             Faction = FactionMgr.GetFactionByID(140);
             RespawnInterval = ServerProperties.Properties.SET_SI_EPIC_ENCOUNTER_RESPAWNINTERVAL * 60000; //1min is 60000 miliseconds
             BodyType = (ushort)NpcTemplateMgr.eBodyType.Giant;
-            SteinvorBrain.PlayerX = 0;
-            SteinvorBrain.PlayerY = 0;
-            SteinvorBrain.PlayerZ = 0;
-            SteinvorBrain.RandomTarget = null;
-            SteinvorBrain.PickedTarget = false;
 
             SteinvorBrain sbrain = new SteinvorBrain();
             SetOwnBrain(sbrain);
@@ -142,7 +137,7 @@ namespace DOL.AI.Brain
             ThinkInterval = 1500;
         }
 
-        public static bool IsPulled = false;
+        public bool IsPulled = false;
         public override void OnAttackedByEnemy(AttackData ad)
         {
             if (IsPulled == false)
@@ -210,16 +205,16 @@ namespace DOL.AI.Brain
             base.Think();
         }
 
-        public static GamePlayer randomtarget = null;
-        public static GamePlayer RandomTarget
+        public GamePlayer randomtarget = null;
+        public GamePlayer RandomTarget
         {
             get { return randomtarget; }
             set { randomtarget = value; }
         }
-        public static bool PickedTarget = false;
-        public static int PlayerX = 0;
-        public static int PlayerY = 0;
-        public static int PlayerZ = 0;
+        public bool PickedTarget = false;
+        public int PlayerX = 0;
+        public int PlayerY = 0;
+        public int PlayerZ = 0;
 
         public int PickPlayer(ECSGameTimer timer)
         {
@@ -367,7 +362,6 @@ namespace DOL.GS
         {
             base.Die(killer);
         }
-        public static bool Spawn_Snakes = false;
         public override bool AddToWorld()
         {
             INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(60162349);
@@ -437,7 +431,7 @@ namespace DOL.AI.Brain
             AggroRange = 600;
             ThinkInterval = 1500;
         }
-        public static bool IsPulled2 = false;
+        public bool IsPulled2 = false;
         public override void OnAttackedByEnemy(AttackData ad)
         {
             if (IsPulled2 == false)

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/Issorden.cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/Issorden.cs
@@ -52,7 +52,6 @@ namespace DOL.GS
         {
             INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(60162545);
             LoadTemplate(npcTemplate);
-            IssordenBrain.BafMobs = false;
             Faction = FactionMgr.GetFactionByID(140);
 
             IssordenBrain sbrain = new IssordenBrain();
@@ -78,14 +77,13 @@ namespace DOL.AI.Brain
             AggroRange = 600;
             ThinkInterval = 2000;
         }
-        public static bool IsTargetPicked = false;
-        public static GamePlayer randomtarget = null;
-        public static GamePlayer RandomTarget
+        public GamePlayer randomtarget = null;
+        public GamePlayer RandomTarget
         {
             get { return randomtarget; }
             set { randomtarget = value; }
         }
-        public static bool BafMobs = false;
+        public bool BafMobs = false;
         private bool PrepareBolt = false;
         public override void Think()
         {

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/JailerVifil.cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/JailerVifil.cs
@@ -113,7 +113,7 @@ namespace DOL.AI.Brain
             ThinkInterval = 2000;
         }
 
-        public static bool IsPulled = false;
+        public bool IsPulled = false;
 
         public override void OnAttackedByEnemy(AttackData ad)
         {
@@ -179,7 +179,7 @@ namespace DOL.AI.Brain
             return 0;
         }
         private bool RemoveAdds = false;
-        public static bool spam_teleport = false;
+        public bool spam_teleport = false;
         public override void Think()
         {
             if (!CheckProximityAggro())

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/KingTuscarAndQueenKula.cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/KingTuscarAndQueenKula.cs
@@ -136,13 +136,27 @@ namespace DOL.GS
                 player.Out.SendMessage(message, eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow);
             }
         }
-        public static int QueenKulaCount = 0;
+        private GameNPC _kingTuscar;
+        public bool IsKingTuscarUp()
+        {
+            if (_kingTuscar == null)
+            {
+                foreach (GameNPC npc in GetNPCsInRadius(8000))
+                {
+                    if (npc is KingTuscar)
+                    {
+                        _kingTuscar = npc;
+                        break;
+                    }
+                }
+            }
+            return _kingTuscar != null && _kingTuscar.IsAlive && _kingTuscar.ObjectState is eObjectState.Active;
+        }
         public override void ProcessDeath(GameObject killer)//on kill generate orbs
         {
-            if(KingTuscar.KingTuscarCount > 0)
+            if (IsKingTuscarUp())
                 BroadcastMessage(String.Format("As the Queen Kula dies, King Tuscar scream in rage and gather more strength!"));
 
-            --QueenKulaCount;
             bool canReportNews = true;
             // due to issues with attackers the following code will send a notify to all in area in order to force quest credit
             foreach (GamePlayer player in GetPlayersInRadius(WorldMgr.VISIBILITY_DISTANCE))
@@ -172,7 +186,6 @@ namespace DOL.GS
             BodyType = (ushort)NpcTemplateMgr.eBodyType.Giant;
             if (!Styles.Contains(taunt))
                 Styles.Add(taunt);
-            ++QueenKulaCount;
 
             GameNpcInventoryTemplate template = new GameNpcInventoryTemplate();
             template.AddNPCEquipment(eInventorySlot.RightHandWeapon, 316, 0);
@@ -197,12 +210,13 @@ namespace DOL.GS
         {
             if (ad != null && ad.Damage > 0 && ad.Attacker != null && ad.Attacker.IsAlive && ad.Attacker is GamePlayer)
             {
-                if(KingTuscar.KingTuscarCount == 0 || HealthPercent <= 50)
+                bool kingTuscarUp = Brain is not QueenKulaBrain brain || brain.KingTuscarUp;
+                if(!kingTuscarUp || HealthPercent <= 50)
                 {
                     if (Util.Chance(50))
                         CastSpell(Cold_DD, SkillBase.GetSpellLine(GlobalSpellsLines.Mob_Spells));
                 }
-                if (KingTuscar.KingTuscarCount > 0 || HealthPercent > 50)
+                if (kingTuscarUp || HealthPercent > 50)
                     if (Util.Chance(10))
                     CastSpell(Cold_DD, SkillBase.GetSpellLine(GlobalSpellsLines.Mob_Spells));
             }
@@ -267,6 +281,7 @@ namespace DOL.AI.Brain
             set { randomtarget = value; }
         }
         public static bool IsTargetPicked = false;
+        public bool KingTuscarUp = true;
         List<GamePlayer> Port_Enemys = new List<GamePlayer>();
         public int PickPlayer(ECSGameTimer timer)
         {
@@ -408,13 +423,15 @@ namespace DOL.AI.Brain
                         " The merciless who are not afraid of death will survive in this brutal world! I am merciless I'm not afraid of death!'"));
                     message1 = true;
                 }
+                bool kingTuscarUp = Body is QueenKula queenKula && queenKula.IsKingTuscarUp();
+                KingTuscarUp = kingTuscarUp;
                 if (IsTargetPicked == false)
                 {
-                    if (KingTuscar.KingTuscarCount == 1)
+                    if (kingTuscarUp)
                     {
                         new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(PickPlayer), Util.Random(15000, 25000));//timer to port and pick player
                     }
-                    else if(KingTuscar.KingTuscarCount == 0)
+                    else
                     {
                         new ECSGameTimer(Body, new ECSGameTimer.ECSTimerCallback(PickPlayer), Util.Random(8000, 12000));//timer to port and pick player
                     }
@@ -434,11 +451,11 @@ namespace DOL.AI.Brain
                             RemoveFromAggroList(player);
                         }
                     }
-                    if (KingTuscar.KingTuscarCount == 1)
+                    if (kingTuscarUp)
                     {
                         Body.Strength = 350;//if king is up it will deal less dmg
                     }
-                    if (KingTuscar.KingTuscarCount == 0 || Body.HealthPercent <= 50)
+                    if (!kingTuscarUp || Body.HealthPercent <= 50)
                     {
                         Body.Strength = 500;//king is dead so more dmg
                     }
@@ -616,11 +633,21 @@ namespace DOL.GS
         {
             get { return 300000; }
         }
-        public static int KingTuscarCount = 0;
-        public override void ProcessDeath(GameObject killer)//on kill generate orbs
+        private GameNPC _queenKula;
+        public bool IsQueenKulaUp()
         {
-            --KingTuscarCount;
-            base.ProcessDeath(killer);
+            if (_queenKula == null)
+            {
+                foreach (GameNPC npc in GetNPCsInRadius(8000))
+                {
+                    if (npc is QueenKula)
+                    {
+                        _queenKula = npc;
+                        break;
+                    }
+                }
+            }
+            return _queenKula != null && _queenKula.IsAlive && _queenKula.ObjectState is eObjectState.Active;
         }
         #region Styles
         public override void OnAttackedByEnemy(AttackData ad)// on Boss actions
@@ -654,7 +681,7 @@ namespace DOL.GS
                 if (Util.Chance(50))
                     CastSpell(Thunder_aoe2, SkillBase.GetSpellLine(GlobalSpellsLines.Mob_Spells));//aoe mjolnirs after style big dmg
             }
-            if (QueenKula.QueenKulaCount == 0 || (HealthPercent <= 50 && KingTuscarBrain.TuscarRage==true))
+            if ((Brain is KingTuscarBrain brain && !brain.QueenKulaUp) || (HealthPercent <= 50 && KingTuscarBrain.TuscarRage==true))
             {
                 if (ad.AttackResult == eAttackResult.HitStyle && ad.Style.ID == 175 && ad.Style.ClassID == 22)
                 {
@@ -688,7 +715,6 @@ namespace DOL.GS
                 Styles.Add(parry_followup);
             if (!Styles.Contains(after_block))
                 Styles.Add(after_block);
-            ++KingTuscarCount;
 
             GameNpcInventoryTemplate template = new GameNpcInventoryTemplate();
             template.AddNPCEquipment(eInventorySlot.TwoHandWeapon, 575, 0);
@@ -883,6 +909,7 @@ namespace DOL.AI.Brain
         }
         public static bool message2 = false;
         public static bool TuscarRage = false;
+        public bool QueenKulaUp = true;
         public static bool IsPulled2 = false;
         public override void OnAttackedByEnemy(AttackData ad)
         {
@@ -942,11 +969,13 @@ namespace DOL.AI.Brain
                 if (Body.TargetObject != null)
                 {
                     GameLiving living = Body.TargetObject as GameLiving;
-                    if(QueenKula.QueenKulaCount == 1)
+                    bool queenKulaUp = Body is KingTuscar kingTuscar && kingTuscar.IsQueenKulaUp();
+                    QueenKulaUp = queenKulaUp;
+                    if(queenKulaUp)
                     {
                         Body.Strength = 350;
                     }
-                    if (QueenKula.QueenKulaCount == 0 || Body.HealthPercent <= 50)
+                    if (!queenKulaUp || Body.HealthPercent <= 50)
                     {
                         Body.Strength = 500;
                     }

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/KingTuscarAndQueenKula.cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/KingTuscarAndQueenKula.cs
@@ -139,8 +139,9 @@ namespace DOL.GS
         private GameNPC _kingTuscar;
         public bool IsKingTuscarUp()
         {
-            if (_kingTuscar == null)
+            if (_kingTuscar == null || _kingTuscar.ObjectState is not eObjectState.Active || _kingTuscar.Brain is not KingTuscarBrain)
             {
+                _kingTuscar = null;
                 foreach (GameNPC npc in GetNPCsInRadius(8000))
                 {
                     if (npc is KingTuscar)
@@ -150,7 +151,7 @@ namespace DOL.GS
                     }
                 }
             }
-            return _kingTuscar != null && _kingTuscar.IsAlive && _kingTuscar.ObjectState is eObjectState.Active;
+            return _kingTuscar != null && _kingTuscar.IsAlive;
         }
         public override void ProcessDeath(GameObject killer)//on kill generate orbs
         {
@@ -210,7 +211,7 @@ namespace DOL.GS
         {
             if (ad != null && ad.Damage > 0 && ad.Attacker != null && ad.Attacker.IsAlive && ad.Attacker is GamePlayer)
             {
-                bool kingTuscarUp = Brain is not QueenKulaBrain brain || brain.KingTuscarUp;
+                bool kingTuscarUp = IsKingTuscarUp();
                 if(!kingTuscarUp || HealthPercent <= 50)
                 {
                     if (Util.Chance(50))
@@ -281,7 +282,6 @@ namespace DOL.AI.Brain
             set { randomtarget = value; }
         }
         public static bool IsTargetPicked = false;
-        public bool KingTuscarUp = true;
         List<GamePlayer> Port_Enemys = new List<GamePlayer>();
         public int PickPlayer(ECSGameTimer timer)
         {
@@ -424,7 +424,6 @@ namespace DOL.AI.Brain
                     message1 = true;
                 }
                 bool kingTuscarUp = Body is QueenKula queenKula && queenKula.IsKingTuscarUp();
-                KingTuscarUp = kingTuscarUp;
                 if (IsTargetPicked == false)
                 {
                     if (kingTuscarUp)
@@ -636,8 +635,9 @@ namespace DOL.GS
         private GameNPC _queenKula;
         public bool IsQueenKulaUp()
         {
-            if (_queenKula == null)
+            if (_queenKula == null || _queenKula.ObjectState is not eObjectState.Active || _queenKula.Brain is not QueenKulaBrain)
             {
+                _queenKula = null;
                 foreach (GameNPC npc in GetNPCsInRadius(8000))
                 {
                     if (npc is QueenKula)
@@ -647,7 +647,7 @@ namespace DOL.GS
                     }
                 }
             }
-            return _queenKula != null && _queenKula.IsAlive && _queenKula.ObjectState is eObjectState.Active;
+            return _queenKula != null && _queenKula.IsAlive;
         }
         #region Styles
         public override void OnAttackedByEnemy(AttackData ad)// on Boss actions
@@ -681,7 +681,7 @@ namespace DOL.GS
                 if (Util.Chance(50))
                     CastSpell(Thunder_aoe2, SkillBase.GetSpellLine(GlobalSpellsLines.Mob_Spells));//aoe mjolnirs after style big dmg
             }
-            if ((Brain is KingTuscarBrain brain && !brain.QueenKulaUp) || (HealthPercent <= 50 && KingTuscarBrain.TuscarRage==true))
+            if (!IsQueenKulaUp() || (HealthPercent <= 50 && KingTuscarBrain.TuscarRage==true))
             {
                 if (ad.AttackResult == eAttackResult.HitStyle && ad.Style.ID == 175 && ad.Style.ClassID == 22)
                 {
@@ -909,7 +909,6 @@ namespace DOL.AI.Brain
         }
         public static bool message2 = false;
         public static bool TuscarRage = false;
-        public bool QueenKulaUp = true;
         public static bool IsPulled2 = false;
         public override void OnAttackedByEnemy(AttackData ad)
         {
@@ -970,7 +969,6 @@ namespace DOL.AI.Brain
                 {
                     GameLiving living = Body.TargetObject as GameLiving;
                     bool queenKulaUp = Body is KingTuscar kingTuscar && kingTuscar.IsQueenKulaUp();
-                    QueenKulaUp = queenKulaUp;
                     if(queenKulaUp)
                     {
                         Body.Strength = 350;

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/KingTuscarAndQueenKula.cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/KingTuscarAndQueenKula.cs
@@ -139,9 +139,8 @@ namespace DOL.GS
         private GameNPC _kingTuscar;
         public bool IsKingTuscarUp()
         {
-            if (_kingTuscar == null || _kingTuscar.ObjectState is not eObjectState.Active || _kingTuscar.Brain is not KingTuscarBrain)
+            if (_kingTuscar == null)
             {
-                _kingTuscar = null;
                 foreach (GameNPC npc in GetNPCsInRadius(8000))
                 {
                     if (npc is KingTuscar)
@@ -151,7 +150,7 @@ namespace DOL.GS
                     }
                 }
             }
-            return _kingTuscar != null && _kingTuscar.IsAlive;
+            return _kingTuscar != null && _kingTuscar.IsAlive && _kingTuscar.ObjectState is eObjectState.Active;
         }
         public override void ProcessDeath(GameObject killer)//on kill generate orbs
         {
@@ -192,9 +191,6 @@ namespace DOL.GS
             template.AddNPCEquipment(eInventorySlot.RightHandWeapon, 316, 0);
             Inventory = template.CloseTemplate();
             SwitchWeapon(eActiveWeaponSlot.Standard);
-            QueenKulaBrain.IsTargetPicked = false;
-            QueenKulaBrain.message1 = false;
-            QueenKulaBrain.IsPulled1 = false;
 
             VisibleActiveWeaponSlots = 16;
             MeleeDamageType = eDamageType.Slash;
@@ -203,6 +199,7 @@ namespace DOL.GS
             LoadedFromScript = false;//load from database
             SaveIntoDatabase();
             base.AddToWorld();
+            IsKingTuscarUp();
             return true;
         }
         #endregion
@@ -275,13 +272,13 @@ namespace DOL.AI.Brain
             }
         }
         #region Teleport Player & PlayerInCenter()
-        public static GamePlayer randomtarget = null;
-        public static GamePlayer RandomTarget
+        public GamePlayer randomtarget = null;
+        public GamePlayer RandomTarget
         {
             get { return randomtarget; }
             set { randomtarget = value; }
         }
-        public static bool IsTargetPicked = false;
+        public bool IsTargetPicked = false;
         List<GamePlayer> Port_Enemys = new List<GamePlayer>();
         public int PickPlayer(ECSGameTimer timer)
         {
@@ -328,7 +325,7 @@ namespace DOL.AI.Brain
             }
             return 0;
         }
-        public static bool message1 = false;
+        public bool message1 = false;
         public void PlayerInCenter()
         {
             Point3D FrostPoint = new Point3D();
@@ -370,7 +367,6 @@ namespace DOL.AI.Brain
         }
         #endregion
         #region OnAttackedByEnemy()
-        public static bool IsPulled1 = false;
         public override void OnAttackedByEnemy(AttackData ad)
         {
             if (HasAggro && Body.TargetObject != null)
@@ -402,7 +398,6 @@ namespace DOL.AI.Brain
                 INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(60165083);
                 Body.Strength = npcTemplate.Strength;
                 IsTargetPicked =false;
-                IsPulled1 = false;
             }
             if (Body.IsOutOfTetherRange)
             {
@@ -635,9 +630,8 @@ namespace DOL.GS
         private GameNPC _queenKula;
         public bool IsQueenKulaUp()
         {
-            if (_queenKula == null || _queenKula.ObjectState is not eObjectState.Active || _queenKula.Brain is not QueenKulaBrain)
+            if (_queenKula == null)
             {
-                _queenKula = null;
                 foreach (GameNPC npc in GetNPCsInRadius(8000))
                 {
                     if (npc is QueenKula)
@@ -647,7 +641,7 @@ namespace DOL.GS
                     }
                 }
             }
-            return _queenKula != null && _queenKula.IsAlive;
+            return _queenKula != null && _queenKula.IsAlive && _queenKula.ObjectState is eObjectState.Active;
         }
         #region Styles
         public override void OnAttackedByEnemy(AttackData ad)// on Boss actions
@@ -681,7 +675,7 @@ namespace DOL.GS
                 if (Util.Chance(50))
                     CastSpell(Thunder_aoe2, SkillBase.GetSpellLine(GlobalSpellsLines.Mob_Spells));//aoe mjolnirs after style big dmg
             }
-            if (!IsQueenKulaUp() || (HealthPercent <= 50 && KingTuscarBrain.TuscarRage==true))
+            if (!IsQueenKulaUp() || (HealthPercent <= 50 && Brain is KingTuscarBrain tuscarBrain && tuscarBrain.TuscarRage))
             {
                 if (ad.AttackResult == eAttackResult.HitStyle && ad.Style.ID == 175 && ad.Style.ClassID == 22)
                 {
@@ -720,9 +714,6 @@ namespace DOL.GS
             template.AddNPCEquipment(eInventorySlot.TwoHandWeapon, 575, 0);
             Inventory = template.CloseTemplate();
             SwitchWeapon(eActiveWeaponSlot.TwoHanded);
-            KingTuscarBrain.message2 = false;
-            KingTuscarBrain.TuscarRage = false;
-            KingTuscarBrain.IsPulled2 = false;
 
             VisibleActiveWeaponSlots = 34;
             MeleeDamageType = eDamageType.Crush;
@@ -731,6 +722,7 @@ namespace DOL.GS
             LoadedFromScript = false;//load from database
             SaveIntoDatabase();
             base.AddToWorld();
+            IsQueenKulaUp();
             return true;
         }       
         #endregion
@@ -907,9 +899,8 @@ namespace DOL.AI.Brain
                 player.Out.SendMessage(message, eChatType.CT_Broadcast, eChatLoc.CL_SystemWindow);
             }
         }
-        public static bool message2 = false;
-        public static bool TuscarRage = false;
-        public static bool IsPulled2 = false;
+        public bool message2 = false;
+        public bool TuscarRage = false;
         public override void OnAttackedByEnemy(AttackData ad)
         {
             if (HasAggro && Body.TargetObject != null)
@@ -941,7 +932,6 @@ namespace DOL.AI.Brain
                 INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(60162909);
                 Body.Strength = npcTemplate.Strength;
                 TuscarRage = false;
-                IsPulled2 = false;
             }
             if (Body.IsOutOfTetherRange)
             {

--- a/GameServer/scripts/namedmobs/TuscarianGlacier/TorstAndHurika.cs
+++ b/GameServer/scripts/namedmobs/TuscarianGlacier/TorstAndHurika.cs
@@ -394,9 +394,9 @@ namespace DOL.AI.Brain
         }
 
         public List<GamePlayer> Port_Enemys = new List<GamePlayer>();
-        public static bool IsTargetPicked = false;
-        public static GamePlayer randomtarget = null;
-        public static GamePlayer RandomTarget
+        public bool IsTargetPicked = false;
+        public GamePlayer randomtarget = null;
+        public GamePlayer RandomTarget
         {
             get { return randomtarget; }
             set { randomtarget = value; }
@@ -587,8 +587,8 @@ namespace DOL.AI.Brain
         private protected bool Point2check = false;
         bool SetNpcTarget = false;
 
-        private protected static GameNPC trostnpc = null;
-        private protected static GameNPC TrostNpc
+        private protected GameNPC trostnpc = null;
+        private protected GameNPC TrostNpc
         {
             get { return trostnpc; }
             set { trostnpc = value; }


### PR DESCRIPTION
Sorry for another giant PR. Overall pattern of changes:                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                              
- Move shared statics (flags, target picks, counters) to instance-level state, so nothing leaks across respawns/wipes or between multiple copies of a scripted NPC                                                                                                                                                                                                                                                              - Cleaned up add tracking and caching to use liveness-checked values and prevent value drift (despawns skip ProcessDeath, so ++/-- counters drifted permanently)                                                                                                                                                                                                                                                               
- Adds modify encounters by referencing the encounter owner rather than writing to a global variable                                                                                                                                                                                                                                                                                                                           
- Use Interlocked increments for kill counters written from the reaper thread